### PR TITLE
Normalize database URL configuration

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 from functools import lru_cache
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field, field_validator
 from dotenv import load_dotenv
@@ -21,15 +22,68 @@ class Settings(BaseModel):
     @classmethod
     def _normalize_database_url(cls, value: str | None) -> str:
         """Normalize the DATABASE_URL for SQLAlchemy / psycopg2 usage."""
+
         if not value:
             return ""
-        normalized = value
-        if normalized.startswith("postgres://"):
-            normalized = normalized.replace("postgres://", "postgresql+psycopg2://", 1)
-        if "sslmode=" not in normalized:
-            separator = "&" if "?" in normalized else "?"
-            normalized = f"{normalized}{separator}sslmode=require"
+
+        value = value.strip()
+        if not value:
+            return ""
+
+        parsed = urlsplit(value)
+
+        lowered_scheme = parsed.scheme.lower()
+        if lowered_scheme in {"postgres", "postgresql"}:
+            scheme = "postgresql+psycopg2"
+        elif lowered_scheme == "postgresql+psycopg2":
+            scheme = "postgresql+psycopg2"
+        else:
+            scheme = parsed.scheme
+
+        path = parsed.path
+        query = parsed.query
+
+        if "sslmode=" in path and not query:
+            base_path, _, sslmode_value = path.partition("sslmode=")
+            base_path = base_path.rstrip("?&")
+            path = base_path or "/"
+            if not path.startswith("/"):
+                path = f"/{path}"
+            query = f"sslmode={sslmode_value.lstrip('?&')}"
+
+        query_params = parse_qsl(query, keep_blank_values=True)
+        filtered_params = [(key, value) for key, value in query_params if key != "sslmode"]
+        filtered_params.append(("sslmode", "require"))
+        normalized_query = urlencode(filtered_params, doseq=True)
+
+        normalized = urlunsplit(
+            (
+                scheme,
+                parsed.netloc,
+                path,
+                normalized_query,
+                parsed.fragment,
+            )
+        )
+
+        if not parsed.netloc and scheme:
+            prefix = f"{scheme}:/"
+            if normalized.startswith(prefix) and not normalized.startswith(f"{scheme}://"):
+                normalized = normalized.replace(prefix, f"{scheme}:///", 1)
+
         return normalized
+
+    @property
+    def DATABASE_URL(self) -> str:  # pragma: no cover - backwards compat helper
+        """Backwards compatible accessor for ``database_url``."""
+
+        return self.database_url
+
+    @property
+    def DB_SCHEMA(self) -> str:  # pragma: no cover - backwards compat helper
+        """Backwards compatible accessor for ``db_schema``."""
+
+        return self.db_schema
 
     model_config: dict[str, Any] = {"frozen": True}
 


### PR DESCRIPTION
## Summary
- normalize DATABASE_URL using urllib.parse to always emit a postgresql+psycopg2 DSN with sslmode=require
- add backwards-compatible DATABASE_URL and DB_SCHEMA properties on Settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf5d0ea90832ea64fbad12a021356