### PR TITLE
Add minimal Vite React frontend for PSI ERP

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://127.0.0.1:8000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "@tanstack/react-query": "5.62.9",
     "axios": "1.7.7",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-router-dom": "6.28.0"
   },
   "devDependencies": {
     "@types/react": "18.3.7",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,134 @@
+:root {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  padding: 2rem 1.5rem;
+  background: #111827;
+  color: #f9fafb;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.sidebar a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  display: block;
+  border-radius: 0.375rem;
+  transition: background-color 0.15s ease;
+}
+
+.sidebar a.active,
+.sidebar a:hover {
+  background-color: #374151;
+}
+
+.app-title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.content {
+  flex: 1;
+  padding: 2rem;
+  overflow-x: auto;
+}
+
+.page {
+  display: grid;
+  gap: 2rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  max-width: 640px;
+}
+
+.form-grid label {
+  display: grid;
+  gap: 0.25rem;
+  font-weight: 600;
+}
+
+input,
+select,
+button {
+  font: inherit;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid #cbd5e1;
+}
+
+button {
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  justify-self: start;
+}
+
+button[disabled] {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.table th {
+  background-color: #f1f5f9;
+  font-weight: 700;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.numeric {
+  text-align: right;
+}
+
+.error {
+  color: #b91c1c;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,312 +1,41 @@
-import { FormEvent, useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "./api";
+import { Navigate, NavLink, Route, Routes } from "react-router-dom";
 
-interface Session {
-  id: string;
-  title: string;
-  description: string | null;
-  is_leader: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-interface CreateSessionPayload {
-  title: string;
-  description?: string | null;
-}
-
-interface DailyPSIEntry {
-  date: string;
-  production: number;
-  sales: number;
-  net_change: number;
-  projected_inventory: number;
-  reported_inventory: number | null;
-}
-
-interface PSIUploadResponse {
-  rows_imported: number;
-  session_id: string | null;
-  dates: string[];
-}
-
-const fetchSessions = async (): Promise<Session[]> => {
-  const response = await api.get<Session[]>("/sessions/");
-  return response.data;
-};
-
-const fetchDailyPSI = async (
-  sessionId: string | null,
-  startDate: string | null,
-  endDate: string | null,
-  startingInventory: number
-): Promise<DailyPSIEntry[]> => {
-  const params: Record<string, string> = {};
-  if (sessionId) params.session_id = sessionId;
-  if (startDate) params.start_date = startDate;
-  if (endDate) params.end_date = endDate;
-  if (!Number.isNaN(startingInventory)) params.starting_inventory = String(startingInventory);
-  const response = await api.get<DailyPSIEntry[]>("/psi/daily", { params });
-  return response.data;
-};
-
-function formatDate(date: string) {
-  return new Date(date).toLocaleDateString();
-}
+import SessionsPage from "./pages/SessionsPage";
+import UploadPage from "./pages/UploadPage";
+import PSITablePage from "./pages/PSITablePage";
+import "./App.css";
 
 export default function App() {
-  const queryClient = useQueryClient();
-  const [sessionForm, setSessionForm] = useState<CreateSessionPayload>({ title: "", description: "" });
-  const [selectedSession, setSelectedSession] = useState<string>("");
-  const [startDate, setStartDate] = useState<string>("");
-  const [endDate, setEndDate] = useState<string>("");
-  const [startingInventory, setStartingInventory] = useState<number>(0);
-  const [uploadMessage, setUploadMessage] = useState<string | null>(null);
-
-  const { data: sessions = [], isLoading: sessionsLoading } = useQuery({
-    queryKey: ["sessions"],
-    queryFn: fetchSessions
-  });
-
-  const dailyQueryKey = useMemo(
-    () => ["dailyPsi", selectedSession || null, startDate || null, endDate || null, startingInventory],
-    [selectedSession, startDate, endDate, startingInventory]
-  );
-
-  const { data: dailyPsi = [], isFetching: dailyLoading } = useQuery({
-    queryKey: dailyQueryKey,
-    queryFn: () =>
-      fetchDailyPSI(selectedSession || null, startDate || null, endDate || null, startingInventory),
-  });
-
-  const createSessionMutation = useMutation<Session, unknown, CreateSessionPayload>({
-    mutationFn: async (payload: CreateSessionPayload) => {
-      const response = await api.post<Session>("/sessions/", payload);
-      return response.data;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sessions"] });
-      setSessionForm({ title: "", description: "" });
-    }
-  });
-
-  const deleteSessionMutation = useMutation<void, unknown, string>({
-    mutationFn: async (sessionId: string) => {
-      await api.delete(`/sessions/${sessionId}`);
-    },
-    onSuccess: (_, sessionId) => {
-      if (selectedSession === sessionId) {
-        setSelectedSession("");
-      }
-      queryClient.invalidateQueries({ queryKey: ["sessions"] });
-      queryClient.invalidateQueries({ queryKey: ["dailyPsi"] });
-    }
-  });
-
-  const setLeaderMutation = useMutation<Session, unknown, string>({
-    mutationFn: async (sessionId: string) => {
-      const response = await api.patch<Session>(`/sessions/${sessionId}/leader`, {});
-      return response.data;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sessions"] });
-    }
-  });
-
-  const uploadMutation = useMutation<
-    PSIUploadResponse,
-    unknown,
-    { file: File; sessionId: string | null }
-  >({
-    mutationFn: async (payload: { file: File; sessionId: string | null }) => {
-      const formData = new FormData();
-      formData.append("file", payload.file);
-      if (payload.sessionId) {
-        formData.append("session_id", payload.sessionId);
-      }
-      const response = await api.post<PSIUploadResponse>("/psi/upload", formData, {
-        headers: { "Content-Type": "multipart/form-data" }
-      });
-      return response.data;
-    },
-    onSuccess: (result) => {
-      setUploadMessage(
-        `Imported ${result.rows_imported} rows${result.session_id ? ` for session ${result.session_id}` : ""}.`
-      );
-      queryClient.invalidateQueries({ queryKey: dailyQueryKey });
-    }
-  });
-
-  const handleSessionSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!sessionForm.title.trim()) return;
-    createSessionMutation.mutate({
-      title: sessionForm.title.trim(),
-      description: sessionForm.description?.trim() || null
-    });
-  };
-
-  const handleFileChange = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const fileInput = event.currentTarget.elements.namedItem("csvFile") as HTMLInputElement;
-    if (!fileInput?.files?.length) {
-      setUploadMessage("Please choose a CSV file to import.");
-      return;
-    }
-    setUploadMessage(null);
-    uploadMutation.mutate({ file: fileInput.files[0], sessionId: selectedSession || null });
-    fileInput.value = "";
-  };
-
   return (
-    <div style={{ margin: "0 auto", maxWidth: "960px", padding: "2rem", fontFamily: "Segoe UI, sans-serif" }}>
-      <h1>PSI Mini ERP</h1>
-
-      <section>
-        <h2>Create Session</h2>
-        <form onSubmit={handleSessionSubmit} style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
-          <input
-            type="text"
-            placeholder="Session title"
-            value={sessionForm.title}
-            onChange={(e) => setSessionForm((prev) => ({ ...prev, title: e.target.value }))}
-            required
-          />
-          <input
-            type="text"
-            placeholder="Description"
-            value={sessionForm.description ?? ""}
-            onChange={(e) => setSessionForm((prev) => ({ ...prev, description: e.target.value }))}
-          />
-          <button type="submit" disabled={createSessionMutation.isPending}>
-            {createSessionMutation.isPending ? "Saving..." : "Add"}
-          </button>
-        </form>
-      </section>
-
-      <section>
-        <h2>Sessions</h2>
-        {sessionsLoading ? (
-          <p>Loading sessions...</p>
-        ) : (
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Title</th>
-                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Leader</th>
-                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sessions.map((session) => (
-                <tr key={session.id}>
-                  <td style={{ padding: "0.5rem 0" }}>
-                    <strong>{session.title}</strong>
-                    <br />
-                    <small>{session.description}</small>
-                  </td>
-                  <td>{session.is_leader ? "⭐" : ""}</td>
-                  <td style={{ display: "flex", gap: "0.5rem" }}>
-                    <button type="button" onClick={() => setSelectedSession(session.id)}>
-                      Use
-                    </button>
-                    <button type="button" onClick={() => setLeaderMutation.mutate(session.id)} disabled={session.is_leader}>
-                      Set leader
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => deleteSessionMutation.mutate(session.id)}
-                      disabled={deleteSessionMutation.isPending}
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-
-      <section>
-        <h2>Import PSI CSV</h2>
-        <form onSubmit={handleFileChange} style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-          <input type="file" name="csvFile" accept=".csv,text/csv" />
-          <p style={{ fontSize: "0.9rem", margin: 0 }}>
-            CSV headers: date, production, sales, inventory (optional). Date must be YYYY-MM-DD.
-          </p>
-          <button type="submit" disabled={uploadMutation.isPending}>
-            {uploadMutation.isPending ? "Uploading..." : "Upload"}
-          </button>
-        </form>
-        {uploadMessage && <p>{uploadMessage}</p>}
-      </section>
-
-      <section>
-        <h2>Daily PSI</h2>
-        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
-          <label>
-            Session:
-            <select value={selectedSession} onChange={(e) => setSelectedSession(e.target.value)}>
-              <option value="">All sessions</option>
-              {sessions.map((session) => (
-                <option key={session.id} value={session.id}>
-                  {session.title}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Start date:
-            <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
-          </label>
-          <label>
-            End date:
-            <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
-          </label>
-          <label>
-            Starting inventory:
-            <input
-              type="number"
-              value={startingInventory}
-              onChange={(e) => setStartingInventory(Number(e.target.value))}
-            />
-          </label>
-        </div>
-        {dailyLoading ? (
-          <p>Computing daily PSI...</p>
-        ) : dailyPsi.length === 0 ? (
-          <p>No PSI data available.</p>
-        ) : (
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Date</th>
-                <th style={{ textAlign: "right", borderBottom: "1px solid #ccc" }}>Production</th>
-                <th style={{ textAlign: "right", borderBottom: "1px solid #ccc" }}>Sales</th>
-                <th style={{ textAlign: "right", borderBottom: "1px solid #ccc" }}>Net</th>
-                <th style={{ textAlign: "right", borderBottom: "1px solid #ccc" }}>Projected inventory</th>
-                <th style={{ textAlign: "right", borderBottom: "1px solid #ccc" }}>Reported inventory</th>
-              </tr>
-            </thead>
-            <tbody>
-              {dailyPsi.map((entry) => (
-                <tr key={entry.date}>
-                  <td style={{ padding: "0.5rem 0" }}>{formatDate(entry.date)}</td>
-                  <td style={{ textAlign: "right" }}>{entry.production.toFixed(2)}</td>
-                  <td style={{ textAlign: "right" }}>{entry.sales.toFixed(2)}</td>
-                  <td style={{ textAlign: "right" }}>{entry.net_change.toFixed(2)}</td>
-                  <td style={{ textAlign: "right" }}>{entry.projected_inventory.toFixed(2)}</td>
-                  <td style={{ textAlign: "right" }}>
-                    {entry.reported_inventory != null ? entry.reported_inventory.toFixed(2) : "-"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
+    <div className="app">
+      <nav className="sidebar">
+        <h1 className="app-title">PSI ERP</h1>
+        <ul>
+          <li>
+            <NavLink to="/sessions" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              Sessions
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/upload" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              Upload CSV
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/psi" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              PSI Table
+            </NavLink>
+          </li>
+        </ul>
+      </nav>
+      <main className="content">
+        <Routes>
+          <Route path="/" element={<Navigate to="/sessions" replace />} />
+          <Route path="/sessions" element={<SessionsPage />} />
+          <Route path="/upload" element={<UploadPage />} />
+          <Route path="/psi" element={<PSITablePage />} />
+        </Routes>
+      </main>
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
+const baseURL = import.meta.env.VITE_API_BASE ?? "http://127.0.0.1:8000";
 
 export const api = axios.create({
   baseURL,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 
@@ -8,8 +9,10 @@ const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/PSITablePage.tsx
+++ b/frontend/src/pages/PSITablePage.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+import { PSIRow, Session } from "../types";
+
+const fetchSessions = async (): Promise<Session[]> => {
+  const { data } = await api.get<Session[]>("/sessions");
+  return data;
+};
+
+const fetchDailyPsi = async (
+  sessionId: string,
+  filters: { sku_code?: string; warehouse_name?: string; channel?: string }
+): Promise<PSIRow[]> => {
+  const params: Record<string, string> = {};
+  if (filters.sku_code?.trim()) params.sku_code = filters.sku_code.trim();
+  if (filters.warehouse_name?.trim()) params.warehouse_name = filters.warehouse_name.trim();
+  if (filters.channel?.trim()) params.channel = filters.channel.trim();
+
+  const { data } = await api.get<PSIRow[]>(`/psi/${sessionId}/daily`, {
+    params,
+  });
+  return data;
+};
+
+const formatNumber = (value?: number | null) => {
+  if (value === null || value === undefined) return "—";
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+};
+
+export default function PSITablePage() {
+  const [sessionId, setSessionId] = useState<string>("");
+  const [skuCode, setSkuCode] = useState<string>("");
+  const [warehouseName, setWarehouseName] = useState<string>("");
+  const [channel, setChannel] = useState<string>("");
+
+  const sessionsQuery = useQuery({
+    queryKey: ["sessions"],
+    queryFn: fetchSessions,
+  });
+
+  useEffect(() => {
+    if (!sessionId && sessionsQuery.data && sessionsQuery.data.length > 0) {
+      setSessionId(sessionsQuery.data[0].id);
+    }
+  }, [sessionId, sessionsQuery.data]);
+
+  const psiQuery = useQuery({
+    queryKey: ["psi-daily", sessionId, skuCode, warehouseName, channel],
+    queryFn: () => fetchDailyPsi(sessionId, { sku_code: skuCode, warehouse_name: warehouseName, channel }),
+    enabled: Boolean(sessionId),
+  });
+
+  return (
+    <div className="page">
+      <header>
+        <h1>PSI Daily Table</h1>
+        <p>Review the computed PSI metrics for the selected session.</p>
+      </header>
+
+      <section>
+        <div className="form-grid">
+          <label>
+            Session
+            <select value={sessionId} onChange={(event) => setSessionId(event.target.value)} disabled={sessionsQuery.isLoading}>
+              <option value="" disabled>
+                Select a session
+              </option>
+              {sessionsQuery.data?.map((session) => (
+                <option key={session.id} value={session.id}>
+                  {session.title}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            SKU Code
+            <input type="text" value={skuCode} onChange={(event) => setSkuCode(event.target.value)} placeholder="Optional" />
+          </label>
+
+          <label>
+            Warehouse
+            <input
+              type="text"
+              value={warehouseName}
+              onChange={(event) => setWarehouseName(event.target.value)}
+              placeholder="Optional"
+            />
+          </label>
+
+          <label>
+            Channel
+            <input type="text" value={channel} onChange={(event) => setChannel(event.target.value)} placeholder="Optional" />
+          </label>
+        </div>
+
+        {sessionsQuery.isLoading && <p>Loading sessions...</p>}
+        {sessionsQuery.isError && <p className="error">Unable to load sessions.</p>}
+      </section>
+
+      <section>
+        {psiQuery.isLoading && sessionId && <p>Loading PSI data...</p>}
+        {psiQuery.isError && <p className="error">Unable to load PSI data.</p>}
+        {psiQuery.data && psiQuery.data.length > 0 ? (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Stock @ Anchor</th>
+                <th>Inbound Qty</th>
+                <th>Outbound Qty</th>
+                <th>Net Flow</th>
+                <th>Stock Closing</th>
+                <th>Safety Stock</th>
+                <th>Movable Stock</th>
+              </tr>
+            </thead>
+            <tbody>
+              {psiQuery.data.map((row) => (
+                <tr key={row.date}>
+                  <td>{new Date(row.date).toLocaleDateString()}</td>
+                  <td className="numeric">{formatNumber(row.stock_at_anchor)}</td>
+                  <td className="numeric">{formatNumber(row.inbound_qty)}</td>
+                  <td className="numeric">{formatNumber(row.outbound_qty)}</td>
+                  <td className="numeric">{formatNumber(row.net_flow)}</td>
+                  <td className="numeric">{formatNumber(row.stock_closing)}</td>
+                  <td className="numeric">{formatNumber(row.safety_stock)}</td>
+                  <td className="numeric">{formatNumber(row.movable_stock)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          sessionId && !psiQuery.isLoading && <p>No PSI data for the current filters.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,0 +1,153 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+import { Session } from "../types";
+
+interface SessionFormState {
+  title: string;
+  description?: string;
+}
+
+const fetchSessions = async (): Promise<Session[]> => {
+  const { data } = await api.get<Session[]>("/sessions");
+  return data;
+};
+
+export default function SessionsPage() {
+  const queryClient = useQueryClient();
+  const [formState, setFormState] = useState<SessionFormState>({ title: "", description: "" });
+
+  const sessionsQuery = useQuery({
+    queryKey: ["sessions"],
+    queryFn: fetchSessions,
+  });
+
+  const createSession = useMutation({
+    mutationFn: async (payload: SessionFormState) => {
+      const { data } = await api.post<Session>("/sessions", {
+        title: payload.title,
+        description: payload.description?.trim() ? payload.description.trim() : undefined,
+      });
+      return data;
+    },
+    onSuccess: () => {
+      setFormState({ title: "", description: "" });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+
+  const deleteSession = useMutation({
+    mutationFn: async (sessionId: string) => {
+      await api.delete(`/sessions/${sessionId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+
+  const makeLeader = useMutation({
+    mutationFn: async (sessionId: string) => {
+      const { data } = await api.patch<Session>(`/sessions/${sessionId}/leader`, {});
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formState.title.trim()) return;
+    createSession.mutate({
+      title: formState.title.trim(),
+      description: formState.description,
+    });
+  };
+
+  return (
+    <div className="page">
+      <header>
+        <h1>Sessions</h1>
+        <p>Create sessions and manage the active leader.</p>
+      </header>
+
+      <section>
+        <h2>New Session</h2>
+        <form onSubmit={handleSubmit} className="form-grid">
+          <label>
+            Title
+            <input
+              type="text"
+              value={formState.title}
+              onChange={(event) => setFormState((prev) => ({ ...prev, title: event.target.value }))}
+              required
+            />
+          </label>
+          <label>
+            Description
+            <input
+              type="text"
+              value={formState.description ?? ""}
+              onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
+              placeholder="Optional"
+            />
+          </label>
+          <button type="submit" disabled={createSession.isPending}>
+            {createSession.isPending ? "Saving..." : "Create"}
+          </button>
+        </form>
+        {createSession.isError && <p className="error">Unable to create session. Try again.</p>}
+      </section>
+
+      <section>
+        <h2>Existing Sessions</h2>
+        {sessionsQuery.isLoading && <p>Loading sessions...</p>}
+        {sessionsQuery.isError && <p className="error">Failed to load sessions.</p>}
+        {sessionsQuery.data && sessionsQuery.data.length > 0 ? (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Description</th>
+                <th>Leader</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessionsQuery.data.map((session) => (
+                <tr key={session.id}>
+                  <td>
+                    <strong>{session.title}</strong>
+                    <br />
+                    <small>{new Date(session.created_at).toLocaleString()}</small>
+                  </td>
+                  <td>{session.description || "—"}</td>
+                  <td>{session.is_leader ? "⭐" : ""}</td>
+                  <td className="actions">
+                    <button
+                      type="button"
+                      onClick={() => makeLeader.mutate(session.id)}
+                      disabled={makeLeader.isPending || session.is_leader}
+                    >
+                      {session.is_leader ? "Leader" : makeLeader.isPending ? "Updating..." : "Make Leader"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteSession.mutate(session.id)}
+                      disabled={deleteSession.isPending}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          !sessionsQuery.isLoading && <p>No sessions yet.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,0 +1,120 @@
+import { FormEvent, useState } from "react";
+import axios from "axios";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+import { Session } from "../types";
+
+const fetchSessions = async (): Promise<Session[]> => {
+  const { data } = await api.get<Session[]>("/sessions");
+  return data;
+};
+
+interface UploadResult {
+  detail?: string;
+}
+
+export default function UploadPage() {
+  const [selectedSession, setSelectedSession] = useState<string>("");
+  const [message, setMessage] = useState<string | null>(null);
+
+  const sessionsQuery = useQuery({
+    queryKey: ["sessions"],
+    queryFn: fetchSessions,
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: async ({ file, sessionId }: { file: File; sessionId: string }) => {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      try {
+        const { data } = await api.post<UploadResult>(`/psi/${sessionId}/upload`, formData, {
+          headers: { "Content-Type": "multipart/form-data" },
+        });
+        return data;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          const { data } = await api.post<UploadResult>("/psi/upload", formData, {
+            params: sessionId ? { session_id: sessionId } : undefined,
+            headers: { "Content-Type": "multipart/form-data" },
+          });
+          return data;
+        }
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      setMessage("Upload successful.");
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error)) {
+        setMessage(error.response?.data?.detail ?? "Upload failed. Check the CSV file and try again.");
+      } else {
+        setMessage("Upload failed. Check the CSV file and try again.");
+      }
+    },
+    onMutate: () => {
+      setMessage(null);
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const fileInput = event.currentTarget.elements.namedItem("file") as HTMLInputElement | null;
+    const file = fileInput?.files?.[0];
+
+    if (!file) {
+      setMessage("Select a CSV file to upload.");
+      return;
+    }
+
+    if (!selectedSession) {
+      setMessage("Choose a session before uploading.");
+      return;
+    }
+
+    uploadMutation.mutate({ file, sessionId: selectedSession });
+    event.currentTarget.reset();
+  };
+
+  return (
+    <div className="page">
+      <header>
+        <h1>Upload PSI CSV</h1>
+        <p>Import PSI data into the selected session.</p>
+      </header>
+
+      <section>
+        <form onSubmit={handleSubmit} className="form-grid">
+          <label>
+            Session
+            <select value={selectedSession} onChange={(event) => setSelectedSession(event.target.value)} required>
+              <option value="" disabled>
+                Select a session
+              </option>
+              {sessionsQuery.data?.map((session) => (
+                <option key={session.id} value={session.id}>
+                  {session.title}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            CSV File
+            <input type="file" name="file" accept=".csv,text/csv" required />
+          </label>
+
+          <button type="submit" disabled={uploadMutation.isPending || sessionsQuery.isLoading}>
+            {uploadMutation.isPending ? "Uploading..." : "Upload"}
+          </button>
+        </form>
+
+        {sessionsQuery.isLoading && <p>Loading sessions...</p>}
+        {sessionsQuery.isError && <p className="error">Unable to load sessions.</p>}
+        {message && <p>{message}</p>}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,19 @@
+export interface Session {
+  id: string;
+  title: string;
+  description?: string | null;
+  is_leader: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PSIRow {
+  date: string;
+  stock_at_anchor?: number | null;
+  inbound_qty?: number | null;
+  outbound_qty?: number | null;
+  net_flow?: number | null;
+  stock_closing?: number | null;
+  safety_stock?: number | null;
+  movable_stock?: number | null;
+}


### PR DESCRIPTION
## Summary
- add routed React layout with dedicated sessions, upload, and PSI table screens backed by React Query
- implement a shared axios API client and types that honour the VITE_API_BASE configuration
- style the app with lightweight CSS and commit the default .env pointing at the FastAPI service

## Testing
- npm install *(fails: npm error 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf98b4c54832ea3e12fd426f41568