### PR TITLE
feat(frontend): support VITE_API_BASE_URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm install
 npm run dev
 ```
 
-The Vite dev server runs on http://localhost:5173. Configure the backend URL with `VITE_API_BASE_URL` if needed.
+The Vite dev server runs on http://localhost:5173. Configure the backend URL with `VITE_API_BASE_URL` (or the legacy `VITE_API_BASE`) if needed.
 
 ## CSV format
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,9 @@
 import axios from "axios";
 
-const baseURL = import.meta.env.VITE_API_BASE ?? "http://127.0.0.1:8000";
+const baseURL =
+  import.meta.env.VITE_API_BASE_URL ??
+  import.meta.env.VITE_API_BASE ??
+  "http://127.0.0.1:8000";
 
 if (typeof console !== "undefined") {
   console.info(`[api] Using base URL: ${baseURL}`);


### PR DESCRIPTION
## Summary
- update the axios API helper to prefer the VITE_API_BASE_URL environment variable, falling back to the previous VITE_API_BASE and default URL
- document the new configuration option in the frontend section of the README

## Testing
- ⚠️ `npm install` *(fails: registry.npmjs.org returns HTTP 403 in the execution environment, so dev dependencies could not be installed to run the frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68cd06d5c7b0832eb2a00ada2d11db86