### PR TITLE
Add master data CRUD UI and inline session CSV uploads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import psi, sessions
+from .routers import masters, psi, sessions
 
 app = FastAPI(title="GEN-like PSI API")
 
@@ -17,6 +17,7 @@ app.add_middleware(
 )
 
 app.include_router(sessions.router, prefix="/sessions", tags=["sessions"])
+app.include_router(masters.router, prefix="/masters", tags=["masters"])
 app.include_router(psi.router, prefix="/psi", tags=["psi"])
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any
 
 from sqlalchemy import (
     BigInteger,
@@ -11,6 +12,7 @@ from sqlalchemy import (
     Date,
     DateTime,
     ForeignKey,
+    JSON,
     Numeric,
     String,
     Text,
@@ -75,6 +77,18 @@ class Session(Base, SchemaMixin, TimestampMixin):
     psi_edits: Mapped[list["PSIEdit"]] = relationship(
         back_populates="session", cascade="all, delete-orphan"
     )
+
+
+class MasterRecord(Base, SchemaMixin, TimestampMixin):
+    """Generic master data record stored as flexible JSON payloads."""
+
+    __tablename__ = "master_records"
+
+    id: Mapped[str] = mapped_column(
+        String(length=36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    master_type: Mapped[str] = mapped_column(String(length=64), index=True, nullable=False)
+    data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
 
 
 class PSIBase(Base, SchemaMixin):

--- a/backend/app/routers/masters.py
+++ b/backend/app/routers/masters.py
@@ -1,0 +1,97 @@
+"""CRUD endpoints for master data records."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session as DBSession
+
+from .. import models, schemas
+from ..deps import get_db
+
+router = APIRouter()
+
+ALLOWED_MASTER_TYPES = {"products", "customers", "suppliers"}
+
+
+def _validate_master_type(master_type: str) -> str:
+    if master_type not in ALLOWED_MASTER_TYPES:
+        raise HTTPException(status_code=404, detail="master not found")
+    return master_type
+
+
+def _get_master_record_or_404(
+    db: DBSession, record_id: str, master_type: str
+) -> models.MasterRecord:
+    try:
+        UUID(record_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="record not found") from exc
+
+    record = db.get(models.MasterRecord, record_id)
+    if record is None or record.master_type != master_type:
+        raise HTTPException(status_code=404, detail="record not found")
+    return record
+
+
+@router.get("/{master_type}", response_model=list[schemas.MasterRecordRead])
+def list_master_records(
+    master_type: str, db: DBSession = Depends(get_db)
+) -> list[schemas.MasterRecordRead]:
+    validated_master = _validate_master_type(master_type)
+    query = (
+        select(models.MasterRecord)
+        .where(models.MasterRecord.master_type == validated_master)
+        .order_by(models.MasterRecord.created_at.desc())
+    )
+    return db.scalars(query).all()
+
+
+@router.post(
+    "/{master_type}",
+    response_model=schemas.MasterRecordRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_master_record(
+    master_type: str,
+    payload: schemas.MasterRecordCreate,
+    db: DBSession = Depends(get_db),
+) -> schemas.MasterRecordRead:
+    validated_master = _validate_master_type(master_type)
+    record = models.MasterRecord(master_type=validated_master, data=payload.data)
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.put("/{master_type}/{record_id}", response_model=schemas.MasterRecordRead)
+def update_master_record(
+    master_type: str,
+    record_id: str,
+    payload: schemas.MasterRecordUpdate,
+    db: DBSession = Depends(get_db),
+) -> schemas.MasterRecordRead:
+    validated_master = _validate_master_type(master_type)
+    record = _get_master_record_or_404(db, record_id, validated_master)
+    record.data = payload.data
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.delete(
+    "/{master_type}/{record_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_master_record(
+    master_type: str, record_id: str, db: DBSession = Depends(get_db)
+) -> Response:
+    validated_master = _validate_master_type(master_type)
+    record = _get_master_record_or_404(db, record_id, validated_master)
+    db.delete(record)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -78,17 +78,18 @@ def set_leader(session_id: str, db: DBSession = Depends(get_db)) -> schemas.Sess
     _ = _get_session_or_404(db, session_id)
 
     # すべての is_leader を False に → 指定のセッションを True に
-    with db.begin():
-        db.execute(update(models.Session).values(is_leader=False))
-        result = db.execute(
-            update(models.Session)
-            .where(models.Session.id == session_id)
-            .values(is_leader=True)
-            .returning(models.Session.id)
-        ).first()
-        if not result:
-            # あり得ないが念のため
-            raise HTTPException(status_code=404, detail="session not found")
+    db.execute(update(models.Session).values(is_leader=False))
+    result = db.execute(
+        update(models.Session)
+        .where(models.Session.id == session_id)
+        .values(is_leader=True)
+        .returning(models.Session.id)
+    ).first()
+    if not result:
+        # あり得ないが念のため
+        raise HTTPException(status_code=404, detail="session not found")
+
+    db.commit()
 
     # 反映後のセッションを返す
     session = db.get(models.Session, session_id)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Annotated, Any
 from uuid import UUID
-from typing import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -60,3 +60,32 @@ class PSIUploadResult(BaseModel):
     rows_imported: int
     session_id: str
     dates: list[date]
+
+
+class MasterRecordBase(BaseModel):
+    """Shared attributes for master record write models."""
+
+    data: dict[str, Any]
+
+
+class MasterRecordCreate(MasterRecordBase):
+    """Schema for creating a master record."""
+
+    pass
+
+
+class MasterRecordUpdate(BaseModel):
+    """Schema for updating a master record."""
+
+    data: dict[str, Any]
+
+
+class MasterRecordRead(MasterRecordBase):
+    """Master record data returned by the API."""
+
+    id: UUID
+    master_type: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,6 +24,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  align-items: stretch;
 }
 
 .sidebar.collapsed {
@@ -67,7 +68,7 @@ body {
   padding: 0.5rem 0.75rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.5rem;
   border-radius: 0.375rem;
   transition: background-color 0.15s ease;
@@ -75,6 +76,7 @@ body {
   border: none;
   font: inherit;
   cursor: pointer;
+  text-align: left;
 }
 
 .menu-icon {
@@ -187,6 +189,7 @@ button[disabled] {
 .actions {
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .numeric {
@@ -207,4 +210,23 @@ button[disabled] {
   margin: 0;
   display: grid;
   gap: 0.5rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+button.secondary {
+  background-color: #6b7280;
+}
+
+button.danger {
+  background-color: #dc2626;
 }

--- a/frontend/src/pages/MasterPage.tsx
+++ b/frontend/src/pages/MasterPage.tsx
@@ -1,10 +1,19 @@
-import { useMemo } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
+
+import { api } from "../lib/api";
+import type { MasterRecord } from "../types";
+
+type FieldType = "text" | "number";
 
 interface MasterField {
   key: string;
   label: string;
   helper: string;
+  type?: FieldType;
+  required?: boolean;
 }
 
 interface MasterConfig {
@@ -13,23 +22,32 @@ interface MasterConfig {
   fields: MasterField[];
 }
 
+type MasterFormState = Record<string, string>;
+type MasterPayload = Record<string, string | number | null>;
+
 const masterConfigs: Record<string, MasterConfig> = {
   products: {
     title: "Product Master",
-    description: "Manage product catalog information including SKU, name, and stock control details.",
+    description:
+      "Manage product catalog information including SKU, name, and stock control details.",
     fields: [
-      { key: "sku", label: "SKU", helper: "Unique product identifier" },
-      { key: "name", label: "Name", helper: "Display name" },
+      { key: "sku_code", label: "SKU", helper: "Unique product identifier", required: true },
+      { key: "name", label: "Name", helper: "Display name", required: true },
       { key: "category", label: "Category", helper: "Grouping for reporting" },
-      { key: "safety_stock", label: "Safety Stock", helper: "Minimum quantity to keep on hand" },
+      {
+        key: "safety_stock",
+        label: "Safety Stock",
+        helper: "Minimum quantity to keep on hand",
+        type: "number",
+      },
     ],
   },
   customers: {
     title: "Customer Master",
     description: "Maintain customer records used for order and PSI planning.",
     fields: [
-      { key: "code", label: "Customer Code", helper: "Unique customer reference" },
-      { key: "name", label: "Name", helper: "Billing or trading name" },
+      { key: "code", label: "Customer Code", helper: "Unique customer reference", required: true },
+      { key: "name", label: "Name", helper: "Billing or trading name", required: true },
       { key: "contact", label: "Contact", helper: "Primary contact information" },
       { key: "region", label: "Region", helper: "Sales territory" },
     ],
@@ -38,32 +56,247 @@ const masterConfigs: Record<string, MasterConfig> = {
     title: "Supplier Master",
     description: "Define suppliers that provide materials feeding the PSI calculations.",
     fields: [
-      { key: "code", label: "Supplier Code", helper: "Unique supplier reference" },
-      { key: "name", label: "Name", helper: "Supplier name" },
-      { key: "lead_time", label: "Lead Time", helper: "Average delivery lead time in days" },
+      {
+        key: "code",
+        label: "Supplier Code",
+        helper: "Unique supplier reference",
+        required: true,
+      },
+      { key: "name", label: "Name", helper: "Supplier name", required: true },
+      {
+        key: "lead_time",
+        label: "Lead Time (days)",
+        helper: "Average delivery lead time",
+        type: "number",
+      },
       { key: "currency", label: "Currency", helper: "Default purchasing currency" },
     ],
   },
 };
 
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const detail = (error.response?.data as { detail?: string } | undefined)?.detail;
+    if (detail) {
+      return detail;
+    }
+    if (error.message) {
+      return error.message;
+    }
+  } else if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const createEmptyFormState = (config: MasterConfig): MasterFormState => {
+  return config.fields.reduce<MasterFormState>((accumulator, field) => {
+    accumulator[field.key] = "";
+    return accumulator;
+  }, {});
+};
+
+const buildPayload = (config: MasterConfig, values: MasterFormState): MasterPayload => {
+  return config.fields.reduce<MasterPayload>((accumulator, field) => {
+    const rawValue = values[field.key] ?? "";
+    const trimmed = rawValue.trim();
+
+    if (!trimmed) {
+      accumulator[field.key] = null;
+      return accumulator;
+    }
+
+    if (field.type === "number") {
+      const numericValue = Number(trimmed);
+      accumulator[field.key] = Number.isNaN(numericValue) ? trimmed : numericValue;
+    } else {
+      accumulator[field.key] = trimmed;
+    }
+
+    return accumulator;
+  }, {});
+};
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") {
+    return "—";
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value.toString() : String(value);
+  }
+
+  return String(value);
+};
+
 export default function MasterPage() {
   const { masterId } = useParams<{ masterId: string }>();
+  const queryClient = useQueryClient();
 
   const config = useMemo(() => {
     if (!masterId) return undefined;
     return masterConfigs[masterId];
   }, [masterId]);
 
+  const [formState, setFormState] = useState<MasterFormState>({});
+  const [editState, setEditState] = useState<MasterFormState>({});
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [status, setStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    if (config) {
+      setFormState(createEmptyFormState(config));
+      setEditState(createEmptyFormState(config));
+      setEditingId(null);
+      setStatus(null);
+    }
+  }, [config]);
+
+  const recordsQuery = useQuery({
+    queryKey: ["masters", masterId],
+    queryFn: async (): Promise<MasterRecord[]> => {
+      if (!masterId) {
+        return [];
+      }
+      const { data } = await api.get<MasterRecord[]>(`/masters/${masterId}`);
+      return data;
+    },
+    enabled: Boolean(masterId && config),
+  });
+
+  const createRecord = useMutation<MasterRecord, unknown, MasterPayload>({
+    mutationFn: async (payload: MasterPayload) => {
+      if (!masterId) throw new Error("Master not selected");
+      const { data } = await api.post<MasterRecord>(`/masters/${masterId}`, { data: payload });
+      return data;
+    },
+    onSuccess: () => {
+      if (config) {
+        setFormState(createEmptyFormState(config));
+      }
+      setStatus({ type: "success", text: "Record added." });
+      queryClient.invalidateQueries({ queryKey: ["masters", masterId] });
+    },
+    onError: (error) => {
+      setStatus({
+        type: "error",
+        text: getErrorMessage(error, "Unable to add record. Try again."),
+      });
+    },
+    onMutate: () => {
+      setStatus(null);
+    },
+  });
+
+  const updateRecord = useMutation<MasterRecord, unknown, { id: string; payload: MasterPayload }>({
+    mutationFn: async ({ id, payload }) => {
+      if (!masterId) throw new Error("Master not selected");
+      const { data } = await api.put<MasterRecord>(`/masters/${masterId}/${id}`, { data: payload });
+      return data;
+    },
+    onSuccess: () => {
+      setEditingId(null);
+      if (config) {
+        setEditState(createEmptyFormState(config));
+      }
+      setStatus({ type: "success", text: "Record updated." });
+      queryClient.invalidateQueries({ queryKey: ["masters", masterId] });
+    },
+    onError: (error) => {
+      setStatus({
+        type: "error",
+        text: getErrorMessage(error, "Unable to update record. Try again."),
+      });
+    },
+    onMutate: () => {
+      setStatus(null);
+    },
+  });
+
+  const deleteRecord = useMutation<void, unknown, string>({
+    mutationFn: async (recordId: string) => {
+      if (!masterId) throw new Error("Master not selected");
+      await api.delete(`/masters/${masterId}/${recordId}`);
+    },
+    onSuccess: () => {
+      setStatus({ type: "success", text: "Record deleted." });
+      queryClient.invalidateQueries({ queryKey: ["masters", masterId] });
+    },
+    onError: (error) => {
+      setStatus({
+        type: "error",
+        text: getErrorMessage(error, "Unable to delete record. Try again."),
+      });
+    },
+    onMutate: (recordId) => {
+      setStatus(null);
+      setDeletingId(recordId);
+    },
+    onSettled: () => {
+      setDeletingId(null);
+    },
+  });
+
   if (!config) {
     return (
       <div className="page">
         <header>
           <h1>Masters</h1>
-          <p>Select a master from the sidebar to view its configuration guidance.</p>
+          <p>Select a master from the sidebar to view and manage its records.</p>
         </header>
       </div>
     );
   }
+
+  const handleCreate = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!masterId) return;
+
+    const missingRequired = config.fields.filter(
+      (field) => field.required && !(formState[field.key] ?? "").trim(),
+    );
+
+    if (missingRequired.length > 0) {
+      setStatus({ type: "error", text: "Fill in all required fields before saving." });
+      return;
+    }
+
+    createRecord.mutate(buildPayload(config, formState));
+  };
+
+  const startEditing = (record: MasterRecord) => {
+    setStatus(null);
+    setEditingId(record.id);
+    const nextState = config.fields.reduce<MasterFormState>((accumulator, field) => {
+      const value = (record.data as Record<string, unknown>)[field.key];
+      accumulator[field.key] = value === null || value === undefined ? "" : String(value);
+      return accumulator;
+    }, createEmptyFormState(config));
+    setEditState(nextState);
+  };
+
+  const handleEditSave = () => {
+    if (!editingId) return;
+
+    const missingRequired = config.fields.filter(
+      (field) => field.required && !(editState[field.key] ?? "").trim(),
+    );
+
+    if (missingRequired.length > 0) {
+      setStatus({ type: "error", text: "Fill in all required fields before saving." });
+      return;
+    }
+
+    updateRecord.mutate({ id: editingId, payload: buildPayload(config, editState) });
+  };
+
+  const handleEditCancel = () => {
+    setEditingId(null);
+    setEditState(createEmptyFormState(config));
+    setStatus(null);
+  };
 
   return (
     <div className="page master-page">
@@ -73,32 +306,113 @@ export default function MasterPage() {
       </header>
 
       <section>
-        <h2>Key Fields</h2>
-        <table className="table">
-          <thead>
-            <tr>
-              <th>Field</th>
-              <th>Purpose</th>
-            </tr>
-          </thead>
-          <tbody>
-            {config.fields.map((field) => (
-              <tr key={field.key}>
-                <td>{field.label}</td>
-                <td>{field.helper}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <h2>Add New Record</h2>
+        <form onSubmit={handleCreate} className="form-grid">
+          {config.fields.map((field) => (
+            <label key={field.key}>
+              {field.label}
+              <input
+                type={field.type ?? "text"}
+                value={formState[field.key] ?? ""}
+                onChange={(event) =>
+                  setFormState((previous) => ({ ...previous, [field.key]: event.target.value }))
+                }
+                required={field.required}
+              />
+              <small>{field.helper}</small>
+            </label>
+          ))}
+          <button type="submit" disabled={createRecord.isPending}>
+            {createRecord.isPending ? "Saving..." : "Add"}
+          </button>
+        </form>
       </section>
 
       <section>
-        <h2>Management Tips</h2>
-        <ul className="master-guidance">
-          <li>Keep master data synchronized with external systems to ensure accurate PSI calculations.</li>
-          <li>Review and audit records regularly to remove obsolete entries.</li>
-          <li>Use consistent coding standards across masters for easier integration.</li>
-        </ul>
+        <h2>Existing Records</h2>
+        {recordsQuery.isLoading && <p>Loading records...</p>}
+        {recordsQuery.isError && (
+          <p className="error" role="alert">
+            {getErrorMessage(recordsQuery.error, "Failed to load master data.")}
+          </p>
+        )}
+        {status && <p className={status.type === "error" ? "error" : "success"}>{status.text}</p>}
+        {recordsQuery.data && recordsQuery.data.length > 0 ? (
+          <table className="table">
+            <thead>
+              <tr>
+                {config.fields.map((field) => (
+                  <th key={field.key}>{field.label}</th>
+                ))}
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recordsQuery.data.map((record) => {
+                const isEditing = editingId === record.id;
+                const isDeleting = deletingId === record.id && deleteRecord.isPending;
+                const isSaving = updateRecord.isPending && updateRecord.variables?.id === record.id;
+
+                return (
+                  <tr key={record.id}>
+                    {config.fields.map((field) => (
+                      <td key={field.key}>
+                        {isEditing ? (
+                          <input
+                            type={field.type ?? "text"}
+                            value={editState[field.key] ?? ""}
+                            onChange={(event) =>
+                              setEditState((previous) => ({
+                                ...previous,
+                                [field.key]: event.target.value,
+                              }))
+                            }
+                            required={field.required}
+                          />
+                        ) : (
+                          formatValue((record.data as Record<string, unknown>)[field.key])
+                        )}
+                      </td>
+                    ))}
+                    <td className="actions">
+                      {isEditing ? (
+                        <>
+                          <button type="button" onClick={handleEditSave} disabled={isSaving}>
+                            {isSaving ? "Saving..." : "Save"}
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary"
+                            onClick={handleEditCancel}
+                            disabled={isSaving}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button type="button" onClick={() => startEditing(record)}>
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="danger"
+                            onClick={() => deleteRecord.mutate(record.id)}
+                            disabled={isDeleting}
+                          >
+                            {isDeleting ? "Deleting..." : "Delete"}
+                          </button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        ) : (
+          !recordsQuery.isLoading && <p>No records yet.</p>
+        )}
       </section>
     </div>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,3 +17,11 @@ export interface PSIRow {
   safety_stock?: number | null;
   movable_stock?: number | null;
 }
+
+export interface MasterRecord {
+  id: string;
+  master_type: string;
+  data: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- align the sidebar navigation layout and add reusable button styles for actions
- move PSI CSV uploads into each existing session row with improved status handling
- implement master data CRUD APIs and UI while fixing the leader toggle transaction error

## Testing
- npm run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd38a35c14832e99b3e7a2844f2d86