### PR TITLE
Adjust PSI navigation and add master records migration

### DIFF
--- a/backend/alembic/versions/0002_create_master_records_table.py
+++ b/backend/alembic/versions/0002_create_master_records_table.py
@@ -1,0 +1,58 @@
+"""create master records table"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.config import settings
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: Union[str, Sequence[str], None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "master_records",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("master_type", sa.String(length=64), nullable=False),
+        sa.Column(
+            "data",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        schema=settings.db_schema,
+    )
+    op.create_index(
+        "ix_master_records_master_type",
+        "master_records",
+        ["master_type"],
+        unique=False,
+        schema=settings.db_schema,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_master_records_master_type",
+        table_name="master_records",
+        schema=settings.db_schema,
+    )
+    op.drop_table("master_records", schema=settings.db_schema)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -137,6 +137,21 @@ body {
   font-weight: 600;
 }
 
+.filters-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.filters-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 600;
+  min-width: 160px;
+}
+
 input,
 select,
 button {
@@ -157,6 +172,27 @@ button {
 button[disabled] {
   opacity: 0.65;
   cursor: not-allowed;
+}
+
+.session-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+button.icon-button {
+  background: transparent;
+  border: none;
+  padding: 0.25rem;
+  color: #2563eb;
+}
+
+button.icon-button:hover,
+button.icon-button:focus-visible {
+  background: rgba(37, 99, 235, 0.12);
+  outline: none;
+  border-radius: 0.375rem;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
 }
 
 .table {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,14 @@ export default function App() {
               <span className="menu-label">Sessions</span>
             </NavLink>
           </li>
+          <li>
+            <NavLink to="/psi" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              <span className="menu-icon" aria-hidden="true">
+                📊
+              </span>
+              <span className="menu-label">PSI Table</span>
+            </NavLink>
+          </li>
           <li className={`has-children ${isMasterMenuOpen ? "open" : ""}`}>
             <button
               type="button"
@@ -76,14 +84,6 @@ export default function App() {
                 </li>
               ))}
             </ul>
-          </li>
-          <li>
-            <NavLink to="/psi" className={({ isActive }) => (isActive ? "active" : undefined)}>
-              <span className="menu-icon" aria-hidden="true">
-                📊
-              </span>
-              <span className="menu-label">PSI Table</span>
-            </NavLink>
           </li>
         </ul>
       </nav>

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, FormEvent, useRef, useState } from "react";
 import axios from "axios";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 
 import { api } from "../lib/api";
 import { Session } from "../types";
@@ -39,6 +40,7 @@ const getErrorMessage = (error: unknown, fallback: string) => {
 
 export default function SessionsPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [formState, setFormState] = useState<SessionFormState>({ title: "", description: "" });
   const [status, setStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [uploadStatus, setUploadStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
@@ -169,6 +171,12 @@ export default function SessionsPage() {
     uploadMutation.mutate({ file, sessionId, sessionTitle });
   };
 
+  const handleOpenPsiTable = (sessionId: string) => {
+    const params = new URLSearchParams();
+    params.set("sessionId", sessionId);
+    navigate({ pathname: "/psi", search: params.toString() });
+  };
+
   return (
     <div className="page">
       <header>
@@ -235,7 +243,17 @@ export default function SessionsPage() {
                 return (
                   <tr key={session.id}>
                     <td>
-                      <strong>{session.title}</strong>
+                      <div className="session-title">
+                        <strong>{session.title}</strong>
+                        <button
+                          type="button"
+                          className="icon-button"
+                          onClick={() => handleOpenPsiTable(session.id)}
+                          aria-label={`Open PSI table for ${session.title}`}
+                        >
+                          ✏️
+                        </button>
+                      </div>
                       <br />
                       <small>{new Date(session.created_at).toLocaleString()}</small>
                     </td>


### PR DESCRIPTION
## Summary
- reorder the sidebar so the Masters menu appears last and add quick navigation from sessions to PSI
- default the PSI table view to the active leader session and streamline the filter layout into a single row
- add an Alembic migration to create the master_records table to resolve missing relation errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd3f38ddb0832eb4454fbf0d55acf5