### PR TITLE
Fix UUID handling for PSI session data

### DIFF
--- a/backend/alembic/versions/0001_create_sessions_and_psi.py
+++ b/backend/alembic/versions/0001_create_sessions_and_psi.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
 
 from app.config import settings
 
@@ -18,7 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "sessions",
-        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
         sa.Column("title", sa.Text(), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("is_leader", sa.Boolean(), nullable=False, server_default=sa.text("false")),
@@ -44,8 +45,8 @@ def upgrade() -> None:
 
     op.create_table(
         "psi_records",
-        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
-        sa.Column("session_id", sa.String(length=36), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("record_date", sa.Date(), nullable=False),
         sa.Column("production", sa.Numeric(12, 2), nullable=False),
         sa.Column("sales", sa.Numeric(12, 2), nullable=False),

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -6,18 +6,8 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import (
-    BigInteger,
-    Boolean,
-    Date,
-    DateTime,
-    ForeignKey,
-    JSON,
-    Numeric,
-    String,
-    Text,
-    func,
-)
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, ForeignKey, JSON, Numeric, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from .config import settings
@@ -64,8 +54,8 @@ class Session(Base, SchemaMixin, TimestampMixin):
 
     __tablename__ = "sessions"
 
-    id: Mapped[str] = mapped_column(
-        String(length=36), primary_key=True, default=lambda: str(uuid.uuid4())
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -100,8 +90,8 @@ class PSIBase(Base, SchemaMixin):
     __tablename__ = "psi_base"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    session_id: Mapped[str] = mapped_column(
-        String(length=36),
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
         ForeignKey(f"{settings.db_schema}.sessions.id", ondelete="CASCADE"),
         nullable=False,
     )
@@ -133,8 +123,8 @@ class PSIEdit(Base, SchemaMixin, TimestampMixin):
     __tablename__ = "psi_edits"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    session_id: Mapped[str] = mapped_column(
-        String(length=36),
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
         ForeignKey(f"{settings.db_schema}.sessions.id", ondelete="CASCADE"),
         nullable=False,
     )

--- a/backend/app/routers/psi.py
+++ b/backend/app/routers/psi.py
@@ -6,6 +6,7 @@ import io
 from collections import defaultdict
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy import delete, func, select
@@ -60,7 +61,7 @@ def _parse_decimal(raw_value: str | None, column: str) -> Decimal | None:
         ) from exc
 
 
-def _get_session_or_404(db: DBSession, session_id: str) -> models.Session:
+def _get_session_or_404(db: DBSession, session_id: UUID) -> models.Session:
     """Return the session or raise a 404 error.
 
     Args:
@@ -83,7 +84,7 @@ def _get_session_or_404(db: DBSession, session_id: str) -> models.Session:
 @router.post("/{session_id}/upload", response_model=schemas.PSIUploadResult)
 async def upload_csv_for_session(
     *,
-    session_id: str,
+    session_id: UUID,
     file: UploadFile = File(...),
     db: DBSession = Depends(get_db),
 ) -> schemas.PSIUploadResult:
@@ -209,7 +210,7 @@ async def upload_csv_for_session(
 @router.get("/{session_id}/daily", response_model=list[schemas.DailyPSI])
 def daily_psi(
     *,
-    session_id: str,
+    session_id: UUID,
     sku_code: str | None = None,
     warehouse_name: str | None = None,
     channel: str | None = None,

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -30,12 +30,7 @@ def create_session(
     return session
 
 
-def _get_session_or_404(db: DBSession, session_id: str) -> models.Session:
-    try:
-        UUID(session_id)
-    except ValueError as exc:  # sanity check
-        raise HTTPException(status_code=404, detail="session not found") from exc
-
+def _get_session_or_404(db: DBSession, session_id: UUID) -> models.Session:
     session = db.get(models.Session, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="session not found")
@@ -43,13 +38,13 @@ def _get_session_or_404(db: DBSession, session_id: str) -> models.Session:
 
 
 @router.get("/{session_id}", response_model=schemas.SessionRead)
-def get_session(session_id: str, db: DBSession = Depends(get_db)) -> schemas.SessionRead:
+def get_session(session_id: UUID, db: DBSession = Depends(get_db)) -> schemas.SessionRead:
     return _get_session_or_404(db, session_id)
 
 
 @router.put("/{session_id}", response_model=schemas.SessionRead)
 def update_session(
-    session_id: str, payload: schemas.SessionUpdate, db: DBSession = Depends(get_db)
+    session_id: UUID, payload: schemas.SessionUpdate, db: DBSession = Depends(get_db)
 ) -> schemas.SessionRead:
     session = _get_session_or_404(db, session_id)
     for field, value in payload.model_dump(exclude_unset=True).items():
@@ -65,7 +60,7 @@ def update_session(
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,  # 204 はボディ無し
 )
-def delete_session(session_id: str, db: DBSession = Depends(get_db)) -> Response:
+def delete_session(session_id: UUID, db: DBSession = Depends(get_db)) -> Response:
     session = _get_session_or_404(db, session_id)
     db.delete(session)
     db.commit()
@@ -73,7 +68,7 @@ def delete_session(session_id: str, db: DBSession = Depends(get_db)) -> Response
 
 
 @router.patch("/{session_id}/leader", response_model=schemas.SessionRead)
-def set_leader(session_id: str, db: DBSession = Depends(get_db)) -> schemas.SessionRead:
+def set_leader(session_id: UUID, db: DBSession = Depends(get_db)) -> schemas.SessionRead:
     # 先に存在確認
     _ = _get_session_or_404(db, session_id)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -58,7 +58,7 @@ class PSIUploadResult(BaseModel):
     """Upload summary returned after processing a PSI CSV file."""
 
     rows_imported: int
-    session_id: str
+    session_id: UUID
     dates: list[date]
 
 


### PR DESCRIPTION
## Summary
- align the Alembic migration and SQLAlchemy models with native UUID columns for session identifiers
- treat session identifiers as UUIDs throughout the PSI and session API routers and response schemas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd47ac8a88832e9066768ebf2f4652