### PR TITLE
feat: enhance PSI daily table controls and layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,11 +3,11 @@
   line-height: 1.5;
   color: #1f2933;
   background-color: #f5f7fa;
-  --psi-col-sku-width: clamp(12ch, 18ch, 24ch);
-  --psi-col-sku-name-width: clamp(12ch, 20ch, 28ch);
-  --psi-col-warehouse-width: clamp(12ch, 18ch, 26ch);
-  --psi-col-channel-width: clamp(10ch, 16ch, 24ch);
-  --psi-col-div-width: clamp(10ch, 14ch, 20ch);
+  --psi-col-sku-width: clamp(10ch, 14ch, 20ch);
+  --psi-col-sku-name-width: clamp(12ch, 18ch, 24ch);
+  --psi-col-warehouse-width: clamp(10ch, 14ch, 20ch);
+  --psi-col-channel-width: clamp(8ch, 12ch, 18ch);
+  --psi-col-div-width: clamp(8ch, 11ch, 16ch);
   --psi-col-offset-sku-name: var(--psi-col-sku-width);
   --psi-col-offset-warehouse: calc(var(--psi-col-offset-sku-name) + var(--psi-col-sku-name-width));
   --psi-col-offset-channel: calc(var(--psi-col-offset-warehouse) + var(--psi-col-warehouse-width));
@@ -146,19 +146,97 @@ body {
   font-weight: 600;
 }
 
-.filters-row {
-  display: flex;
+.psi-controls {
+  display: grid;
   gap: 1rem;
-  flex-wrap: wrap;
-  align-items: flex-end;
 }
 
-.filters-row label {
+.psi-controls-header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.psi-controls-header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+button.collapse-toggle {
+  background: transparent;
+  color: #2563eb;
+  border: 1px solid #bfdbfe;
+  padding: 0.35rem 0.9rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+button.collapse-toggle:hover,
+button.collapse-toggle:focus-visible {
+  background: rgba(37, 99, 235, 0.12);
+  outline: none;
+}
+
+.psi-controls-body {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 4fr);
+  gap: 1.5rem;
+}
+
+@media (max-width: 960px) {
+  .psi-controls-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.psi-panel {
+  background: #ffffff;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.psi-panel h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.psi-filter-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.psi-filter-grid label {
+  display: grid;
   gap: 0.25rem;
   font-weight: 600;
-  min-width: 160px;
+}
+
+.psi-description-panel label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.psi-description-dates,
+.psi-session-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.psi-description-dates strong,
+.psi-session-meta strong {
+  display: inline-block;
+  min-width: 4.5rem;
+}
+
+.psi-session-meta {
+  font-size: 0.875rem;
+  color: #475569;
 }
 
 input,
@@ -249,12 +327,13 @@ button.icon-button:focus-visible {
 .psi-table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 960px;
+  min-width: 840px;
+  font-size: 0.8125rem;
 }
 
 .psi-table th,
 .psi-table td {
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 0.625rem;
   border-bottom: 1px solid #e2e8f0;
   white-space: nowrap;
 }
@@ -264,7 +343,7 @@ button.icon-button:focus-visible {
   top: 0;
   background: #f1f5f9;
   font-weight: 700;
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   z-index: 6;
   text-transform: none;
 }
@@ -323,16 +402,82 @@ button.icon-button:focus-visible {
 }
 
 .psi-table .date-header {
-  min-width: 140px;
+  min-width: 110px;
+}
+
+.metric-header {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.metric-toggle {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.metric-toggle::after {
+  content: "▾";
+  font-size: 0.65rem;
+}
+
+.metric-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
+  border-radius: 0.375rem;
+}
+
+.metric-selector {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+  padding: 0.75rem 1rem;
+  z-index: 20;
+  min-width: 220px;
+}
+
+.metric-selector-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.metric-selector-options {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.metric-selector label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+}
+
+.metric-selector input[type="checkbox"] {
+  accent-color: #2563eb;
 }
 
 .psi-edit-input {
   width: 100%;
-  padding: 0.35rem 0.5rem;
+  padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   border: 1px solid #cbd5e1;
   background: #f8fafc;
   text-align: right;
+  font-size: 0.8125rem;
 }
 
 .psi-edit-input:focus {
@@ -379,6 +524,7 @@ button.icon-button:focus-visible {
 
 .numeric {
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .error {


### PR DESCRIPTION
## Summary
- restructure the PSI Daily filters into a collapsible two-column control panel and surface session creation/update timestamps
- add a metric visibility popover on the div column together with a CSV export for the currently displayed table
- tighten PSI table typography and column widths so more data fits on screen

## Testing
- npm run build *(fails: missing optional dependency @rollup/rollup-linux-x64-gnu in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5ae66ac8832e8e7e08da519245d4