### PR TITLE
Fix PSI table layout and sticky columns

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,11 +18,11 @@
   --accent-green: #22c55e;
   --accent-amber: #f59e0b;
   --accent-red: #ef4444;
-  --psi-col-sku-width: clamp(10ch, 14ch, 20ch);
-  --psi-col-sku-name-width: clamp(12ch, 18ch, 24ch);
-  --psi-col-warehouse-width: clamp(10ch, 14ch, 20ch);
-  --psi-col-channel-width: clamp(8ch, 12ch, 18ch);
-  --psi-col-div-width: clamp(8ch, 11ch, 16ch);
+  --psi-col-sku-width: 128px;
+  --psi-col-sku-name-width: 232px;
+  --psi-col-warehouse-width: 168px;
+  --psi-col-channel-width: 148px;
+  --psi-col-div-width: 132px;
   --psi-col-offset-sku-name: var(--psi-col-sku-width);
   --psi-col-offset-warehouse: calc(var(--psi-col-offset-sku-name) + var(--psi-col-sku-name-width));
   --psi-col-offset-channel: calc(var(--psi-col-offset-warehouse) + var(--psi-col-warehouse-width));
@@ -507,9 +507,9 @@ button.icon-button:focus-visible {
 }
 
 .psi-table-container {
+  position: relative;
   flex: 1;
-  overflow-x: auto;
-  overflow-y: visible;
+  overflow: auto;
   background: var(--surface-panel);
   border-radius: 0.75rem;
   border: 1px solid var(--border-default);
@@ -518,6 +518,7 @@ button.icon-button:focus-visible {
 
 .psi-table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   min-width: 840px;
   font-size: 0.8125rem;
@@ -542,6 +543,11 @@ button.icon-button:focus-visible {
 
 .psi-table tbody tr:nth-child(even) td {
   background: var(--surface-table-zebra);
+}
+
+td.numeric {
+  min-width: 0;
+  overflow: hidden;
 }
 
 .psi-table thead th {
@@ -610,11 +616,14 @@ button.icon-button:focus-visible {
 }
 
 .psi-table .today-column {
+  position: relative;
+  z-index: 1;
   background: var(--psi-today-bg);
   box-shadow: inset 1px 0 0 var(--psi-today-border), inset -1px 0 0 var(--psi-today-border);
 }
 
 .psi-table thead .today-column {
+  z-index: 8;
   background: var(--psi-today-header-bg);
   color: var(--text-primary);
 }
@@ -752,13 +761,16 @@ button.icon-button:focus-visible {
 
 .psi-edit-input {
   width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  min-width: 0;
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   border: 1px solid var(--border-input);
-  background: var(--surface-input);
+  background: rgba(148, 163, 184, 0.08);
   text-align: right;
   font-size: 0.8125rem;
-  color: var(--text-primary);
+  color: inherit;
 }
 
 .psi-edit-input:focus {

--- a/frontend/src/pages/PSITablePage.tsx
+++ b/frontend/src/pages/PSITablePage.tsx
@@ -1282,6 +1282,7 @@ export default function PSITablePage() {
                                       <input
                                         type="text"
                                         className={`psi-edit-input${isEdited ? " edited" : ""}`}
+                                        style={{ width: "100%" }}
                                         value={currentValue ?? ""}
                                         onChange={(event) =>
                                           handleEditableChange(channelKey, date, metric.key, event.target.value)


### PR DESCRIPTION
## Summary
- fix PSI table container and table layout to keep inputs within cells
- adjust sticky column widths, offsets, and highlight layering to avoid overlap
- ensure PSI edit inputs inherit colors and fill cells reliably

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68ce0b6fd56c832ea83a35fce01623aa