### PR TITLE
Refactor PSI table page into modular components

### DIFF
--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -1,0 +1,322 @@
+import { MutableRefObject } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, UIEvent as ReactUIEvent } from "react";
+
+import iconUrls from "../lib/iconUrls.json";
+import {
+  EditableField,
+  EditableMetricDefinition,
+  MetricDefinition,
+  MetricKey,
+  PSIEditableChannel,
+  PSIEditableDay,
+} from "../pages/psiTableTypes";
+
+interface PSITableContentProps {
+  sessionId: string;
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string | null;
+  tableData: PSIEditableChannel[];
+  visibleMetrics: MetricDefinition[];
+  metricDefinitions: MetricDefinition[];
+  visibleMetricKeys: MetricKey[];
+  isMetricSelectorOpen: boolean;
+  onMetricSelectorToggle: () => void;
+  onMetricVisibilityChange: (metricKey: MetricKey) => void;
+  metricSelectorRef: MutableRefObject<HTMLDivElement | null>;
+  allDates: string[];
+  todayIso: string;
+  formatDisplayDate: (iso: string) => string;
+  tableContentWidth: number;
+  tableRef: MutableRefObject<HTMLTableElement | null>;
+  tableScrollContainerRef: MutableRefObject<HTMLDivElement | null>;
+  topScrollContainerRef: MutableRefObject<HTMLDivElement | null>;
+  tableScrollAreaRef: MutableRefObject<HTMLDivElement | null>;
+  onTopScroll: (event: ReactUIEvent<HTMLDivElement>) => void;
+  onBottomScroll: (event: ReactUIEvent<HTMLDivElement>) => void;
+  onDownload: () => void;
+  canDownload: boolean;
+  selectedChannelKey: string | null;
+  onClearSelection: () => void;
+  applyError: string | null;
+  applySuccess: string | null;
+  baselineMap: Map<string, PSIEditableDay>;
+  onEditableChange: (channelKey: string, date: string, field: EditableField, rawValue: string) => void;
+  onPasteValues: (channelKey: string, date: string, field: EditableField, clipboardText: string) => void;
+  formatNumber: (value?: number | null) => string;
+  isEditableMetric: (metric: MetricDefinition) => metric is EditableMetricDefinition;
+  makeChannelKey: (channel: { sku_code: string; warehouse_name: string; channel: string }) => string;
+  makeCellKey: (channelKey: string, date: string) => string;
+  valuesEqual: (a: number | null | undefined, b: number | null | undefined) => boolean;
+  onRowSelection: (channelKey: string) => void;
+  rowGroupRefs: MutableRefObject<(HTMLTableRowElement | null)[]>;
+  onRowKeyDown: (event: ReactKeyboardEvent<HTMLTableRowElement>, index: number, channelKey: string) => void;
+}
+
+const PSITableContent = ({
+  sessionId,
+  isLoading,
+  isError,
+  errorMessage,
+  tableData,
+  visibleMetrics,
+  metricDefinitions,
+  visibleMetricKeys,
+  isMetricSelectorOpen,
+  onMetricSelectorToggle,
+  onMetricVisibilityChange,
+  metricSelectorRef,
+  allDates,
+  todayIso,
+  formatDisplayDate,
+  tableContentWidth,
+  tableRef,
+  tableScrollContainerRef,
+  topScrollContainerRef,
+  tableScrollAreaRef,
+  onTopScroll,
+  onBottomScroll,
+  onDownload,
+  canDownload,
+  selectedChannelKey,
+  onClearSelection,
+  applyError,
+  applySuccess,
+  baselineMap,
+  onEditableChange,
+  onPasteValues,
+  formatNumber,
+  isEditableMetric,
+  makeChannelKey,
+  makeCellKey,
+  valuesEqual,
+  onRowSelection,
+  rowGroupRefs,
+  onRowKeyDown,
+}: PSITableContentProps) => {
+  return (
+    <section className="psi-table-section">
+      {isLoading && sessionId && <p className="psi-table-status">Loading PSI data...</p>}
+      {isError && <p className="psi-table-status error">{errorMessage}</p>}
+      {tableData.length > 0 ? (
+        <div className="psi-table-wrapper">
+          <div className="psi-table-toolbar">
+            <div className="psi-table-toolbar-group">
+              <button
+                type="button"
+                className="psi-button secondary"
+                onClick={onDownload}
+                disabled={!canDownload}
+                aria-label="CSVをダウンロード"
+              >
+                <img src={iconUrls.downloadCsv} alt="" aria-hidden="true" className="psi-button-icon" />
+                <span>CSV</span>
+              </button>
+              {selectedChannelKey && (
+                <button
+                  type="button"
+                  className="psi-button secondary"
+                  onClick={onClearSelection}
+                  aria-label="選択を解除"
+                >
+                  <img src={iconUrls.clear} alt="" aria-hidden="true" className="psi-button-icon" />
+                  <span>選択解除</span>
+                </button>
+              )}
+            </div>
+            {(applyError || applySuccess) && (
+              <div className="psi-table-messages">
+                {applyError && <span className="error">{applyError}</span>}
+                {applySuccess && <span className="success">{applySuccess}</span>}
+              </div>
+            )}
+          </div>
+          <div className="psi-table-scroll-area" ref={tableScrollAreaRef}>
+            <div
+              className="psi-scrollbar psi-scrollbar-top"
+              ref={topScrollContainerRef}
+              onScroll={onTopScroll}
+              role="presentation"
+            >
+              <div className="psi-scrollbar-filler" style={{ width: `${tableContentWidth}px` }} />
+            </div>
+            <div className="psi-table-container" ref={tableScrollContainerRef} onScroll={onBottomScroll}>
+              <table className="psi-table" ref={tableRef}>
+                <thead>
+                  <tr>
+                    <th className="sticky-col col-sku">sku_code</th>
+                    <th className="sticky-col col-sku-name">sku_name</th>
+                    <th className="sticky-col col-warehouse">warehouse_name</th>
+                    <th className="sticky-col col-channel">channel</th>
+                    <th className="sticky-col col-div">
+                      <div className="metric-header" ref={metricSelectorRef}>
+                        <button
+                          type="button"
+                          className="metric-toggle"
+                          onClick={onMetricSelectorToggle}
+                          aria-expanded={isMetricSelectorOpen}
+                        >
+                          div
+                        </button>
+                        {isMetricSelectorOpen && (
+                          <div className="metric-selector">
+                            <p className="metric-selector-title">表示する指標</p>
+                            <div className="metric-selector-options">
+                              {metricDefinitions.map((metric) => {
+                                const key = metric.key as MetricKey;
+                                const checked = visibleMetricKeys.includes(key);
+                                const disabled = checked && visibleMetricKeys.length === 1;
+                                return (
+                                  <label key={metric.key}>
+                                    <input
+                                      type="checkbox"
+                                      checked={checked}
+                                      disabled={disabled}
+                                      onChange={() => onMetricVisibilityChange(key)}
+                                    />
+                                    {metric.label}
+                                  </label>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </th>
+                    {allDates.map((date) => (
+                      <th
+                        key={date}
+                        className={`date-header${date === todayIso ? " today-column" : ""}`}
+                        data-date={date}
+                      >
+                        {formatDisplayDate(date)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {tableData.map((item, channelIndex) => {
+                    const channelKey = makeChannelKey(item);
+                    const rowSpan = Math.max(visibleMetrics.length, 1);
+                    const dateMap = new Map(item.daily.map((entry) => [entry.date, entry]));
+
+                    if (!visibleMetrics.length) {
+                      return null;
+                    }
+
+                    const isSelected = selectedChannelKey === channelKey;
+
+                    return visibleMetrics.map((metric, metricIndex) => {
+                      const isFirstMetricRow = metricIndex === 0;
+
+                      return (
+                        <tr
+                          key={`${channelKey}-${metric.key}`}
+                          className={`psi-table-row${isSelected ? " selected" : ""}`}
+                          onClick={() => onRowSelection(channelKey)}
+                          tabIndex={isFirstMetricRow ? 0 : -1}
+                          ref={
+                            isFirstMetricRow
+                              ? (element) => {
+                                  rowGroupRefs.current[channelIndex] = element ?? null;
+                                }
+                              : undefined
+                          }
+                          onKeyDown={
+                            isFirstMetricRow
+                              ? (event) => onRowKeyDown(event, channelIndex, channelKey)
+                              : undefined
+                          }
+                          aria-selected={isSelected}
+                        >
+                          {isFirstMetricRow && (
+                            <>
+                              <td className={`sticky-col col-sku${isSelected ? " selected" : ""}`} rowSpan={rowSpan}>
+                                {item.sku_code}
+                              </td>
+                              <td
+                                className={`sticky-col col-sku-name${isSelected ? " selected" : ""}`}
+                                rowSpan={rowSpan}
+                              >
+                                {item.sku_name ?? "—"}
+                              </td>
+                              <td
+                                className={`sticky-col col-warehouse${isSelected ? " selected" : ""}`}
+                                rowSpan={rowSpan}
+                              >
+                                {item.warehouse_name}
+                              </td>
+                              <td
+                                className={`sticky-col col-channel${isSelected ? " selected" : ""}`}
+                                rowSpan={rowSpan}
+                              >
+                                {item.channel}
+                              </td>
+                            </>
+                          )}
+                          <td className={`sticky-col col-div psi-metric-name${isSelected ? " selected" : ""}`}>
+                            {metric.label}
+                          </td>
+                          {allDates.map((date) => {
+                            const entry = dateMap.get(date);
+                            const cellKey = `${channelKey}-${metric.key}-${date}`;
+                            const todayClass = date === todayIso ? " today-column" : "";
+
+                            if (!entry) {
+                              return (
+                                <td key={cellKey} className={`numeric${todayClass}`}>
+                                  —
+                                </td>
+                              );
+                            }
+
+                            const value = entry[metric.key];
+
+                            if (isEditableMetric(metric)) {
+                              const baselineEntry = baselineMap.get(makeCellKey(channelKey, date));
+                              const baselineValue = baselineEntry ? baselineEntry[metric.key] ?? null : null;
+                              const currentValue = value ?? null;
+                              const isEdited = !valuesEqual(currentValue, baselineValue);
+
+                              return (
+                                <td key={cellKey} className={`numeric${todayClass}`}>
+                                  <input
+                                    type="text"
+                                    className={`psi-edit-input${isEdited ? " edited" : ""}`}
+                                    value={currentValue ?? ""}
+                                    onChange={(event) =>
+                                      onEditableChange(channelKey, date, metric.key, event.target.value)
+                                    }
+                                    inputMode="decimal"
+                                    onPaste={(event) => {
+                                      event.preventDefault();
+                                      onPasteValues(channelKey, date, metric.key, event.clipboardData.getData("text"));
+                                    }}
+                                  />
+                                </td>
+                              );
+                            }
+
+                            return (
+                              <td key={cellKey} className={`numeric${todayClass}`}>
+                                {formatNumber(value)}
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      );
+                    });
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      ) : (
+        sessionId && !isLoading && <p className="psi-table-status">No PSI data for the current filters.</p>
+      )}
+    </section>
+  );
+};
+
+export default PSITableContent;

--- a/frontend/src/components/PSITableControls.tsx
+++ b/frontend/src/components/PSITableControls.tsx
@@ -1,0 +1,243 @@
+import { ForwardedRef, forwardRef } from "react";
+import { UseQueryResult } from "@tanstack/react-query";
+
+import iconUrls from "../lib/iconUrls.json";
+import { PSISessionSummary, Session } from "../types";
+
+interface PSITableControlsProps {
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  sessionId: string;
+  availableSessions: Session[];
+  onSessionChange: (value: string) => void;
+  sessionsQuery: UseQueryResult<Session[], unknown>;
+  skuCode: string;
+  onSkuCodeChange: (value: string) => void;
+  warehouseName: string;
+  onWarehouseNameChange: (value: string) => void;
+  channel: string;
+  onChannelChange: (value: string) => void;
+  sessionSummaryQuery: UseQueryResult<PSISessionSummary, unknown>;
+  formattedStart: string;
+  formattedEnd: string;
+  formattedCreatedAt: string;
+  formattedUpdatedAt: string;
+  descriptionDraft: string;
+  onDescriptionChange: (value: string) => void;
+  onDescriptionSave: () => void;
+  isDescriptionDirty: boolean;
+  isSavingDescription: boolean;
+  descriptionError: string | null;
+  descriptionSaved: boolean;
+  onApply: () => void;
+  canApply: boolean;
+  isApplying: boolean;
+  onRefresh: () => void;
+  refreshDisabled: boolean;
+  onReset: () => void;
+  onTodayClick: () => void;
+  hasBaselineData: boolean;
+  getErrorMessage: (error: unknown, fallback: string) => string;
+}
+
+const PSITableControls = forwardRef(function PSITableControls(
+  {
+    isCollapsed,
+    onToggleCollapse,
+    sessionId,
+    availableSessions,
+    onSessionChange,
+    sessionsQuery,
+    skuCode,
+    onSkuCodeChange,
+    warehouseName,
+    onWarehouseNameChange,
+    channel,
+    onChannelChange,
+    sessionSummaryQuery,
+    formattedStart,
+    formattedEnd,
+    formattedCreatedAt,
+    formattedUpdatedAt,
+    descriptionDraft,
+    onDescriptionChange,
+    onDescriptionSave,
+    isDescriptionDirty,
+    isSavingDescription,
+    descriptionError,
+    descriptionSaved,
+    onApply,
+    canApply,
+    isApplying,
+    onRefresh,
+    refreshDisabled,
+    onReset,
+    onTodayClick,
+    hasBaselineData,
+    getErrorMessage,
+  }: PSITableControlsProps,
+  ref: ForwardedRef<HTMLElement>
+) {
+  return (
+    <section ref={ref} className={`psi-controls${isCollapsed ? " collapsed" : ""}`}>
+      <div className="psi-controls-header">
+        <h2>Filters &amp; Description</h2>
+        <button type="button" className="collapse-toggle" onClick={onToggleCollapse}>
+          {isCollapsed ? "詳細を表示" : "詳細を折りたたむ"}
+        </button>
+      </div>
+      {!isCollapsed && (
+        <div className="psi-controls-body">
+          <div className="psi-panel psi-filter-panel">
+            <h3>フィルタ</h3>
+            <div className="psi-filter-grid">
+              <label>
+                Session
+                <select
+                  value={sessionId}
+                  onChange={(event) => onSessionChange(event.target.value)}
+                  disabled={sessionsQuery.isLoading}
+                >
+                  <option value="" disabled>
+                    Select a session
+                  </option>
+                  {availableSessions.map((session) => (
+                    <option key={session.id} value={session.id}>
+                      {session.title}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                SKU Code
+                <input
+                  type="text"
+                  value={skuCode}
+                  onChange={(event) => onSkuCodeChange(event.target.value)}
+                  placeholder="Optional"
+                />
+              </label>
+              <label>
+                Warehouse
+                <input
+                  type="text"
+                  value={warehouseName}
+                  onChange={(event) => onWarehouseNameChange(event.target.value)}
+                  placeholder="Optional"
+                />
+              </label>
+              <label>
+                Channel
+                <input
+                  type="text"
+                  value={channel}
+                  onChange={(event) => onChannelChange(event.target.value)}
+                  placeholder="Optional"
+                />
+              </label>
+            </div>
+            {sessionsQuery.isLoading && <p>Loading sessions...</p>}
+            {sessionsQuery.isError && (
+              <p className="error">{getErrorMessage(sessionsQuery.error, "Unable to load sessions.")}</p>
+            )}
+          </div>
+          <div className="psi-panel psi-description-panel">
+            {sessionId ? (
+              <>
+                <div className="psi-description-dates">
+                  <div>
+                    <strong>開始日</strong>
+                    <span>{sessionSummaryQuery.isLoading ? "…" : formattedStart}</span>
+                  </div>
+                  <div>
+                    <strong>終了日</strong>
+                    <span>{sessionSummaryQuery.isLoading ? "…" : formattedEnd}</span>
+                  </div>
+                </div>
+                {sessionSummaryQuery.isError && (
+                  <p className="error">
+                    {getErrorMessage(sessionSummaryQuery.error, "Unable to load session date range.")}
+                  </p>
+                )}
+                <label>
+                  Description
+                  <textarea
+                    value={descriptionDraft}
+                    onChange={(event) => onDescriptionChange(event.target.value)}
+                    placeholder="Add a description for this session"
+                  />
+                </label>
+                <div className="session-summary-actions">
+                  <button
+                    type="button"
+                    className="psi-button secondary"
+                    onClick={onDescriptionSave}
+                    disabled={!isDescriptionDirty || isSavingDescription}
+                    aria-label={isSavingDescription ? "説明を保存中" : "説明を保存"}
+                  >
+                    <img src={iconUrls.save} alt="" aria-hidden="true" className="psi-button-icon" />
+                    <span>{isSavingDescription ? "保存中…" : "保存"}</span>
+                  </button>
+                  {descriptionError && <span className="error">{descriptionError}</span>}
+                  {descriptionSaved && <span className="success">Description updated.</span>}
+                </div>
+                <div className="psi-session-meta">
+                  <div>
+                    <strong>作成日</strong>
+                    <span>{formattedCreatedAt}</span>
+                  </div>
+                  <div>
+                    <strong>更新日</strong>
+                    <span>{formattedUpdatedAt}</span>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <p>Select a session to view its details.</p>
+            )}
+          </div>
+        </div>
+      )}
+      <div className="psi-toolbar" role="toolbar" aria-label="PSI data actions">
+        <div className="psi-toolbar-group">
+          <button
+            type="button"
+            className="psi-button primary"
+            onClick={onApply}
+            disabled={!canApply || isApplying}
+          >
+            <img src={iconUrls.apply} alt="" aria-hidden="true" className="psi-button-icon" />
+            <span>{isApplying ? "Applying…" : "適用"}</span>
+          </button>
+        </div>
+        <div className="psi-toolbar-group">
+          <button
+            type="button"
+            className="psi-button secondary"
+            onClick={onRefresh}
+            disabled={refreshDisabled}
+          >
+            <img src={iconUrls.refresh} alt="" aria-hidden="true" className="psi-button-icon" />
+            <span>更新</span>
+          </button>
+          <button
+            type="button"
+            className="psi-button secondary"
+            onClick={onReset}
+            disabled={!hasBaselineData}
+          >
+            <img src={iconUrls.reset} alt="" aria-hidden="true" className="psi-button-icon" />
+            <span>リセット</span>
+          </button>
+        </div>
+        <div className="psi-toolbar-spacer" aria-hidden="true" />
+        <button type="button" className="psi-button today" onClick={onTodayClick} aria-label="今日の列へ移動">
+          <img src={iconUrls.today} alt="" aria-hidden="true" className="psi-button-icon" />
+          <span>今日へ</span>
+        </button>
+      </div>
+    </section>
+  );
+});
+
+export default PSITableControls;

--- a/frontend/src/hooks/usePsiQueries.ts
+++ b/frontend/src/hooks/usePsiQueries.ts
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+import { PSIChannel, PSISessionSummary, Session } from "../types";
+
+const fetchSessions = async (): Promise<Session[]> => {
+  const { data } = await api.get<Session[]>("/sessions/");
+  return data;
+};
+
+const fetchDailyPsi = async (
+  sessionId: string,
+  filters: { sku_code?: string; warehouse_name?: string; channel?: string }
+): Promise<PSIChannel[]> => {
+  const params: Record<string, string> = {};
+  if (filters.sku_code?.trim()) params.sku_code = filters.sku_code.trim();
+  if (filters.warehouse_name?.trim()) params.warehouse_name = filters.warehouse_name.trim();
+  if (filters.channel?.trim()) params.channel = filters.channel.trim();
+
+  const { data } = await api.get<PSIChannel[]>(`/psi/${sessionId}/daily`, {
+    params,
+  });
+  return data;
+};
+
+const fetchSessionSummary = async (sessionId: string): Promise<PSISessionSummary> => {
+  const { data } = await api.get<PSISessionSummary>(`/psi/${sessionId}/summary`);
+  return data;
+};
+
+export const useSessionsQuery = () =>
+  useQuery({
+    queryKey: ["sessions"],
+    queryFn: fetchSessions,
+  });
+
+export const useDailyPsiQuery = (
+  sessionId: string,
+  filters: { sku_code?: string; warehouse_name?: string; channel?: string }
+) =>
+  useQuery({
+    queryKey: ["psi-daily", sessionId, filters.sku_code, filters.warehouse_name, filters.channel],
+    queryFn: () => fetchDailyPsi(sessionId, filters),
+    enabled: Boolean(sessionId),
+  });
+
+export const useSessionSummaryQuery = (sessionId: string) =>
+  useQuery({
+    queryKey: ["psi-session-summary", sessionId],
+    queryFn: () => fetchSessionSummary(sessionId),
+    enabled: Boolean(sessionId),
+  });

--- a/frontend/src/pages/psiTableTypes.ts
+++ b/frontend/src/pages/psiTableTypes.ts
@@ -1,0 +1,48 @@
+import { PSIChannel, PSIDailyEntry } from "../types";
+
+export type MetricKey =
+  | "stock_at_anchor"
+  | "inbound_qty"
+  | "outbound_qty"
+  | "net_flow"
+  | "stock_closing"
+  | "safety_stock"
+  | "movable_stock";
+
+export type EditableField = "inbound_qty" | "outbound_qty" | "safety_stock";
+
+export interface PSIEditableDay extends PSIDailyEntry {
+  base_stock_at_anchor: number | null;
+}
+
+export interface PSIEditableChannel extends Omit<PSIChannel, "daily"> {
+  daily: PSIEditableDay[];
+}
+
+export interface MetricDefinitionBase {
+  key: MetricKey;
+  label: string;
+  editable?: false;
+}
+
+export interface EditableMetricDefinition {
+  key: EditableField;
+  label: string;
+  editable: true;
+}
+
+export type MetricDefinition = MetricDefinitionBase | EditableMetricDefinition;
+
+export const metricDefinitions: MetricDefinition[] = [
+  { key: "stock_at_anchor", label: "stock_at_anchor" },
+  { key: "inbound_qty", label: "inbound_qty", editable: true },
+  { key: "outbound_qty", label: "outbound_qty", editable: true },
+  { key: "net_flow", label: "net_flow" },
+  { key: "stock_closing", label: "stock_closing" },
+  { key: "safety_stock", label: "safety_stock", editable: true },
+  { key: "movable_stock", label: "movable_stock" },
+];
+
+export const isEditableMetric = (
+  metric: MetricDefinition
+): metric is EditableMetricDefinition => metric.editable === true;


### PR DESCRIPTION
## Summary
- move PSI data fetching logic for sessions, daily PSI, and summaries into a shared hook
- extract the PSI filter/description controls and table rendering into dedicated components
- centralize reusable PSI table types and constants for use across the new modules

## Testing
- npm run build *(fails: optional Rollup binary @rollup/rollup-linux-x64-gnu missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1359f9b8832e95c440076646fa26