### PR TITLE
Refactor PSI hooks and centralize API calls

### DIFF
--- a/frontend/src/hooks/usePsi.ts
+++ b/frontend/src/hooks/usePsi.ts
@@ -1,16 +1,28 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "../lib/api";
-import { PSIChannel, PSISessionSummary, Session } from "../types";
+import {
+  PSIChannel,
+  PSIEditApplyResult,
+  PSIEditUpdatePayload,
+  PSISessionSummary,
+  Session,
+} from "../types";
 
-const fetchSessions = async (): Promise<Session[]> => {
+export type PsiFilters = {
+  sku_code?: string;
+  warehouse_name?: string;
+  channel?: string;
+};
+
+export const fetchSessions = async (): Promise<Session[]> => {
   const { data } = await api.get<Session[]>("/sessions/");
   return data;
 };
 
-const fetchDailyPsi = async (
+export const fetchDailyPsi = async (
   sessionId: string,
-  filters: { sku_code?: string; warehouse_name?: string; channel?: string }
+  filters: PsiFilters
 ): Promise<PSIChannel[]> => {
   const params: Record<string, string> = {};
   if (filters.sku_code?.trim()) params.sku_code = filters.sku_code.trim();
@@ -23,8 +35,18 @@ const fetchDailyPsi = async (
   return data;
 };
 
-const fetchSessionSummary = async (sessionId: string): Promise<PSISessionSummary> => {
+export const fetchSessionSummary = async (
+  sessionId: string
+): Promise<PSISessionSummary> => {
   const { data } = await api.get<PSISessionSummary>(`/psi/${sessionId}/summary`);
+  return data;
+};
+
+export const applyPsiEdits = async (
+  sessionId: string,
+  edits: PSIEditUpdatePayload[]
+): Promise<PSIEditApplyResult> => {
+  const { data } = await api.post<PSIEditApplyResult>(`/psi/${sessionId}/edits/apply`, { edits });
   return data;
 };
 
@@ -36,10 +58,16 @@ export const useSessionsQuery = () =>
 
 export const useDailyPsiQuery = (
   sessionId: string,
-  filters: { sku_code?: string; warehouse_name?: string; channel?: string }
+  filters: PsiFilters
 ) =>
   useQuery({
-    queryKey: ["psi-daily", sessionId, filters.sku_code, filters.warehouse_name, filters.channel],
+    queryKey: [
+      "psi-daily",
+      sessionId,
+      filters.sku_code,
+      filters.warehouse_name,
+      filters.channel,
+    ],
     queryFn: () => fetchDailyPsi(sessionId, filters),
     enabled: Boolean(sessionId),
   });

--- a/frontend/src/pages/PSITablePage.tsx
+++ b/frontend/src/pages/PSITablePage.tsx
@@ -5,10 +5,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 
 import { api } from "../lib/api";
-import { PSIChannel, PSIDailyEntry, PSIEditApplyResult, Session } from "../types";
+import { PSIChannel, PSIDailyEntry, PSIEditUpdatePayload, Session } from "../types";
 import PSITableContent from "../components/PSITableContent";
 import PSITableControls from "../components/PSITableControls";
-import { useDailyPsiQuery, useSessionSummaryQuery, useSessionsQuery } from "../hooks/usePsiQueries";
+import { applyPsiEdits, useDailyPsiQuery, useSessionSummaryQuery, useSessionsQuery } from "../hooks/usePsi";
 import {
   EditableField,
   MetricDefinition,
@@ -33,24 +33,6 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   }
 
   return fallback;
-};
-
-interface PSIEditUpdatePayload {
-  sku_code: string;
-  warehouse_name: string;
-  channel: string;
-  date: string;
-  inbound_qty?: number | null;
-  outbound_qty?: number | null;
-  safety_stock?: number | null;
-}
-
-const applyPsiEdits = async (
-  sessionId: string,
-  edits: PSIEditUpdatePayload[]
-): Promise<PSIEditApplyResult> => {
-  const { data } = await api.post<PSIEditApplyResult>(`/psi/${sessionId}/edits/apply`, { edits });
-  return data;
 };
 
 const numberFormatter = new Intl.NumberFormat("ja-JP", {

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,10 +1,11 @@
 import { ChangeEvent, FormEvent, useRef, useState } from "react";
 import axios from "axios";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import { api } from "../lib/api";
 import { Session } from "../types";
+import { useSessionsQuery } from "../hooks/usePsi";
 
 interface SessionFormState {
   title: string;
@@ -16,11 +17,6 @@ interface UploadVariables {
   sessionId: string;
   sessionTitle: string;
 }
-
-const fetchSessions = async (): Promise<Session[]> => {
-  const { data } = await api.get<Session[]>("/sessions/");
-  return data;
-};
 
 const getErrorMessage = (error: unknown, fallback: string) => {
   if (axios.isAxiosError(error)) {
@@ -46,10 +42,7 @@ export default function SessionsPage() {
   const [uploadStatus, setUploadStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [uploadingSessionId, setUploadingSessionId] = useState<string | null>(null);
 
-  const sessionsQuery = useQuery({
-    queryKey: ["sessions"],
-    queryFn: fetchSessions,
-  });
+  const sessionsQuery = useSessionsQuery();
 
   const createSession = useMutation<Session, unknown, SessionFormState>({
     mutationFn: async (payload: SessionFormState) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,16 @@ export interface PSIEditApplyResult {
   log_entries: number;
 }
 
+export interface PSIEditUpdatePayload {
+  sku_code: string;
+  warehouse_name: string;
+  channel: string;
+  date: string;
+  inbound_qty?: number | null;
+  outbound_qty?: number | null;
+  safety_stock?: number | null;
+}
+
 export interface MasterRecord {
   id: string;
   master_type: string;


### PR DESCRIPTION
## Summary
- centralize PSI API helper functions and React Query hooks in `usePsi`
- update PSI table and sessions pages to consume the shared hooks and helpers
- add a shared `PSIEditUpdatePayload` type for edit submissions

## Testing
- npm run build *(fails: rollup optional dependency missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce164a8dc0832eb1355db3eb2cbfae