### PR TITLE
Extract PSI filter and description panels

### DIFF
--- a/frontend/src/components/PSIDescriptionPanel.tsx
+++ b/frontend/src/components/PSIDescriptionPanel.tsx
@@ -1,0 +1,98 @@
+import { UseQueryResult } from "@tanstack/react-query";
+
+import iconUrls from "../lib/iconUrls.json";
+import { PSISessionSummary } from "../types";
+
+interface PSIDescriptionPanelProps {
+  sessionId: string;
+  sessionSummaryQuery: UseQueryResult<PSISessionSummary, unknown>;
+  formattedStart: string;
+  formattedEnd: string;
+  formattedCreatedAt: string;
+  formattedUpdatedAt: string;
+  descriptionDraft: string;
+  onDescriptionChange: (value: string) => void;
+  onDescriptionSave: () => void;
+  isDescriptionDirty: boolean;
+  isSavingDescription: boolean;
+  descriptionError: string | null;
+  descriptionSaved: boolean;
+  getErrorMessage: (error: unknown, fallback: string) => string;
+}
+
+function PSIDescriptionPanel({
+  sessionId,
+  sessionSummaryQuery,
+  formattedStart,
+  formattedEnd,
+  formattedCreatedAt,
+  formattedUpdatedAt,
+  descriptionDraft,
+  onDescriptionChange,
+  onDescriptionSave,
+  isDescriptionDirty,
+  isSavingDescription,
+  descriptionError,
+  descriptionSaved,
+  getErrorMessage,
+}: PSIDescriptionPanelProps) {
+  return (
+    <div className="psi-panel psi-description-panel">
+      {sessionId ? (
+        <>
+          <div className="psi-description-dates">
+            <div>
+              <strong>開始日</strong>
+              <span>{sessionSummaryQuery.isLoading ? "…" : formattedStart}</span>
+            </div>
+            <div>
+              <strong>終了日</strong>
+              <span>{sessionSummaryQuery.isLoading ? "…" : formattedEnd}</span>
+            </div>
+          </div>
+          {sessionSummaryQuery.isError && (
+            <p className="error">
+              {getErrorMessage(sessionSummaryQuery.error, "Unable to load session date range.")}
+            </p>
+          )}
+          <label>
+            Description
+            <textarea
+              value={descriptionDraft}
+              onChange={(event) => onDescriptionChange(event.target.value)}
+              placeholder="Add a description for this session"
+            />
+          </label>
+          <div className="session-summary-actions">
+            <button
+              type="button"
+              className="psi-button secondary"
+              onClick={onDescriptionSave}
+              disabled={!isDescriptionDirty || isSavingDescription}
+              aria-label={isSavingDescription ? "説明を保存中" : "説明を保存"}
+            >
+              <img src={iconUrls.save} alt="" aria-hidden="true" className="psi-button-icon" />
+              <span>{isSavingDescription ? "保存中…" : "保存"}</span>
+            </button>
+            {descriptionError && <span className="error">{descriptionError}</span>}
+            {descriptionSaved && <span className="success">Description updated.</span>}
+          </div>
+          <div className="psi-session-meta">
+            <div>
+              <strong>作成日</strong>
+              <span>{formattedCreatedAt}</span>
+            </div>
+            <div>
+              <strong>更新日</strong>
+              <span>{formattedUpdatedAt}</span>
+            </div>
+          </div>
+        </>
+      ) : (
+        <p>Select a session to view its details.</p>
+      )}
+    </div>
+  );
+}
+
+export default PSIDescriptionPanel;

--- a/frontend/src/components/PSIFilterPanel.tsx
+++ b/frontend/src/components/PSIFilterPanel.tsx
@@ -1,0 +1,89 @@
+import { UseQueryResult } from "@tanstack/react-query";
+
+import { Session } from "../types";
+
+interface PSIFilterPanelProps {
+  sessionId: string;
+  availableSessions: Session[];
+  onSessionChange: (value: string) => void;
+  sessionsQuery: UseQueryResult<Session[], unknown>;
+  skuCode: string;
+  onSkuCodeChange: (value: string) => void;
+  warehouseName: string;
+  onWarehouseNameChange: (value: string) => void;
+  channel: string;
+  onChannelChange: (value: string) => void;
+  getErrorMessage: (error: unknown, fallback: string) => string;
+}
+
+function PSIFilterPanel({
+  sessionId,
+  availableSessions,
+  onSessionChange,
+  sessionsQuery,
+  skuCode,
+  onSkuCodeChange,
+  warehouseName,
+  onWarehouseNameChange,
+  channel,
+  onChannelChange,
+  getErrorMessage,
+}: PSIFilterPanelProps) {
+  return (
+    <div className="psi-panel psi-filter-panel">
+      <h3>フィルタ</h3>
+      <div className="psi-filter-grid">
+        <label>
+          Session
+          <select
+            value={sessionId}
+            onChange={(event) => onSessionChange(event.target.value)}
+            disabled={sessionsQuery.isLoading}
+          >
+            <option value="" disabled>
+              Select a session
+            </option>
+            {availableSessions.map((session) => (
+              <option key={session.id} value={session.id}>
+                {session.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          SKU Code
+          <input
+            type="text"
+            value={skuCode}
+            onChange={(event) => onSkuCodeChange(event.target.value)}
+            placeholder="Optional"
+          />
+        </label>
+        <label>
+          Warehouse
+          <input
+            type="text"
+            value={warehouseName}
+            onChange={(event) => onWarehouseNameChange(event.target.value)}
+            placeholder="Optional"
+          />
+        </label>
+        <label>
+          Channel
+          <input
+            type="text"
+            value={channel}
+            onChange={(event) => onChannelChange(event.target.value)}
+            placeholder="Optional"
+          />
+        </label>
+      </div>
+      {sessionsQuery.isLoading && <p>Loading sessions...</p>}
+      {sessionsQuery.isError && (
+        <p className="error">{getErrorMessage(sessionsQuery.error, "Unable to load sessions.")}</p>
+      )}
+    </div>
+  );
+}
+
+export default PSIFilterPanel;

--- a/frontend/src/components/PSITableControls.tsx
+++ b/frontend/src/components/PSITableControls.tsx
@@ -3,6 +3,8 @@ import { UseQueryResult } from "@tanstack/react-query";
 
 import iconUrls from "../lib/iconUrls.json";
 import { PSISessionSummary, Session } from "../types";
+import PSIDescriptionPanel from "./PSIDescriptionPanel";
+import PSIFilterPanel from "./PSIFilterPanel";
 
 interface PSITableControlsProps {
   isCollapsed: boolean;
@@ -88,114 +90,35 @@ const PSITableControls = forwardRef(function PSITableControls(
       </div>
       {!isCollapsed && (
         <div className="psi-controls-body">
-          <div className="psi-panel psi-filter-panel">
-            <h3>フィルタ</h3>
-            <div className="psi-filter-grid">
-              <label>
-                Session
-                <select
-                  value={sessionId}
-                  onChange={(event) => onSessionChange(event.target.value)}
-                  disabled={sessionsQuery.isLoading}
-                >
-                  <option value="" disabled>
-                    Select a session
-                  </option>
-                  {availableSessions.map((session) => (
-                    <option key={session.id} value={session.id}>
-                      {session.title}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                SKU Code
-                <input
-                  type="text"
-                  value={skuCode}
-                  onChange={(event) => onSkuCodeChange(event.target.value)}
-                  placeholder="Optional"
-                />
-              </label>
-              <label>
-                Warehouse
-                <input
-                  type="text"
-                  value={warehouseName}
-                  onChange={(event) => onWarehouseNameChange(event.target.value)}
-                  placeholder="Optional"
-                />
-              </label>
-              <label>
-                Channel
-                <input
-                  type="text"
-                  value={channel}
-                  onChange={(event) => onChannelChange(event.target.value)}
-                  placeholder="Optional"
-                />
-              </label>
-            </div>
-            {sessionsQuery.isLoading && <p>Loading sessions...</p>}
-            {sessionsQuery.isError && (
-              <p className="error">{getErrorMessage(sessionsQuery.error, "Unable to load sessions.")}</p>
-            )}
-          </div>
-          <div className="psi-panel psi-description-panel">
-            {sessionId ? (
-              <>
-                <div className="psi-description-dates">
-                  <div>
-                    <strong>開始日</strong>
-                    <span>{sessionSummaryQuery.isLoading ? "…" : formattedStart}</span>
-                  </div>
-                  <div>
-                    <strong>終了日</strong>
-                    <span>{sessionSummaryQuery.isLoading ? "…" : formattedEnd}</span>
-                  </div>
-                </div>
-                {sessionSummaryQuery.isError && (
-                  <p className="error">
-                    {getErrorMessage(sessionSummaryQuery.error, "Unable to load session date range.")}
-                  </p>
-                )}
-                <label>
-                  Description
-                  <textarea
-                    value={descriptionDraft}
-                    onChange={(event) => onDescriptionChange(event.target.value)}
-                    placeholder="Add a description for this session"
-                  />
-                </label>
-                <div className="session-summary-actions">
-                  <button
-                    type="button"
-                    className="psi-button secondary"
-                    onClick={onDescriptionSave}
-                    disabled={!isDescriptionDirty || isSavingDescription}
-                    aria-label={isSavingDescription ? "説明を保存中" : "説明を保存"}
-                  >
-                    <img src={iconUrls.save} alt="" aria-hidden="true" className="psi-button-icon" />
-                    <span>{isSavingDescription ? "保存中…" : "保存"}</span>
-                  </button>
-                  {descriptionError && <span className="error">{descriptionError}</span>}
-                  {descriptionSaved && <span className="success">Description updated.</span>}
-                </div>
-                <div className="psi-session-meta">
-                  <div>
-                    <strong>作成日</strong>
-                    <span>{formattedCreatedAt}</span>
-                  </div>
-                  <div>
-                    <strong>更新日</strong>
-                    <span>{formattedUpdatedAt}</span>
-                  </div>
-                </div>
-              </>
-            ) : (
-              <p>Select a session to view its details.</p>
-            )}
-          </div>
+          <PSIFilterPanel
+            sessionId={sessionId}
+            availableSessions={availableSessions}
+            onSessionChange={onSessionChange}
+            sessionsQuery={sessionsQuery}
+            skuCode={skuCode}
+            onSkuCodeChange={onSkuCodeChange}
+            warehouseName={warehouseName}
+            onWarehouseNameChange={onWarehouseNameChange}
+            channel={channel}
+            onChannelChange={onChannelChange}
+            getErrorMessage={getErrorMessage}
+          />
+          <PSIDescriptionPanel
+            sessionId={sessionId}
+            sessionSummaryQuery={sessionSummaryQuery}
+            formattedStart={formattedStart}
+            formattedEnd={formattedEnd}
+            formattedCreatedAt={formattedCreatedAt}
+            formattedUpdatedAt={formattedUpdatedAt}
+            descriptionDraft={descriptionDraft}
+            onDescriptionChange={onDescriptionChange}
+            onDescriptionSave={onDescriptionSave}
+            isDescriptionDirty={isDescriptionDirty}
+            isSavingDescription={isSavingDescription}
+            descriptionError={descriptionError}
+            descriptionSaved={descriptionSaved}
+            getErrorMessage={getErrorMessage}
+          />
         </div>
       )}
       <div className="psi-toolbar" role="toolbar" aria-label="PSI data actions">


### PR DESCRIPTION
## Summary
- extract the PSI filter UI into a dedicated `PSIFilterPanel` component that receives all state via props
- move the session description controls into a new `PSIDescriptionPanel` component and wire it up from `PSITableControls`
- update `PSITableControls` to compose the new panels while keeping existing toolbar behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce17f9a5bc832ea2573a4b5991bc1f