### PR TITLE
Refactor PSI table layout into synchronized left/right panes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,6 +27,13 @@
   --psi-col-offset-warehouse: calc(var(--psi-col-offset-sku-name) + var(--psi-col-sku-name-width));
   --psi-col-offset-channel: calc(var(--psi-col-offset-warehouse) + var(--psi-col-warehouse-width));
   --psi-col-offset-div: calc(var(--psi-col-offset-channel) + var(--psi-col-channel-width));
+  --psi-left-width: calc(
+    var(--psi-col-sku-width) +
+      var(--psi-col-sku-name-width) +
+      var(--psi-col-warehouse-width) +
+      var(--psi-col-channel-width) +
+      var(--psi-col-div-width)
+  );
   --psi-today-bg: rgba(59, 130, 246, 0.14);
   --psi-today-header-bg: rgba(59, 130, 246, 0.18);
   --psi-today-border: rgba(96, 165, 250, 0.4);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import SessionsPage from "./pages/SessionsPage";
 import PSITablePage from "./pages/PSITablePage";
 import MasterPage from "./pages/MasterPage";
 import "./App.css";
+import "./styles/psi-sticky.css";
 
 export default function App() {
   const location = useLocation();

--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -1,15 +1,9 @@
 import { MutableRefObject } from "react";
-import type { KeyboardEvent as ReactKeyboardEvent, UIEvent as ReactUIEvent } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import iconUrls from "../lib/iconUrls.json";
-import {
-  EditableField,
-  EditableMetricDefinition,
-  MetricDefinition,
-  MetricKey,
-  PSIEditableChannel,
-  PSIEditableDay,
-} from "../pages/psiTableTypes";
+import { EditableField, MetricDefinition, MetricKey, PSIEditableChannel, PSIEditableDay } from "../pages/psiTableTypes";
+import PSITableSplit from "./PSITableSplit";
 
 interface PSITableContentProps {
   sessionId: string;
@@ -27,16 +21,14 @@ interface PSITableContentProps {
   allDates: string[];
   todayIso: string;
   formatDisplayDate: (iso: string) => string;
-  tableContentWidth: number;
   tableRef: MutableRefObject<HTMLTableElement | null>;
   tableScrollContainerRef: MutableRefObject<HTMLDivElement | null>;
   topScrollContainerRef: MutableRefObject<HTMLDivElement | null>;
   tableScrollAreaRef: MutableRefObject<HTMLDivElement | null>;
-  onTopScroll: (event: ReactUIEvent<HTMLDivElement>) => void;
-  onBottomScroll: (event: ReactUIEvent<HTMLDivElement>) => void;
   onDownload: () => void;
   canDownload: boolean;
   selectedChannelKey: string | null;
+  setSelectedChannelKey: (key: string | null) => void;
   onClearSelection: () => void;
   applyError: string | null;
   applySuccess: string | null;
@@ -44,11 +36,9 @@ interface PSITableContentProps {
   onEditableChange: (channelKey: string, date: string, field: EditableField, rawValue: string) => void;
   onPasteValues: (channelKey: string, date: string, field: EditableField, clipboardText: string) => void;
   formatNumber: (value?: number | null) => string;
-  isEditableMetric: (metric: MetricDefinition) => metric is EditableMetricDefinition;
   makeChannelKey: (channel: { sku_code: string; warehouse_name: string; channel: string }) => string;
   makeCellKey: (channelKey: string, date: string) => string;
   valuesEqual: (a: number | null | undefined, b: number | null | undefined) => boolean;
-  onRowSelection: (channelKey: string) => void;
   rowGroupRefs: MutableRefObject<(HTMLTableRowElement | null)[]>;
   onRowKeyDown: (event: ReactKeyboardEvent<HTMLTableRowElement>, index: number, channelKey: string) => void;
 }
@@ -69,16 +59,14 @@ const PSITableContent = ({
   allDates,
   todayIso,
   formatDisplayDate,
-  tableContentWidth,
   tableRef,
   tableScrollContainerRef,
   topScrollContainerRef,
   tableScrollAreaRef,
-  onTopScroll,
-  onBottomScroll,
   onDownload,
   canDownload,
   selectedChannelKey,
+  setSelectedChannelKey,
   onClearSelection,
   applyError,
   applySuccess,
@@ -86,11 +74,9 @@ const PSITableContent = ({
   onEditableChange,
   onPasteValues,
   formatNumber,
-  isEditableMetric,
   makeChannelKey,
   makeCellKey,
   valuesEqual,
-  onRowSelection,
   rowGroupRefs,
   onRowKeyDown,
 }: PSITableContentProps) => {
@@ -132,184 +118,33 @@ const PSITableContent = ({
             )}
           </div>
           <div className="psi-table-scroll-area" ref={tableScrollAreaRef}>
-            <div
-              className="psi-scrollbar psi-scrollbar-top"
-              ref={topScrollContainerRef}
-              onScroll={onTopScroll}
-              role="presentation"
-            >
-              <div className="psi-scrollbar-filler" style={{ width: `${tableContentWidth}px` }} />
-            </div>
-            <div className="psi-table-container" ref={tableScrollContainerRef} onScroll={onBottomScroll}>
-              <table className="psi-table" ref={tableRef}>
-                <thead>
-                  <tr>
-                    <th className="sticky-col col-sku">sku_code</th>
-                    <th className="sticky-col col-sku-name">sku_name</th>
-                    <th className="sticky-col col-warehouse">warehouse_name</th>
-                    <th className="sticky-col col-channel">channel</th>
-                    <th className="sticky-col col-div">
-                      <div className="metric-header" ref={metricSelectorRef}>
-                        <button
-                          type="button"
-                          className="metric-toggle"
-                          onClick={onMetricSelectorToggle}
-                          aria-expanded={isMetricSelectorOpen}
-                        >
-                          div
-                        </button>
-                        {isMetricSelectorOpen && (
-                          <div className="metric-selector">
-                            <p className="metric-selector-title">表示する指標</p>
-                            <div className="metric-selector-options">
-                              {metricDefinitions.map((metric) => {
-                                const key = metric.key as MetricKey;
-                                const checked = visibleMetricKeys.includes(key);
-                                const disabled = checked && visibleMetricKeys.length === 1;
-                                return (
-                                  <label key={metric.key}>
-                                    <input
-                                      type="checkbox"
-                                      checked={checked}
-                                      disabled={disabled}
-                                      onChange={() => onMetricVisibilityChange(key)}
-                                    />
-                                    {metric.label}
-                                  </label>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </th>
-                    {allDates.map((date) => (
-                      <th
-                        key={date}
-                        className={`date-header${date === todayIso ? " today-column" : ""}`}
-                        data-date={date}
-                      >
-                        {formatDisplayDate(date)}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {tableData.map((item, channelIndex) => {
-                    const channelKey = makeChannelKey(item);
-                    const rowSpan = Math.max(visibleMetrics.length, 1);
-                    const dateMap = new Map(item.daily.map((entry) => [entry.date, entry]));
-
-                    if (!visibleMetrics.length) {
-                      return null;
-                    }
-
-                    const isSelected = selectedChannelKey === channelKey;
-
-                    return visibleMetrics.map((metric, metricIndex) => {
-                      const isFirstMetricRow = metricIndex === 0;
-
-                      return (
-                        <tr
-                          key={`${channelKey}-${metric.key}`}
-                          className={`psi-table-row${isSelected ? " selected" : ""}`}
-                          onClick={() => onRowSelection(channelKey)}
-                          tabIndex={isFirstMetricRow ? 0 : -1}
-                          ref={
-                            isFirstMetricRow
-                              ? (element) => {
-                                  rowGroupRefs.current[channelIndex] = element ?? null;
-                                }
-                              : undefined
-                          }
-                          onKeyDown={
-                            isFirstMetricRow
-                              ? (event) => onRowKeyDown(event, channelIndex, channelKey)
-                              : undefined
-                          }
-                          aria-selected={isSelected}
-                        >
-                          {isFirstMetricRow && (
-                            <>
-                              <td className={`sticky-col col-sku${isSelected ? " selected" : ""}`} rowSpan={rowSpan}>
-                                {item.sku_code}
-                              </td>
-                              <td
-                                className={`sticky-col col-sku-name${isSelected ? " selected" : ""}`}
-                                rowSpan={rowSpan}
-                              >
-                                {item.sku_name ?? "—"}
-                              </td>
-                              <td
-                                className={`sticky-col col-warehouse${isSelected ? " selected" : ""}`}
-                                rowSpan={rowSpan}
-                              >
-                                {item.warehouse_name}
-                              </td>
-                              <td
-                                className={`sticky-col col-channel${isSelected ? " selected" : ""}`}
-                                rowSpan={rowSpan}
-                              >
-                                {item.channel}
-                              </td>
-                            </>
-                          )}
-                          <td className={`sticky-col col-div psi-metric-name${isSelected ? " selected" : ""}`}>
-                            {metric.label}
-                          </td>
-                          {allDates.map((date) => {
-                            const entry = dateMap.get(date);
-                            const cellKey = `${channelKey}-${metric.key}-${date}`;
-                            const todayClass = date === todayIso ? " today-column" : "";
-
-                            if (!entry) {
-                              return (
-                                <td key={cellKey} className={`numeric${todayClass}`}>
-                                  —
-                                </td>
-                              );
-                            }
-
-                            const value = entry[metric.key];
-
-                            if (isEditableMetric(metric)) {
-                              const baselineEntry = baselineMap.get(makeCellKey(channelKey, date));
-                              const baselineValue = baselineEntry ? baselineEntry[metric.key] ?? null : null;
-                              const currentValue = value ?? null;
-                              const isEdited = !valuesEqual(currentValue, baselineValue);
-
-                              return (
-                                <td key={cellKey} className={`numeric${todayClass}`}>
-                                  <input
-                                    type="text"
-                                    className={`psi-edit-input${isEdited ? " edited" : ""}`}
-                                    value={currentValue ?? ""}
-                                    onChange={(event) =>
-                                      onEditableChange(channelKey, date, metric.key, event.target.value)
-                                    }
-                                    inputMode="decimal"
-                                    onPaste={(event) => {
-                                      event.preventDefault();
-                                      onPasteValues(channelKey, date, metric.key, event.clipboardData.getData("text"));
-                                    }}
-                                  />
-                                </td>
-                              );
-                            }
-
-                            return (
-                              <td key={cellKey} className={`numeric${todayClass}`}>
-                                {formatNumber(value)}
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      );
-                    });
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <PSITableSplit
+              tableData={tableData}
+              baselineMap={baselineMap}
+              visibleMetrics={visibleMetrics}
+              metricDefinitions={metricDefinitions}
+              visibleMetricKeys={visibleMetricKeys}
+              isMetricSelectorOpen={isMetricSelectorOpen}
+              onMetricSelectorToggle={onMetricSelectorToggle}
+              onMetricVisibilityChange={onMetricVisibilityChange}
+              metricSelectorRef={metricSelectorRef}
+              allDates={allDates}
+              todayIso={todayIso}
+              formatDisplayDate={formatDisplayDate}
+              onEditableChange={onEditableChange}
+              onPasteValues={onPasteValues}
+              formatNumber={formatNumber}
+              makeChannelKey={makeChannelKey}
+              makeCellKey={makeCellKey}
+              valuesEqual={valuesEqual}
+              selectedChannelKey={selectedChannelKey}
+              setSelectedChannelKey={setSelectedChannelKey}
+              rowGroupRefs={rowGroupRefs}
+              onRowKeyDown={onRowKeyDown}
+              tableRef={tableRef}
+              tableScrollContainerRef={tableScrollContainerRef}
+              headerRightScrollRef={topScrollContainerRef}
+            />
           </div>
         </div>
       ) : (

--- a/frontend/src/components/PSITableSplit.tsx
+++ b/frontend/src/components/PSITableSplit.tsx
@@ -1,0 +1,401 @@
+import { MutableRefObject, useEffect, useMemo, useRef } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+import {
+  EditableField,
+  MetricDefinition,
+  MetricKey,
+  PSIEditableChannel,
+  PSIEditableDay,
+  isEditableMetric,
+} from "../pages/psiTableTypes";
+
+interface PSITableSplitProps {
+  tableData: PSIEditableChannel[];
+  baselineMap: Map<string, PSIEditableDay>;
+  visibleMetrics: MetricDefinition[];
+  metricDefinitions: MetricDefinition[];
+  visibleMetricKeys: MetricKey[];
+  isMetricSelectorOpen: boolean;
+  onMetricSelectorToggle: () => void;
+  onMetricVisibilityChange: (metricKey: MetricKey) => void;
+  metricSelectorRef: MutableRefObject<HTMLDivElement | null>;
+  allDates: string[];
+  todayIso: string;
+  formatDisplayDate: (iso: string) => string;
+  onEditableChange: (channelKey: string, date: string, field: EditableField, rawValue: string) => void;
+  onPasteValues: (
+    channelKey: string,
+    date: string,
+    field: EditableField,
+    clipboardText: string
+  ) => void;
+  formatNumber: (value?: number | null) => string;
+  makeChannelKey: (channel: { sku_code: string; warehouse_name: string; channel: string }) => string;
+  makeCellKey: (channelKey: string, date: string) => string;
+  valuesEqual: (a: number | null | undefined, b: number | null | undefined) => boolean;
+  selectedChannelKey: string | null;
+  setSelectedChannelKey: (key: string | null) => void;
+  rowGroupRefs: MutableRefObject<(HTMLTableRowElement | null)[]>;
+  onRowKeyDown: (
+    event: ReactKeyboardEvent<HTMLTableRowElement>,
+    index: number,
+    channelKey: string
+  ) => void;
+  tableRef: MutableRefObject<HTMLTableElement | null>;
+  tableScrollContainerRef: MutableRefObject<HTMLDivElement | null>;
+  headerRightScrollRef: MutableRefObject<HTMLDivElement | null>;
+}
+
+interface TableRowDefinition {
+  channel: PSIEditableChannel;
+  channelIndex: number;
+  channelKey: string;
+  metric: MetricDefinition;
+  metricIndex: number;
+  rowSpan: number;
+  dateMap: Map<string, PSIEditableDay>;
+}
+
+const PSITableSplit = ({
+  tableData,
+  baselineMap,
+  visibleMetrics,
+  metricDefinitions,
+  visibleMetricKeys,
+  isMetricSelectorOpen,
+  onMetricSelectorToggle,
+  onMetricVisibilityChange,
+  metricSelectorRef,
+  allDates,
+  todayIso,
+  formatDisplayDate,
+  onEditableChange,
+  onPasteValues,
+  formatNumber,
+  makeChannelKey,
+  makeCellKey,
+  valuesEqual,
+  selectedChannelKey,
+  setSelectedChannelKey,
+  rowGroupRefs,
+  onRowKeyDown,
+  tableRef,
+  tableScrollContainerRef,
+  headerRightScrollRef,
+}: PSITableSplitProps) => {
+  const leftPaneRef = useRef<HTMLDivElement | null>(null);
+  const rightPaneRef = useRef<HTMLDivElement | null>(null);
+  const headerRightInnerRef = useRef<HTMLDivElement | null>(null);
+  const syncingRef = useRef(false);
+
+  useEffect(() => {
+    tableScrollContainerRef.current = rightPaneRef.current;
+    return () => {
+      if (tableScrollContainerRef.current === rightPaneRef.current) {
+        tableScrollContainerRef.current = null;
+      }
+    };
+  }, [tableScrollContainerRef]);
+
+  useEffect(() => {
+    headerRightScrollRef.current = headerRightInnerRef.current;
+    return () => {
+      if (headerRightScrollRef.current === headerRightInnerRef.current) {
+        headerRightScrollRef.current = null;
+      }
+    };
+  }, [headerRightScrollRef]);
+
+  const rows = useMemo<TableRowDefinition[]>(() => {
+    if (!visibleMetrics.length) {
+      return [];
+    }
+
+    return tableData.flatMap((channel, channelIndex) => {
+      const channelKey = makeChannelKey(channel);
+      const rowSpan = visibleMetrics.length;
+      const dateMap = new Map(channel.daily.map((entry) => [entry.date, entry]));
+
+      return visibleMetrics.map((metric, metricIndex) => ({
+        channel,
+        channelIndex,
+        channelKey,
+        metric,
+        metricIndex,
+        rowSpan,
+        dateMap,
+      }));
+    });
+  }, [makeChannelKey, tableData, visibleMetrics]);
+
+  const handleLeftScroll = () => {
+    const left = leftPaneRef.current;
+    const right = rightPaneRef.current;
+    if (!left || !right) {
+      return;
+    }
+    if (syncingRef.current) {
+      return;
+    }
+    syncingRef.current = true;
+    right.scrollTop = left.scrollTop;
+    window.requestAnimationFrame(() => {
+      syncingRef.current = false;
+    });
+  };
+
+  const handleRightScroll = () => {
+    const left = leftPaneRef.current;
+    const right = rightPaneRef.current;
+    const headerRight = headerRightInnerRef.current;
+    if (!right) {
+      return;
+    }
+    if (syncingRef.current) {
+      return;
+    }
+    syncingRef.current = true;
+    if (left) {
+      left.scrollTop = right.scrollTop;
+    }
+    if (headerRight) {
+      headerRight.scrollLeft = right.scrollLeft;
+    }
+    window.requestAnimationFrame(() => {
+      syncingRef.current = false;
+    });
+  };
+
+  const handleHeaderScroll = () => {
+    const right = rightPaneRef.current;
+    const headerRight = headerRightInnerRef.current;
+    if (!right || !headerRight) {
+      return;
+    }
+    if (syncingRef.current) {
+      return;
+    }
+    syncingRef.current = true;
+    right.scrollLeft = headerRight.scrollLeft;
+    window.requestAnimationFrame(() => {
+      syncingRef.current = false;
+    });
+  };
+
+  const renderMetricSelector = () => (
+    <div className="metric-header" ref={metricSelectorRef}>
+      <button
+        type="button"
+        className="metric-toggle"
+        onClick={onMetricSelectorToggle}
+        aria-expanded={isMetricSelectorOpen}
+      >
+        div
+      </button>
+      {isMetricSelectorOpen && (
+        <div className="metric-selector">
+          <p className="metric-selector-title">表示する指標</p>
+          <div className="metric-selector-options">
+            {metricDefinitions.map((metric) => {
+              const key = metric.key as MetricKey;
+              const checked = visibleMetricKeys.includes(key);
+              const disabled = checked && visibleMetricKeys.length === 1;
+              return (
+                <label key={metric.key}>
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={disabled}
+                    onChange={() => onMetricVisibilityChange(key)}
+                  />
+                  {metric.label}
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="psi-grid">
+      <div className="psi-header">
+        <div className="psi-header-row">
+          <div className="psi-header-left">
+            <table className="psi-table">
+              <thead>
+                <tr>
+                  <th className="col-sku">sku_code</th>
+                  <th className="col-sku-name">sku_name</th>
+                  <th className="col-warehouse">warehouse_name</th>
+                  <th className="col-channel">channel</th>
+                  <th className="col-div">{renderMetricSelector()}</th>
+                </tr>
+              </thead>
+            </table>
+          </div>
+          <div className="psi-header-right">
+            <div
+              className="psi-header-right-scroll"
+              ref={headerRightInnerRef}
+              onScroll={handleHeaderScroll}
+              role="presentation"
+            >
+              <table className="psi-table" ref={tableRef}>
+                <thead>
+                  <tr>
+                    {allDates.map((date) => (
+                      <th
+                        key={date}
+                        className={`date-header${date === todayIso ? " today-column" : ""}`}
+                        data-date={date}
+                      >
+                        {formatDisplayDate(date)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="psi-body">
+        <div className="psi-left-pane" ref={leftPaneRef} onScroll={handleLeftScroll}>
+          <table className="psi-table">
+            <tbody>
+              {rows.map(({
+                channel,
+                channelIndex,
+                channelKey,
+                metric,
+                metricIndex,
+                rowSpan,
+              }) => {
+                const isFirstMetricRow = metricIndex === 0;
+                const isSelected = selectedChannelKey === channelKey;
+
+                return (
+                  <tr
+                    key={`left-${channelKey}-${metric.key}`}
+                    className={`psi-table-row${isSelected ? " selected" : ""}`}
+                    onClick={() => setSelectedChannelKey(channelKey)}
+                    tabIndex={isFirstMetricRow ? 0 : -1}
+                    ref={
+                      isFirstMetricRow
+                        ? (element) => {
+                            rowGroupRefs.current[channelIndex] = element ?? null;
+                          }
+                        : undefined
+                    }
+                    onKeyDown={
+                      isFirstMetricRow
+                        ? (event) => onRowKeyDown(event, channelIndex, channelKey)
+                        : undefined
+                    }
+                    aria-selected={isSelected}
+                  >
+                    {isFirstMetricRow && (
+                      <>
+                        <td className={`col-sku${isSelected ? " selected" : ""}`} rowSpan={rowSpan}>
+                          {channel.sku_code}
+                        </td>
+                        <td className={`col-sku-name${isSelected ? " selected" : ""}`} rowSpan={rowSpan}>
+                          {channel.sku_name ?? "—"}
+                        </td>
+                        <td className={`col-warehouse${isSelected ? " selected" : ""}`} rowSpan={rowSpan}>
+                          {channel.warehouse_name}
+                        </td>
+                        <td className={`col-channel${isSelected ? " selected" : ""}`} rowSpan={rowSpan}>
+                          {channel.channel}
+                        </td>
+                      </>
+                    )}
+                    <td className={`col-div psi-metric-name${isSelected ? " selected" : ""}`}>
+                      {metric.label}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div className="psi-right-pane" ref={rightPaneRef} onScroll={handleRightScroll}>
+          <table className="psi-table">
+            <tbody>
+              {rows.map(({ channelKey, metric, dateMap }) => {
+                const isSelected = selectedChannelKey === channelKey;
+
+                return (
+                  <tr
+                    key={`right-${channelKey}-${metric.key}`}
+                    className={`psi-table-row${isSelected ? " selected" : ""}`}
+                    onClick={() => setSelectedChannelKey(channelKey)}
+                    tabIndex={-1}
+                    aria-selected={isSelected}
+                  >
+                    {allDates.map((date) => {
+                      const entry = dateMap.get(date);
+                      const cellKey = `${channelKey}-${metric.key}-${date}`;
+                      const todayClass = date === todayIso ? " today-column" : "";
+
+                      if (!entry) {
+                        return (
+                          <td key={cellKey} className={`numeric${todayClass}`}>
+                            —
+                          </td>
+                        );
+                      }
+
+                      const value = entry[metric.key];
+
+                      if (isEditableMetric(metric)) {
+                        const baselineEntry = baselineMap.get(makeCellKey(channelKey, date));
+                        const baselineValue = baselineEntry ? baselineEntry[metric.key] ?? null : null;
+                        const currentValue = value ?? null;
+                        const isEdited = !valuesEqual(currentValue, baselineValue);
+
+                        return (
+                          <td key={cellKey} className={`numeric${todayClass}`}>
+                            <input
+                              type="text"
+                              className={`psi-edit-input${isEdited ? " edited" : ""}`}
+                              value={currentValue ?? ""}
+                              onChange={(event) =>
+                                onEditableChange(channelKey, date, metric.key, event.target.value)
+                              }
+                              inputMode="decimal"
+                              onPaste={(event) => {
+                                event.preventDefault();
+                                onPasteValues(
+                                  channelKey,
+                                  date,
+                                  metric.key,
+                                  event.clipboardData.getData("text")
+                                );
+                              }}
+                            />
+                          </td>
+                        );
+                      }
+
+                      return (
+                        <td key={cellKey} className={`numeric${todayClass}`}>
+                          {formatNumber(value)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PSITableSplit;

--- a/frontend/src/styles/psi-sticky.css
+++ b/frontend/src/styles/psi-sticky.css
@@ -1,0 +1,79 @@
+.psi-grid {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+}
+
+.psi-header {
+  position: sticky;
+  top: var(--psi-table-header-offset, 0px);
+  z-index: 50;
+  background: var(--surface-panel, #111827);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.psi-body {
+  display: grid;
+  grid-template-columns: var(--psi-left-width, 520px) 1fr;
+  min-height: 0;
+}
+
+.psi-left-pane {
+  overflow-y: auto;
+  overflow-x: hidden;
+  border-right: 1px solid var(--border-default);
+}
+
+.psi-right-pane {
+  overflow: auto;
+}
+
+.psi-table {
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+}
+
+.psi-table th,
+.psi-table td {
+  padding: 8px 10px;
+  vertical-align: middle;
+}
+
+.psi-table td.numeric {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.psi-edit-input {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.psi-left-pane td,
+.psi-left-pane th {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.psi-header-row {
+  display: grid;
+  grid-template-columns: var(--psi-left-width, 520px) 1fr;
+  align-items: stretch;
+}
+
+.psi-header-left {
+  overflow: hidden;
+}
+
+.psi-header-right {
+  overflow: hidden;
+}
+
+.psi-header-right-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+}


### PR DESCRIPTION
## Summary
- add a new `PSITableSplit` component that renders the PSI table using coordinated left and right panes with independent header sections and scroll synchronization
- update `PSITableContent` and `PSITablePage` to use the split layout, remove the old sticky column handling, and keep selection/keyboard behaviour intact
- introduce layout CSS for the two-pane grid and define a shared left-pane width variable that keeps headers and body aligned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4921952c832ea8537189aac3c3a5