### PR TITLE
Add SKU summary table for PSI view

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -304,6 +304,81 @@ button.collapse-toggle:focus-visible {
   font-weight: 600;
 }
 
+.psi-summary-card {
+  grid-column: 1 / -1;
+  margin-top: 12px;
+  background: var(--surface-panel);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.psi-summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.psi-pager {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.psi-pager button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.psi-summary-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.psi-summary-table th,
+.psi-summary-table td {
+  padding: 6px 10px;
+}
+
+.psi-summary-table .numeric {
+  text-align: right;
+}
+
+.psi-summary-row {
+  cursor: pointer;
+}
+
+.psi-summary-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.psi-summary-row.is-selected {
+  outline: 2px solid var(--brand, #3b82f6);
+  outline-offset: -2px;
+}
+
+.psi-summary-sku {
+  text-align: left;
+}
+
+.psi-summary-sku-code {
+  font-weight: 600;
+}
+
+.psi-summary-sku-name {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.psi-summary-empty {
+  margin: 0;
+  color: var(--text-muted);
+}
+
 .psi-description-panel label {
   display: grid;
   gap: 0.5rem;

--- a/frontend/src/components/PSISummaryTable.tsx
+++ b/frontend/src/components/PSISummaryTable.tsx
@@ -1,0 +1,133 @@
+import { memo, useMemo } from "react";
+
+import { ChannelAgg, SummaryRow } from "../utils/psiSummary";
+
+type Props = {
+  rows: SummaryRow[];
+  onSelectSku: (sku: string | null) => void;
+  selectedSku?: string | null;
+  channelOrder?: string[];
+};
+
+const numberFormatter = new Intl.NumberFormat("ja-JP", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const formatValue = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  return numberFormatter.format(value);
+};
+
+const metricLabels: { key: keyof ChannelAgg; label: string }[] = [
+  { key: "inbound_sum", label: "Inbound" },
+  { key: "outbound_sum", label: "Outbound" },
+  { key: "last_closing", label: "Stock Closing" },
+];
+
+const PSISummaryTable = memo(function PSISummaryTable({
+  rows,
+  onSelectSku,
+  selectedSku,
+  channelOrder,
+}: Props) {
+  const orderedChannels = useMemo(() => {
+    const unique = new Set<string>();
+    rows.forEach((row) => {
+      Object.keys(row.channels).forEach((channel) => {
+        unique.add(channel);
+      });
+    });
+
+    const channels = Array.from(unique);
+
+    if (!channelOrder || !channelOrder.length) {
+      return channels.sort((a, b) => a.localeCompare(b));
+    }
+
+    const priority = new Map(channelOrder.map((channel, index) => [channel, index] as const));
+
+    return channels.sort((a, b) => {
+      const aPriority = priority.has(a) ? priority.get(a)! : Number.POSITIVE_INFINITY;
+      const bPriority = priority.has(b) ? priority.get(b)! : Number.POSITIVE_INFINITY;
+      if (aPriority !== bPriority) {
+        return aPriority - bPriority;
+      }
+      return a.localeCompare(b);
+    });
+  }, [rows, channelOrder]);
+
+  if (!rows.length) {
+    return null;
+  }
+
+  return (
+    <table className="psi-summary-table">
+      <thead>
+        <tr>
+          <th scope="col">SKU</th>
+          <th scope="col">Metric</th>
+          {orderedChannels.map((channel) => (
+            <th key={channel} scope="col" className="numeric">
+              {channel}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const isSelected = row.sku_code === selectedSku;
+          const handleSelect = () => {
+            onSelectSku(isSelected ? null : row.sku_code);
+          };
+
+          return metricLabels.map((metric, index) => {
+            const labelCell = (
+              <th scope="row" key={`${row.sku_code}-${metric.key}-label`}>
+                {metric.label}
+              </th>
+            );
+
+            return (
+              <tr
+                key={`${row.sku_code}-${metric.key}`}
+                className={`psi-summary-row${isSelected ? " is-selected" : ""}`}
+                onClick={handleSelect}
+                role="button"
+                tabIndex={index === 0 ? 0 : -1}
+                aria-pressed={isSelected}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleSelect();
+                  }
+                }}
+              >
+                {index === 0 && (
+                  <th scope="rowgroup" rowSpan={metricLabels.length} className="psi-summary-sku">
+                    <div className="psi-summary-sku-code">{row.sku_code}</div>
+                    {row.sku_name && <div className="psi-summary-sku-name">{row.sku_name}</div>}
+                  </th>
+                )}
+                {labelCell}
+                {orderedChannels.map((channel) => {
+                  const channelAgg = row.channels[channel];
+                  const value = channelAgg ? channelAgg[metric.key] : null;
+                  return (
+                    <td key={`${row.sku_code}-${metric.key}-${channel}`} className="numeric">
+                      {formatValue(value)}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          });
+        })}
+      </tbody>
+    </table>
+  );
+});
+
+export default PSISummaryTable;

--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -11,6 +11,8 @@ interface PSITableContentProps {
   isError: boolean;
   errorMessage: string | null;
   tableData: PSIEditableChannel[];
+  hasAnyData: boolean;
+  selectedSku: string | null;
   visibleMetrics: MetricDefinition[];
   metricDefinitions: MetricDefinition[];
   visibleMetricKeys: MetricKey[];
@@ -49,6 +51,8 @@ const PSITableContent = ({
   isError,
   errorMessage,
   tableData,
+  hasAnyData,
+  selectedSku,
   visibleMetrics,
   metricDefinitions,
   visibleMetricKeys,
@@ -80,11 +84,15 @@ const PSITableContent = ({
   rowGroupRefs,
   onRowKeyDown,
 }: PSITableContentProps) => {
+  const hasTableRows = tableData.length > 0;
+  const showSelectionPlaceholder = !selectedSku && hasAnyData;
+  const showNoDataMessage = !hasAnyData && sessionId && !isLoading;
+
   return (
     <section className="psi-table-section">
       {isLoading && sessionId && <p className="psi-table-status">Loading PSI data...</p>}
       {isError && <p className="psi-table-status error">{errorMessage}</p>}
-      {tableData.length > 0 ? (
+      {hasTableRows ? (
         <div className="psi-table-wrapper">
           <div className="psi-table-toolbar">
             <div className="psi-table-toolbar-group">
@@ -147,8 +155,10 @@ const PSITableContent = ({
             />
           </div>
         </div>
+      ) : showSelectionPlaceholder ? (
+        <p className="psi-table-status">上段の集計からSKUを選択してください。</p>
       ) : (
-        sessionId && !isLoading && <p className="psi-table-status">No PSI data for the current filters.</p>
+        showNoDataMessage && <p className="psi-table-status">No PSI data for the current filters.</p>
       )}
     </section>
   );

--- a/frontend/src/utils/psiSummary.ts
+++ b/frontend/src/utils/psiSummary.ts
@@ -1,0 +1,71 @@
+import { PSIChannel } from "../types";
+
+export type ChannelAgg = {
+  inbound_sum: number;
+  outbound_sum: number;
+  last_closing: number | null;
+};
+
+export type SummaryRow = {
+  sku_code: string;
+  sku_name?: string;
+  channels: Record<string, ChannelAgg>;
+};
+
+const parseDate = (value: string) => new Date(`${value}T00:00:00Z`).getTime();
+
+export function buildSummary(psi: PSIChannel[], start?: string | null, end?: string | null): SummaryRow[] {
+  if (!psi.length) {
+    return [];
+  }
+
+  const startTime = start ? parseDate(start) : null;
+  const endTime = end ? parseDate(end) : null;
+  const rows = new Map<string, SummaryRow>();
+  const channelDates = new Map<string, string | null>();
+
+  psi.forEach((channel) => {
+    const existing = rows.get(channel.sku_code);
+    const summary: SummaryRow = existing ?? {
+      sku_code: channel.sku_code,
+      sku_name: channel.sku_name ?? undefined,
+      channels: {},
+    };
+
+    if (!summary.sku_name && channel.sku_name) {
+      summary.sku_name = channel.sku_name;
+    }
+
+    const stateKeyPrefix = `${channel.sku_code}::${channel.channel}`;
+    const current = summary.channels[channel.channel] ?? {
+      inbound_sum: 0,
+      outbound_sum: 0,
+      last_closing: null,
+    };
+
+    channel.daily.forEach((entry) => {
+      const entryTime = parseDate(entry.date);
+      if (startTime !== null && entryTime < startTime) {
+        return;
+      }
+      if (endTime !== null && entryTime > endTime) {
+        return;
+      }
+
+      current.inbound_sum += entry.inbound_qty ?? 0;
+      current.outbound_sum += entry.outbound_qty ?? 0;
+
+      const lastDateKey = `${stateKeyPrefix}::date`;
+      const previousDate = channelDates.get(lastDateKey);
+      if (!previousDate || entry.date >= previousDate) {
+        channelDates.set(lastDateKey, entry.date);
+        current.last_closing = entry.stock_closing ?? null;
+      }
+    });
+
+    summary.channels[channel.channel] = current;
+    rows.set(channel.sku_code, summary);
+  });
+
+  return Array.from(rows.values());
+}


### PR DESCRIPTION
## Summary
- add a `buildSummary` helper and memoized `PSISummaryTable` component to aggregate PSI data by SKU and channel
- embed a paginated summary card into the PSI controls and wire selection to filter the detailed table view
- adjust the detailed PSI table to show a selection placeholder and add styling for the new summary block

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4e57444c832e97b2a7cc572b3d46