### PR TITLE
Refactor PSI controls layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -229,7 +229,7 @@ body {
 
 .psi-controls-header h2 {
   margin: 0;
-  font-size: 1.125rem;
+  font-size: 1rem;
 }
 
 button.collapse-toggle {
@@ -249,40 +249,30 @@ button.collapse-toggle:focus-visible {
 
 .psi-controls-body {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr);
-  grid-template-areas: "filters description summary";
-  gap: 1.25rem;
+  grid-template-columns: 1fr 2fr;
+  gap: 16px;
   align-items: start;
 }
 
-.psi-filter-panel {
-  grid-area: filters;
+.psi-left-pane {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
 }
 
-.psi-description-panel {
-  grid-area: description;
+.psi-left-pane .row-full {
+  grid-column: 1 / -1;
 }
 
-.psi-summary-card {
-  grid-area: summary;
+.psi-right-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-@media (max-width: 1280px) {
-  .psi-controls-body {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-areas:
-      "filters summary"
-      "description description";
-  }
-}
-
-@media (max-width: 960px) {
+@media (max-width: 1100px) {
   .psi-controls-body {
     grid-template-columns: 1fr;
-    grid-template-areas:
-      "filters"
-      "description"
-      "summary";
   }
 }
 
@@ -322,7 +312,12 @@ button.collapse-toggle:focus-visible {
 
 .psi-filter-grid {
   display: grid;
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.psi-filter-grid .row-full {
+  grid-column: 1 / -1;
 }
 
 .psi-filter-grid label {

--- a/frontend/src/components/PSITableControls.tsx
+++ b/frontend/src/components/PSITableControls.tsx
@@ -134,140 +134,144 @@ const PSITableControls = forwardRef(function PSITableControls(
       </div>
       {!isCollapsed && (
         <div className="psi-controls-body">
-          <div className="psi-panel psi-filter-panel">
-            <h3>フィルタ</h3>
-            <div className="psi-filter-grid">
-              <label>
-                Session
-                <select
-                  value={sessionId}
-                  onChange={(event) => onSessionChange(event.target.value)}
-                  disabled={sessionsQuery.isLoading}
-                >
-                  <option value="" disabled>
-                    Select a session
-                  </option>
-                  {availableSessions.map((session) => (
-                    <option key={session.id} value={session.id}>
-                      {session.title}
+          <section className="psi-left-pane">
+            <div className="psi-panel psi-filter-panel row-full">
+              <h3>フィルタ</h3>
+              <div className="psi-filter-grid">
+                <label className="row-full">
+                  Session
+                  <select
+                    value={sessionId}
+                    onChange={(event) => onSessionChange(event.target.value)}
+                    disabled={sessionsQuery.isLoading}
+                  >
+                    <option value="" disabled>
+                      Select a session
                     </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                SKU Code
-                <input
-                  type="text"
-                  value={skuCode}
-                  onChange={(event) => onSkuCodeChange(event.target.value)}
-                  placeholder="Optional"
-                />
-              </label>
-              <label>
-                Warehouse
-                <input
-                  type="text"
-                  value={warehouseName}
-                  onChange={(event) => onWarehouseNameChange(event.target.value)}
-                  placeholder="Optional"
-                />
-              </label>
-              <label>
-                Channel
-                <input
-                  type="text"
-                  value={channel}
-                  onChange={(event) => onChannelChange(event.target.value)}
-                  placeholder="Optional"
-                />
-              </label>
-            </div>
-            {sessionsQuery.isLoading && <p>Loading sessions...</p>}
-            {sessionsQuery.isError && (
-              <p className="error">{getErrorMessage(sessionsQuery.error, "Unable to load sessions.")}</p>
-            )}
-          </div>
-          <div className="psi-panel psi-description-panel">
-            {sessionId ? (
-              <>
-                <div className="psi-description-dates">
-                  <div>
-                    <strong>開始日</strong>
-                    <span>{sessionSummaryQuery.isLoading ? "…" : formattedStart}</span>
-                  </div>
-                  <div>
-                    <strong>終了日</strong>
-                    <span>{sessionSummaryQuery.isLoading ? "…" : formattedEnd}</span>
-                  </div>
-                </div>
-                {sessionSummaryQuery.isError && (
-                  <p className="error">
-                    {getErrorMessage(sessionSummaryQuery.error, "Unable to load session date range.")}
-                  </p>
-                )}
-                <label>
-                  Description
-                  <textarea
-                    value={descriptionDraft}
-                    onChange={(event) => onDescriptionChange(event.target.value)}
-                    placeholder="Add a description for this session"
+                    {availableSessions.map((session) => (
+                      <option key={session.id} value={session.id}>
+                        {session.title}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="row-full">
+                  SKU Code
+                  <input
+                    type="text"
+                    value={skuCode}
+                    onChange={(event) => onSkuCodeChange(event.target.value)}
+                    placeholder="Optional"
                   />
                 </label>
-                <div className="session-summary-actions">
-                  <button
-                    type="button"
-                    className="psi-button secondary"
-                    onClick={onDescriptionSave}
-                    disabled={!isDescriptionDirty || isSavingDescription}
-                    aria-label={isSavingDescription ? "説明を保存中" : "説明を保存"}
-                  >
-                    <img src={iconUrls.save} alt="" aria-hidden="true" className="psi-button-icon" />
-                    <span>{isSavingDescription ? "保存中…" : "保存"}</span>
-                  </button>
-                  {descriptionError && <span className="error">{descriptionError}</span>}
-                  {descriptionSaved && <span className="success">Description updated.</span>}
-                </div>
-                <div className="psi-session-meta">
-                  <div>
-                    <strong>作成日</strong>
-                    <span>{formattedCreatedAt}</span>
-                  </div>
-                  <div>
-                    <strong>更新日</strong>
-                    <span>{formattedUpdatedAt}</span>
-                  </div>
-                </div>
-              </>
-            ) : (
-              <p>Select a session to view its details.</p>
-            )}
-          </div>
-          <div className="psi-summary-card">
-            <div className="psi-summary-header">
-              <h3>集計（3 SKU / ページ）</h3>
-              <div className="psi-pager">
-                <button type="button" onClick={goPrev} disabled={page <= 1 || sorted.length === 0}>
-                  ‹ 前へ
-                </button>
-                <span>
-                  {sorted.length === 0 ? "0 / 0" : `${page} / ${totalPages}`}
-                </span>
-                <button type="button" onClick={goNext} disabled={page >= totalPages || sorted.length === 0}>
-                  次へ ›
-                </button>
+                <label>
+                  Warehouse
+                  <input
+                    type="text"
+                    value={warehouseName}
+                    onChange={(event) => onWarehouseNameChange(event.target.value)}
+                    placeholder="Optional"
+                  />
+                </label>
+                <label>
+                  Channel
+                  <input
+                    type="text"
+                    value={channel}
+                    onChange={(event) => onChannelChange(event.target.value)}
+                    placeholder="Optional"
+                  />
+                </label>
               </div>
+              {sessionsQuery.isLoading && <p className="row-full">Loading sessions...</p>}
+              {sessionsQuery.isError && (
+                <p className="error row-full">{getErrorMessage(sessionsQuery.error, "Unable to load sessions.")}</p>
+              )}
             </div>
-            {sorted.length > 0 ? (
-              <PSISummaryTable
-                rows={pageRows}
-                onSelectSku={onSelectSku}
-                selectedSku={selectedSku}
-                channelOrder={["online", "retail", "wholesale"]}
-              />
-            ) : (
-              <p className="psi-summary-empty">該当する集計データがありません。</p>
-            )}
-          </div>
+            <div className="psi-panel psi-description-panel row-full">
+              {sessionId ? (
+                <>
+                  <div className="psi-description-dates">
+                    <div>
+                      <strong>開始日</strong>
+                      <span>{sessionSummaryQuery.isLoading ? "…" : formattedStart}</span>
+                    </div>
+                    <div>
+                      <strong>終了日</strong>
+                      <span>{sessionSummaryQuery.isLoading ? "…" : formattedEnd}</span>
+                    </div>
+                  </div>
+                  {sessionSummaryQuery.isError && (
+                    <p className="error">
+                      {getErrorMessage(sessionSummaryQuery.error, "Unable to load session date range.")}
+                    </p>
+                  )}
+                  <label className="row-full">
+                    Description
+                    <textarea
+                      value={descriptionDraft}
+                      onChange={(event) => onDescriptionChange(event.target.value)}
+                      placeholder="Add a description for this session"
+                    />
+                  </label>
+                  <div className="session-summary-actions">
+                    <button
+                      type="button"
+                      className="psi-button secondary"
+                      onClick={onDescriptionSave}
+                      disabled={!isDescriptionDirty || isSavingDescription}
+                      aria-label={isSavingDescription ? "説明を保存中" : "説明を保存"}
+                    >
+                      <img src={iconUrls.save} alt="" aria-hidden="true" className="psi-button-icon" />
+                      <span>{isSavingDescription ? "保存中…" : "保存"}</span>
+                    </button>
+                    {descriptionError && <span className="error">{descriptionError}</span>}
+                    {descriptionSaved && <span className="success">Description updated.</span>}
+                  </div>
+                  <div className="psi-session-meta">
+                    <div>
+                      <strong>作成日</strong>
+                      <span>{formattedCreatedAt}</span>
+                    </div>
+                    <div>
+                      <strong>更新日</strong>
+                      <span>{formattedUpdatedAt}</span>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <p>Select a session to view its details.</p>
+              )}
+            </div>
+          </section>
+          <aside className="psi-right-pane">
+            <div className="psi-summary-card">
+              <div className="psi-summary-header">
+                <h3>集計（3 SKU / ページ）</h3>
+                <div className="psi-pager">
+                  <button type="button" onClick={goPrev} disabled={page <= 1 || sorted.length === 0}>
+                    ‹ 前へ
+                  </button>
+                  <span>
+                    {sorted.length === 0 ? "0 / 0" : `${page} / ${totalPages}`}
+                  </span>
+                  <button type="button" onClick={goNext} disabled={page >= totalPages || sorted.length === 0}>
+                    次へ ›
+                  </button>
+                </div>
+              </div>
+              {sorted.length > 0 ? (
+                <PSISummaryTable
+                  rows={pageRows}
+                  onSelectSku={onSelectSku}
+                  selectedSku={selectedSku}
+                  channelOrder={["online", "retail", "wholesale"]}
+                />
+              ) : (
+                <p className="psi-summary-empty">該当する集計データがありません。</p>
+              )}
+            </div>
+          </aside>
         </div>
       )}
       <div className="psi-toolbar" role="toolbar" aria-label="PSI data actions">


### PR DESCRIPTION
## Summary
- restructure the PSI controls body into dedicated left and right panes with the summary table isolated on the right
- align the filter inputs within a responsive two-column grid so Warehouse and Channel sit side-by-side and move the description block beneath them
- update supporting styles, including the Filters & Description heading size and responsive behavior at 1100px

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce58ea6664832e99c73fb07409586d