### PR TITLE
Replace PSI daily table with React Data Grid

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "5.62.9",
         "axios": "^1.12.2",
         "react": "18.3.1",
+        "react-data-grid": "file:vendor/react-data-grid",
         "react-dom": "18.3.1",
         "react-router-dom": "6.28.0"
       },
@@ -1767,6 +1768,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-data-grid": {
+      "resolved": "vendor/react-data-grid",
+      "link": true
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -2003,6 +2008,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "vendor/react-data-grid": {
+      "version": "0.0.0-local"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "axios": "^1.12.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.28.0"
+    "react-router-dom": "6.28.0",
+    "react-data-grid": "file:vendor/react-data-grid"
   },
   "devDependencies": {
     "@types/react": "18.3.7",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -987,6 +987,78 @@ button.icon-button:focus-visible {
   min-height: 0;
 }
 
+.psi-warehouse-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-block: 0.5rem 0;
+}
+
+.psi-warehouse-tab {
+  flex: 1 0 calc(25% - 0.5rem);
+  min-width: 140px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #c8d1dc;
+  border-radius: 20px;
+  background-color: #ffffff;
+  color: #1f2937;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.psi-warehouse-tab.active {
+  background-color: #1f7ae0;
+  color: #ffffff;
+  border-color: #1f7ae0;
+}
+
+.psi-warehouse-tab:hover:not(.active) {
+  background-color: #f3f8ff;
+}
+
+.psi-grid-container {
+  width: 100%;
+}
+
+.psi-data-grid {
+  width: 100%;
+  background-color: transparent;
+}
+
+.psi-grid-channel-cell,
+.psi-grid-metric-cell {
+  font-weight: 600;
+  background-color: #f9fbfd;
+  justify-content: flex-start;
+}
+
+.psi-grid-value-cell {
+  justify-content: flex-end;
+  font-variant-numeric: tabular-nums;
+}
+
+.psi-grid-cell-editable {
+  background-color: #fdfcff;
+}
+
+.psi-grid-cell-today {
+  background-color: #fff4ce;
+}
+
+.psi-grid-header-today {
+  background-color: #ffe8a1;
+}
+
+.psi-grid-editor {
+  width: 100%;
+  font: inherit;
+  padding: 4px 6px;
+  border: 1px solid #9da7b2;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
 .psi-table-toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
+import "./App.css";
+import "react-data-grid/lib/styles.css";
 
 const queryClient = new QueryClient();
 

--- a/frontend/src/pages/psiTableTypes.ts
+++ b/frontend/src/pages/psiTableTypes.ts
@@ -19,6 +19,17 @@ export interface PSIEditableChannel extends Omit<PSIChannel, "daily"> {
   daily: PSIEditableDay[];
 }
 
+export type PSIGridRow = {
+  id: string;
+  channelKey: string;
+  sku_code: string;
+  warehouse_name: string;
+  channel: string;
+  metric: string;
+  metricKey: MetricKey;
+  metricEditable: boolean;
+} & Record<string, number | null | string | boolean>;
+
 export interface MetricDefinitionBase {
   key: MetricKey;
   label: string;

--- a/frontend/vendor/react-data-grid/index.d.ts
+++ b/frontend/vendor/react-data-grid/index.d.ts
@@ -1,0 +1,58 @@
+import type { CSSProperties, MouseEvent } from "react";
+
+export interface Column<RowType> {
+  key: string;
+  name: string;
+  width?: number;
+  frozen?: boolean;
+  headerCellClass?: string;
+  className?: string | ((row: RowType) => string | undefined);
+  renderCell?: (props: RenderCellProps<RowType>) => React.ReactNode;
+  renderEditCell?: (props: RenderEditCellProps<RowType>) => React.ReactNode;
+  editorOptions?: {
+    editOnClick?: boolean;
+  };
+  setHeaderRef?: (element: HTMLDivElement | null) => void;
+}
+
+export interface RenderCellProps<RowType> {
+  row: RowType;
+  column: Column<RowType>;
+}
+
+export interface RenderEditCellProps<RowType> {
+  row: RowType;
+  column: Column<RowType>;
+  onRowChange: (row: RowType, commit?: boolean) => void;
+  onClose: (commit: boolean) => void;
+}
+
+export interface RowsChangeData<RowType> {
+  column: Column<RowType>;
+  indexes: number[];
+}
+
+export interface CellClickArgs<RowType> {
+  row: RowType;
+  column: Column<RowType>;
+  rowIdx: number;
+  columnIdx: number;
+  event: MouseEvent<HTMLDivElement>;
+}
+
+export interface DataGridProps<RowType> {
+  columns: readonly Column<RowType>[];
+  rows: readonly RowType[];
+  rowKeyGetter?: (row: RowType) => string | number;
+  onRowsChange?: (rows: RowType[], data: RowsChangeData<RowType>) => void;
+  onCellClick?: (args: CellClickArgs<RowType>) => void;
+  style?: CSSProperties;
+  className?: string;
+  defaultColumnOptions?: {
+    width?: number;
+  };
+  viewportRef?: React.Ref<HTMLDivElement>;
+}
+
+export default function DataGrid<RowType>(props: DataGridProps<RowType>): JSX.Element;
+export { DataGrid };

--- a/frontend/vendor/react-data-grid/index.jsx
+++ b/frontend/vendor/react-data-grid/index.jsx
@@ -1,0 +1,273 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+function clsx(...values) {
+  return values.filter(Boolean).join(" ");
+}
+
+function ensureRef(ref, value) {
+  if (typeof ref === "function") {
+    ref(value);
+    return () => ref(null);
+  }
+  if (ref && "current" in ref) {
+    ref.current = value;
+    return () => {
+      if (ref.current === value) {
+        ref.current = null;
+      }
+    };
+  }
+  return () => {};
+}
+
+function DataGrid({
+  columns,
+  rows,
+  rowKeyGetter,
+  onRowsChange,
+  onCellClick,
+  style,
+  className,
+  defaultColumnOptions,
+  viewportRef,
+}) {
+  const columnWidth = defaultColumnOptions?.width ?? 140;
+  const columnsWithWidth = useMemo(
+    () =>
+      columns.map((column) => ({
+        ...column,
+        width: column.width ?? columnWidth,
+      })),
+    [columns, columnWidth]
+  );
+
+  const templateColumns = useMemo(
+    () => columnsWithWidth.map((column) => `${column.width}px`).join(" "),
+    [columnsWithWidth]
+  );
+
+  const frozenOffsets = useMemo(() => {
+    let offset = 0;
+    return columnsWithWidth.map((column) => {
+      if (!column.frozen) {
+        return null;
+      }
+      const current = offset;
+      offset += column.width;
+      return current;
+    });
+  }, [columnsWithWidth]);
+
+  const [internalRows, setInternalRows] = useState(rows);
+  const [editing, setEditing] = useState(null);
+  const headerInnerRef = useRef(null);
+  const bodyRef = useRef(null);
+
+  useEffect(() => {
+    setInternalRows(rows);
+    setEditing(null);
+  }, [rows]);
+
+  useEffect(() => {
+    if (!viewportRef) {
+      return undefined;
+    }
+    return ensureRef(viewportRef, bodyRef.current);
+  }, [viewportRef]);
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    const headerInner = headerInnerRef.current;
+    if (!body || !headerInner) {
+      return undefined;
+    }
+
+    const handleScroll = () => {
+      headerInner.style.transform = `translateX(${-body.scrollLeft}px)`;
+    };
+
+    body.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      body.removeEventListener("scroll", handleScroll);
+    };
+  }, [templateColumns]);
+
+  const startEditing = (rowIdx, column, columnIdx) => {
+    if (!column.renderEditCell) {
+      return;
+    }
+    setEditing({
+      rowIdx,
+      columnKey: column.key,
+      column,
+      columnIdx,
+      draftRow: { ...internalRows[rowIdx] },
+    });
+  };
+
+  const commitRow = (updatedRow, column, rowIdx) => {
+    setInternalRows((previousRows) => {
+      const nextRows = previousRows.map((row, index) => (index === rowIdx ? updatedRow : row));
+      if (onRowsChange) {
+        onRowsChange(nextRows, { column, indexes: [rowIdx] });
+      }
+      return nextRows;
+    });
+    setEditing(null);
+  };
+
+  const handleRowChange = (updatedRow, commit = false) => {
+    setEditing((previous) => {
+      if (!previous) {
+        return previous;
+      }
+      const next = { ...previous, draftRow: updatedRow };
+      if (commit) {
+        commitRow(updatedRow, previous.column, previous.rowIdx);
+      }
+      return next;
+    });
+  };
+
+  const handleClose = (commit) => {
+    setEditing((previous) => {
+      if (!previous) {
+        return previous;
+      }
+      if (commit) {
+        commitRow(previous.draftRow, previous.column, previous.rowIdx);
+        return null;
+      }
+      return null;
+    });
+  };
+
+  const renderCellContent = (row, column, rowIdx, columnIdx) => {
+    const isEditing =
+      editing &&
+      editing.rowIdx === rowIdx &&
+      editing.columnKey === column.key &&
+      column.renderEditCell;
+
+    if (isEditing) {
+      return column.renderEditCell({
+        row: editing.draftRow,
+        column,
+        onRowChange: handleRowChange,
+        onClose: handleClose,
+      });
+    }
+
+    if (column.renderCell) {
+      return column.renderCell({ row, column });
+    }
+
+    const value = row[column.key];
+    return value == null ? "" : String(value);
+  };
+
+  const rowsToRender = internalRows;
+
+  return (
+    <div className={clsx("rdg", className)} style={style}>
+      <div className="rdg-header">
+        <div className="rdg-header-row" ref={headerInnerRef} style={{ gridTemplateColumns: templateColumns }}>
+          {columnsWithWidth.map((column, columnIdx) => {
+            const frozenOffset = frozenOffsets[columnIdx];
+            return (
+              <div
+                key={column.key}
+                data-column-key={column.key}
+                className={clsx("rdg-header-cell", column.headerCellClass)}
+                style={{
+                  width: column.width,
+                  minWidth: column.width,
+                  maxWidth: column.width,
+                  ...(column.frozen
+                    ? {
+                        position: "sticky",
+                        left: frozenOffset ?? 0,
+                        zIndex: 3,
+                      }
+                    : null),
+                }}
+                ref={column.setHeaderRef || null}
+              >
+                {column.name}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="rdg-body" ref={bodyRef}>
+        {rowsToRender.map((row, rowIdx) => {
+          const rowKey = rowKeyGetter ? rowKeyGetter(row) : rowIdx;
+          return (
+            <div key={rowKey} className="rdg-row" style={{ gridTemplateColumns: templateColumns }}>
+              {columnsWithWidth.map((column, columnIdx) => {
+                const frozenOffset = frozenOffsets[columnIdx];
+                const cellClass =
+                  typeof column.className === "function"
+                    ? column.className(row)
+                    : column.className;
+                const isEditable = Boolean(column.renderEditCell);
+                const editOnClick = Boolean(column.editorOptions?.editOnClick);
+
+                const handleClick = (event) => {
+                  if (onCellClick) {
+                    onCellClick({
+                      row,
+                      column,
+                      rowIdx,
+                      columnIdx,
+                      event,
+                    });
+                  }
+                  if (isEditable && editOnClick) {
+                    event.preventDefault();
+                    startEditing(rowIdx, column, columnIdx);
+                  }
+                };
+
+                const handleDoubleClick = () => {
+                  if (isEditable) {
+                    startEditing(rowIdx, column, columnIdx);
+                  }
+                };
+
+                return (
+                  <div
+                    key={column.key}
+                    data-column-key={column.key}
+                    className={clsx("rdg-cell", cellClass)}
+                    style={{
+                      width: column.width,
+                      minWidth: column.width,
+                      maxWidth: column.width,
+                      ...(column.frozen
+                        ? {
+                            position: "sticky",
+                            left: frozenOffset ?? 0,
+                            zIndex: 2,
+                          }
+                        : null),
+                    }}
+                    onClick={handleClick}
+                    onDoubleClick={handleDoubleClick}
+                  >
+                    {renderCellContent(row, column, rowIdx, columnIdx)}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default DataGrid;
+export { DataGrid };

--- a/frontend/vendor/react-data-grid/lib/styles.css
+++ b/frontend/vendor/react-data-grid/lib/styles.css
@@ -1,0 +1,73 @@
+.rdg {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  overflow: hidden;
+  background-color: #fff;
+  color: #24292f;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+}
+
+.rdg-header {
+  background-color: #f6f8fa;
+  border-bottom: 1px solid #d0d7de;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.rdg-header-row {
+  display: grid;
+}
+
+.rdg-header-cell {
+  padding: 8px 12px;
+  font-weight: 600;
+  border-right: 1px solid #d0d7de;
+  box-sizing: border-box;
+  background-color: inherit;
+}
+
+.rdg-body {
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+.rdg-row {
+  display: grid;
+  min-height: 36px;
+  border-bottom: 1px solid #ecf1f6;
+}
+
+.rdg-cell {
+  padding: 6px 10px;
+  border-right: 1px solid #ecf1f6;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  background-color: inherit;
+}
+
+.rdg-cell:last-child,
+.rdg-header-cell:last-child {
+  border-right: none;
+}
+
+.rdg-row:nth-child(even) .rdg-cell {
+  background-color: #fbfdff;
+}
+
+.rdg-row:hover .rdg-cell {
+  background-color: #f0f6ff;
+}
+
+.rdg-cell input {
+  width: 100%;
+  font: inherit;
+  padding: 4px 6px;
+  border: 1px solid #9da7b2;
+  border-radius: 4px;
+  box-sizing: border-box;
+}

--- a/frontend/vendor/react-data-grid/package.json
+++ b/frontend/vendor/react-data-grid/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-data-grid",
+  "version": "0.0.0-local",
+  "type": "module",
+  "exports": {
+    ".": "./index.jsx",
+    "./lib/styles.css": "./lib/styles.css"
+  },
+  "main": "./index.jsx",
+  "module": "./index.jsx",
+  "types": "./index.d.ts"
+}


### PR DESCRIPTION
## Summary
- replace the PSI table rendering with a React Data Grid implementation that supports editable cells and today highlighting
- add warehouse tabs and centralized apply handling backed by a local react-data-grid package
- update styling to support the new grid layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce5d2d8508832ebaac994513beef41