### PR TITLE
feat: dim duplicate fixed column values in PSI RDG

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1033,6 +1033,18 @@ button.icon-button:focus-visible {
   justify-content: flex-start;
 }
 
+.psi-grid-cell-duplicate {
+  color: #9da7b2;
+  transition: color 0.2s ease;
+}
+
+.psi-grid-cell-duplicate:hover,
+.psi-grid-cell-duplicate:focus,
+.psi-grid-cell-duplicate:focus-within,
+.rdg-row:hover .psi-grid-cell-duplicate {
+  color: inherit;
+}
+
 .psi-grid-value-cell {
   justify-content: flex-end;
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary
- detect repeated fixed-column values per channel within the PSI data grid and flag them as duplicates
- add a CSS treatment to dim duplicate cells while restoring full contrast on hover, focus, or edit

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce642ee620832e85abc5be237d5d73