### PR TITLE
Align PSI summary RDG theme with daily grid

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -357,87 +357,18 @@ button.collapse-toggle:focus-visible {
 }
 
 
-.psi-summary-table {
+.psi-summary-grid {
   width: 100%;
-  table-layout: fixed;
-  border-collapse: separate;
-  border-spacing: 0 10px;
 }
 
-.psi-summary-table th,
-.psi-summary-table td {
-  padding: 10px 14px;
+.psi-summary-data-grid.rdg {
+  border-radius: 0.75rem;
 }
-
-.psi-summary-table .numeric {
-  text-align: right;
-}
-
-.psi-summary-row {
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.psi-summary-row th,
-.psi-summary-row td {
-  background: transparent;
-}
-
-.psi-summary-row.group-start th,
-.psi-summary-row.group-start td {
-  padding-top: 16px;
-}
-
-.psi-summary-row.group-end th,
-.psi-summary-row.group-end td {
-  padding-bottom: 16px;
-}
-
-.psi-summary-group {
-  position: relative;
-  background: rgba(15, 23, 42, 0.45);
-  border-radius: 14px;
-  transition: background-color 0.2s ease;
-  overflow: hidden;
-}
-
-.psi-summary-group::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 14px;
-  border: 2px solid transparent;
-  pointer-events: none;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  z-index: 1;
-}
-
-.psi-summary-group:not(.is-selected):hover {
-  background: rgba(148, 163, 184, 0.18);
-}
-
-.psi-summary-group:not(.is-selected):hover::before {
-  border-color: rgba(148, 163, 184, 0.45);
-}
-
-.psi-summary-group:focus-within::before {
-  border-color: rgba(59, 130, 246, 0.7);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
-}
-
-.psi-summary-group.is-selected {
-  background: rgba(37, 99, 235, 0.18);
-}
-
-.psi-summary-group.is-selected::before {
-  border-color: var(--brand, #3b82f6);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
-}
-
 
 .psi-summary-sku {
+  display: grid;
+  gap: 0.25rem;
   text-align: left;
-  vertical-align: top;
 }
 
 .psi-summary-sku-code {
@@ -1023,18 +954,84 @@ button.icon-button:focus-visible {
 
 .psi-data-grid {
   width: 100%;
-  background-color: transparent;
+}
+
+.psi-data-grid.rdg {
+  --psi-grid-border: rgba(148, 163, 184, 0.28);
+  --psi-grid-hover: rgba(59, 130, 246, 0.18);
+  --psi-grid-selection: rgba(37, 99, 235, 0.22);
+  --psi-grid-selection-border: rgba(37, 99, 235, 0.45);
+  --psi-grid-editable: rgba(37, 99, 235, 0.14);
+  border: 1px solid var(--psi-grid-border);
+  border-radius: 0.5rem;
+  background-color: var(--surface-table);
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  line-height: 1.3;
+}
+
+.psi-data-grid .rdg-header {
+  background-color: var(--surface-table-header);
+  border-bottom: 1px solid var(--psi-grid-border);
+}
+
+.psi-data-grid .rdg-header-row {
+  min-height: 32px;
+}
+
+.psi-data-grid .rdg-header-cell {
+  padding: 0.25rem 0.5rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  border-right: 1px solid var(--psi-grid-border);
+}
+
+.psi-data-grid .rdg-header-cell:last-child {
+  border-right: none;
+}
+
+.psi-data-grid .rdg-body {
+  background: transparent;
+}
+
+.psi-data-grid .rdg-row {
+  min-height: 32px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.45);
+}
+
+.psi-data-grid .rdg-cell {
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  border-right: 1px solid rgba(15, 23, 42, 0.45);
+  background-color: var(--surface-table);
+  color: var(--text-primary);
+  gap: 0.25rem;
+}
+
+.psi-data-grid .rdg-cell:last-child {
+  border-right: none;
+}
+
+.psi-data-grid .rdg-row:nth-child(even) .rdg-cell {
+  background-color: var(--surface-table-zebra);
+}
+
+.psi-data-grid .rdg-row:hover .rdg-cell:not(.psi-grid-stock-warning):not(.psi-grid-cell-today):not(.psi-grid-cell-editable) {
+  background-color: var(--psi-grid-hover);
 }
 
 .psi-grid-channel-cell,
-.psi-grid-metric-cell {
-  font-weight: 600;
-  background-color: #f9fbfd;
+.psi-grid-metric-cell,
+.psi-grid-summary-sku-cell,
+.psi-grid-summary-metric-cell {
   justify-content: flex-start;
+  font-weight: 600;
 }
 
 .psi-grid-cell-duplicate {
-  color: #9da7b2;
+  color: var(--text-muted);
   transition: color 0.2s ease;
 }
 
@@ -1042,7 +1039,7 @@ button.icon-button:focus-visible {
 .psi-grid-cell-duplicate:focus,
 .psi-grid-cell-duplicate:focus-within,
 .rdg-row:hover .psi-grid-cell-duplicate {
-  color: inherit;
+  color: var(--text-primary);
 }
 
 .psi-grid-value-cell {
@@ -1051,24 +1048,56 @@ button.icon-button:focus-visible {
 }
 
 .psi-grid-cell-editable {
-  background-color: #fdfcff;
+  background-color: var(--psi-grid-editable);
 }
 
 .psi-grid-cell-today {
-  background-color: #fff4ce;
+  background-color: var(--psi-today-bg);
+  position: relative;
+  z-index: 1;
 }
 
 .psi-grid-header-today {
-  background-color: #ffe8a1;
+  background-color: var(--psi-today-header-bg);
+  position: relative;
+  z-index: 2;
+}
+
+.psi-grid-stock-warning {
+  background-color: rgba(245, 158, 11, 0.32);
+  color: var(--accent-red);
+  font-weight: 600;
+}
+
+.psi-grid-row-selected {
+  box-shadow: inset 0 0 0 1px var(--psi-grid-selection-border);
+}
+
+.psi-grid-row-selected:not(.psi-grid-stock-warning) {
+  background-color: var(--psi-grid-selection);
+}
+
+.psi-grid-group-start {
+  box-shadow: 0 -4px 0 var(--surface-panel);
+}
+
+.psi-data-grid .rdg-row:first-child .psi-grid-group-start {
+  box-shadow: none;
+}
+
+.psi-grid-header-numeric {
+  justify-content: flex-end;
 }
 
 .psi-grid-editor {
   width: 100%;
   font: inherit;
   padding: 4px 6px;
-  border: 1px solid #9da7b2;
+  border: 1px solid rgba(148, 163, 184, 0.6);
   border-radius: 4px;
   box-sizing: border-box;
+  background-color: var(--surface-input);
+  color: var(--text-primary);
 }
 
 .psi-table-toolbar {

--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -284,12 +284,17 @@ const PSITableContent = ({
           key: date,
           name: formatDisplayDate(date),
           width: 132,
-          className: (row: PSIGridRow) =>
-            classNames(
+          className: (row: PSIGridRow) => {
+            const cellValue = row[date] as number | null | undefined;
+            const isNegative =
+              row.metricKey === "stock_closing" && typeof cellValue === "number" && cellValue < 0;
+            return classNames(
               "psi-grid-value-cell",
               row.metricEditable && "psi-grid-cell-editable",
-              isToday && "psi-grid-cell-today"
-            ),
+              isToday && "psi-grid-cell-today",
+              row.metricKey === "stock_closing" && isNegative && "psi-grid-stock-warning"
+            );
+          },
           headerCellClass: classNames("psi-grid-date-header", isToday && "psi-grid-header-today"),
           renderCell: ({ row }) => formatNumber(row[date] as number | null | undefined),
           renderEditCell: (props) => <NumberEditor {...props} />,

--- a/frontend/src/utils/psiSummary.ts
+++ b/frontend/src/utils/psiSummary.ts
@@ -4,6 +4,8 @@ export type ChannelAgg = {
   inbound_sum: number;
   outbound_sum: number;
   last_closing: number | null;
+  last_safety_stock: number | null;
+  last_movable_stock: number | null;
 };
 
 export type SummaryRow = {
@@ -41,6 +43,8 @@ export function buildSummary(psi: PSIChannel[], start?: string | null, end?: str
       inbound_sum: 0,
       outbound_sum: 0,
       last_closing: null,
+      last_safety_stock: null,
+      last_movable_stock: null,
     };
 
     channel.daily.forEach((entry) => {
@@ -59,7 +63,17 @@ export function buildSummary(psi: PSIChannel[], start?: string | null, end?: str
       const previousDate = channelDates.get(lastDateKey);
       if (!previousDate || entry.date >= previousDate) {
         channelDates.set(lastDateKey, entry.date);
-        current.last_closing = entry.stock_closing ?? null;
+        const closing = entry.stock_closing ?? null;
+        const safety = entry.safety_stock ?? null;
+        const movable =
+          entry.movable_stock !== undefined && entry.movable_stock !== null
+            ? entry.movable_stock
+            : closing !== null && safety !== null
+              ? closing - safety
+              : null;
+        current.last_closing = closing;
+        current.last_safety_stock = safety;
+        current.last_movable_stock = movable;
       }
     });
 


### PR DESCRIPTION
## Summary
- convert the PSI summary card to use the shared react-data-grid implementation with SKU blocks, totals, surplus column, and consistent selection/hover styling
- unify the data grid theme across summary and daily tables including striped rows, today/negative highlights, and fixed column look
- extend PSI summary aggregation to surface safety/movable stock for surplus totals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea18049c4832eab4f058094a498cd