### PR TITLE
Improve PSI summary grid usability

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -988,6 +988,7 @@ button.icon-button:focus-visible {
   --psi-grid-hover: rgba(253, 224, 71, 0.28);
   --psi-grid-selection: rgba(37, 99, 235, 0.22);
   --psi-grid-selection-border: rgba(37, 99, 235, 0.45);
+  --psi-grid-selection-outline: rgba(250, 204, 21, 0.8);
   --psi-grid-editable: rgba(37, 99, 235, 0.14);
   border: 1px solid var(--psi-grid-border);
   border-radius: 0.5rem;
@@ -1054,6 +1055,7 @@ button.icon-button:focus-visible {
 .psi-data-grid .rdg-row {
   min-height: 32px;
   border-bottom: 1px solid rgba(15, 23, 42, 0.45);
+  box-sizing: border-box;
 }
 
 .psi-data-grid .rdg-cell {
@@ -1128,12 +1130,54 @@ button.icon-button:focus-visible {
   font-weight: 600;
 }
 
-.psi-grid-row-selected {
-  box-shadow: inset 0 0 0 1px var(--psi-grid-selection-border);
+.psi-summary-cell-selected {
+  background-color: var(--psi-grid-selection);
 }
 
-.psi-grid-row-selected:not(.psi-grid-stock-warning) {
+.psi-summary-cell-placeholder {
+  background-color: transparent;
+}
+
+.psi-summary-row-selected {
   background-color: var(--psi-grid-selection);
+  border-left: 2px solid var(--psi-grid-selection-outline);
+  border-right: 2px solid var(--psi-grid-selection-outline);
+  border-bottom: 0;
+}
+
+.psi-summary-row-selected-start {
+  border-top: 2px solid var(--psi-grid-selection-outline);
+}
+
+.psi-summary-row-selected-middle {
+  border-top: 0;
+}
+
+.psi-summary-row-selected-end {
+  border-bottom: 2px solid var(--psi-grid-selection-outline);
+}
+
+.psi-summary-row-placeholder {
+  background-color: transparent;
+}
+
+.psi-summary-row-placeholder .rdg-cell {
+  background-color: var(--surface-table);
+  color: transparent;
+}
+
+.psi-grid-value-negative {
+  transition: color 0.15s ease;
+}
+
+.psi-grid-value-negative:hover,
+.psi-grid-value-negative:focus,
+.psi-grid-value-negative:focus-within {
+  color: var(--accent-red);
+}
+
+.rdg-cell.rdg-cell-editing.psi-grid-value-negative {
+  color: inherit;
 }
 
 .psi-grid-group-start {

--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -305,13 +305,15 @@ const PSITableContent = ({
           width: 132,
           className: (row: PSIGridRow) => {
             const cellValue = row[date] as number | null | undefined;
-            const isNegative =
-              row.metricKey === "stock_closing" && typeof cellValue === "number" && cellValue < 0;
+            const numericValue = typeof cellValue === "number" ? cellValue : null;
+            const isNegativeValue = numericValue !== null && numericValue < 0;
+            const showStockWarning = row.metricKey === "stock_closing" && isNegativeValue;
             return classNames(
               "psi-grid-value-cell",
               row.metricEditable && "psi-grid-cell-editable",
               isToday && "psi-grid-cell-today",
-              row.metricKey === "stock_closing" && isNegative && "psi-grid-stock-warning"
+              isNegativeValue && "psi-grid-value-negative",
+              showStockWarning && "psi-grid-stock-warning"
             );
           },
           headerCellClass: classNames("psi-grid-date-header", isToday && "psi-grid-header-today"),

--- a/frontend/vendor/react-data-grid/index.d.ts
+++ b/frontend/vendor/react-data-grid/index.d.ts
@@ -52,6 +52,7 @@ export interface DataGridProps<RowType> {
     width?: number;
   };
   viewportRef?: React.Ref<HTMLDivElement>;
+  rowClassName?: (row: RowType, rowIdx: number) => string | undefined;
 }
 
 export default function DataGrid<RowType>(props: DataGridProps<RowType>): JSX.Element;

--- a/frontend/vendor/react-data-grid/index.jsx
+++ b/frontend/vendor/react-data-grid/index.jsx
@@ -30,6 +30,7 @@ function DataGrid({
   className,
   defaultColumnOptions,
   viewportRef,
+  rowClassName,
 }) {
   const columnWidth = defaultColumnOptions?.width ?? 140;
   const columnsWithWidth = useMemo(
@@ -204,8 +205,13 @@ function DataGrid({
       <div className="rdg-body" ref={bodyRef}>
         {rowsToRender.map((row, rowIdx) => {
           const rowKey = rowKeyGetter ? rowKeyGetter(row) : rowIdx;
+          const extraRowClassName = rowClassName ? rowClassName(row, rowIdx) : undefined;
           return (
-            <div key={rowKey} className="rdg-row" style={{ gridTemplateColumns: templateColumns }}>
+            <div
+              key={rowKey}
+              className={clsx("rdg-row", extraRowClassName)}
+              style={{ gridTemplateColumns: templateColumns }}
+            >
               {columnsWithWidth.map((column, columnIdx) => {
                 const frozenOffset = frozenOffsets[columnIdx];
                 const cellClass =


### PR DESCRIPTION
## Summary
- ensure the PSI summary grid always renders nine rows by padding pages with placeholders and widening the SKU column while keeping other columns balanced
- add hover-driven negative number emphasis, including in the detailed PSI table, without disrupting edit states
- provide a contiguous yellow outline for multi-row SKU selections via new summary row styling and support for row-level classes in the local DataGrid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceafa56748832e812f19bd2e8eef04