### PR TITLE
Fix summary selection overlay visibility

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -395,7 +395,7 @@ button.collapse-toggle:focus-visible {
 
 .psi-summary-selection-overlay {
   position: absolute;
-  border: 2px solid var(--psi-grid-selection-outline);
+  border: 2px solid transparent;
   border-radius: 0.5rem;
   box-sizing: border-box;
   pointer-events: none;

--- a/frontend/src/components/PSISummaryTable.tsx
+++ b/frontend/src/components/PSISummaryTable.tsx
@@ -24,6 +24,7 @@ type SelectionOverlayMetrics = {
   height: number;
   left: number;
   width: number;
+  borderColor: string;
 };
 
 type Props = {
@@ -255,6 +256,11 @@ const PSISummaryTable = memo(function PSISummaryTable({
 
     const containerRect = container.getBoundingClientRect();
     const gridRect = gridElement.getBoundingClientRect();
+    const gridComputedStyle = window.getComputedStyle(gridElement);
+    const selectionOutlineColor = gridComputedStyle
+      .getPropertyValue("--psi-grid-selection-outline")
+      .trim();
+    const borderColor = selectionOutlineColor || "rgba(250, 204, 21, 0.8)";
     const firstRowRect = selectedRows[0].getBoundingClientRect();
     const lastRowRect = selectedRows[selectedRows.length - 1].getBoundingClientRect();
 
@@ -264,6 +270,7 @@ const PSISummaryTable = memo(function PSISummaryTable({
       height: lastRowRect.bottom - firstRowRect.top + outlineOffset * 2,
       left: gridRect.left - containerRect.left - outlineOffset,
       width: gridRect.width + outlineOffset * 2,
+      borderColor,
     };
 
     setSelectionOverlay((previous) => {
@@ -272,7 +279,8 @@ const PSISummaryTable = memo(function PSISummaryTable({
         Math.abs(previous.top - overlayMetrics.top) < 0.5 &&
         Math.abs(previous.height - overlayMetrics.height) < 0.5 &&
         Math.abs(previous.left - overlayMetrics.left) < 0.5 &&
-        Math.abs(previous.width - overlayMetrics.width) < 0.5
+        Math.abs(previous.width - overlayMetrics.width) < 0.5 &&
+        previous.borderColor === overlayMetrics.borderColor
       ) {
         return previous;
       }
@@ -449,6 +457,7 @@ const PSISummaryTable = memo(function PSISummaryTable({
             left: `${selectionOverlay.left}px`,
             width: `${selectionOverlay.width}px`,
             height: `${selectionOverlay.height}px`,
+            borderColor: selectionOverlay.borderColor,
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- compute the summary selection overlay color from the data grid theme tokens and fall back to the expected yellow accent
- persist the overlay border style so the yellow outline renders reliably across the frozen and scrollable regions

## Testing
- npm run build *(fails: [vite]: Rollup failed to resolve import "react-data-grid/lib/styles.css" from "/workspace/psi-erp/frontend/src/main.tsx".)*

------
https://chatgpt.com/codex/tasks/task_e_68cec0a91a70832e9bff79db3c1902d9