### PR TITLE
Move summary deselect control to SKU column header

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1091,6 +1091,31 @@ button.icon-button:focus-visible {
   outline-offset: 1px;
 }
 
+.psi-grid-header-selection {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.psi-grid-header-selection button {
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--border-input);
+  background-color: var(--surface-input);
+  color: var(--text-secondary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.psi-grid-header-selection button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.psi-grid-header-selection button:focus {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+}
+
 .psi-data-grid .rdg-header-cell:last-child {
   border-right: none;
 }

--- a/frontend/src/components/PSISummaryTable.tsx
+++ b/frontend/src/components/PSISummaryTable.tsx
@@ -81,6 +81,7 @@ const PSISummaryTable = memo(function PSISummaryTable({
 }: Props) {
   const [metricFilter, setMetricFilter] = useState("");
   const [metricHeaderElement, setMetricHeaderElement] = useState<HTMLDivElement | null>(null);
+  const [skuHeaderElement, setSkuHeaderElement] = useState<HTMLDivElement | null>(null);
   const gridContainerRef = useRef<HTMLDivElement | null>(null);
   const [selectionOverlay, setSelectionOverlay] = useState<SelectionOverlayMetrics | null>(null);
   const animationFrameRef = useRef<number | null>(null);
@@ -244,6 +245,10 @@ const PSISummaryTable = memo(function PSISummaryTable({
     setMetricHeaderElement(element);
   }, []);
 
+  const handleSkuHeaderRef = useCallback((element: HTMLDivElement | null) => {
+    setSkuHeaderElement(element);
+  }, []);
+
   const updateSelectionOverlay = useCallback(() => {
     const container = gridContainerRef.current;
     if (!container) {
@@ -352,6 +357,7 @@ const PSISummaryTable = memo(function PSISummaryTable({
       name: "SKU",
       width: skuColumnWidth,
       frozen: true,
+      setHeaderRef: handleSkuHeaderRef,
       className: (row) =>
         classNames(
           "psi-grid-summary-sku-cell",
@@ -416,7 +422,7 @@ const PSISummaryTable = memo(function PSISummaryTable({
     };
 
     return [skuColumn, metricColumn, ...channelColumns, surplusColumn, totalColumn];
-  }, [handleMetricHeaderRef, orderedChannels, valueClassName]);
+  }, [handleMetricHeaderRef, handleSkuHeaderRef, orderedChannels, valueClassName]);
 
   useEffect(() => {
     return () => {
@@ -439,19 +445,27 @@ const PSISummaryTable = memo(function PSISummaryTable({
             placeholder="フィルタ"
             aria-label="Metricをフィルタ"
           />
-          <button
-            type="button"
-            onClick={() => {
-              onSelectSku(null);
-              scheduleSelectionOverlayUpdate();
-            }}
-            disabled={!selectedSku}
-          >
-            選択解除
-          </button>
         </div>
       </div>,
       metricHeaderElement
+    );
+
+  const skuHeaderPortal =
+    skuHeaderElement &&
+    createPortal(
+      <div className="psi-grid-header-selection">
+        <button
+          type="button"
+          onClick={() => {
+            onSelectSku(null);
+            scheduleSelectionOverlayUpdate();
+          }}
+          disabled={!selectedSku}
+        >
+          選択解除
+        </button>
+      </div>,
+      skuHeaderElement
     );
 
   const handleCellClick = useCallback(
@@ -515,6 +529,7 @@ const PSISummaryTable = memo(function PSISummaryTable({
           }}
         />
       )}
+      {skuHeaderPortal}
       {metricHeaderPortal}
       <DataGrid
         columns={columns}


### PR DESCRIPTION
## Summary
- render the summary table's SKU deselect button inside the SKU header instead of the metric header
- add header styling for the relocated deselect control

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cec4dc3ae0832e953cad8b977e1198