### PR TITLE
Add channel transfer table and schemas

### DIFF
--- a/backend/alembic/versions/0003_create_channel_transfers_table.py
+++ b/backend/alembic/versions/0003_create_channel_transfers_table.py
@@ -1,0 +1,69 @@
+"""create channel transfers table"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.config import settings
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: Union[str, Sequence[str], None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "channel_transfers",
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sku_code", sa.Text(), nullable=False),
+        sa.Column("warehouse_name", sa.Text(), nullable=False),
+        sa.Column("transfer_date", sa.Date(), nullable=False),
+        sa.Column("from_channel", sa.Text(), nullable=False),
+        sa.Column("to_channel", sa.Text(), nullable=False),
+        sa.Column("qty", sa.Numeric(20, 6), nullable=False),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"],
+            [f"{settings.db_schema}.sessions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "session_id",
+            "sku_code",
+            "warehouse_name",
+            "transfer_date",
+            "from_channel",
+            "to_channel",
+        ),
+        sa.UniqueConstraint(
+            "session_id",
+            "sku_code",
+            "warehouse_name",
+            "transfer_date",
+            "from_channel",
+            "to_channel",
+            name="uq_channel_transfers_key",
+        ),
+        schema=settings.db_schema,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("channel_transfers", schema=settings.db_schema)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,21 @@
+"""Expose commonly used application models for Alembic autogeneration."""
+
+from .models import (
+    Base,
+    ChannelTransfer,
+    MasterRecord,
+    PSIBase,
+    PSIEdit,
+    PSIEditLog,
+    Session,
+)
+
+__all__ = [
+    "Base",
+    "ChannelTransfer",
+    "MasterRecord",
+    "PSIBase",
+    "PSIEdit",
+    "PSIEditLog",
+    "Session",
+]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -132,3 +132,43 @@ class MasterRecordRead(MasterRecordBase):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class ChannelTransferBase(BaseModel):
+    """Shared attributes for channel transfer write models."""
+
+    sku_code: str
+    warehouse_name: str
+    transfer_date: date
+    from_channel: str
+    to_channel: str
+    qty: float
+    note: str | None = None
+
+
+class ChannelTransferCreate(ChannelTransferBase):
+    """Schema for creating a channel transfer."""
+
+    session_id: UUID
+
+
+class ChannelTransferUpdate(BaseModel):
+    """Schema for updating a channel transfer."""
+
+    sku_code: str | None = None
+    warehouse_name: str | None = None
+    transfer_date: date | None = None
+    from_channel: str | None = None
+    to_channel: str | None = None
+    qty: float | None = None
+    note: str | None = None
+
+
+class ChannelTransferRead(ChannelTransferBase):
+    """Channel transfer data returned by the API."""
+
+    session_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/database.md
+++ b/database.md
@@ -199,6 +199,23 @@ CREATE INDEX IF NOT EXISTS idx_transfers_key
   ON psi.stock_transfers (session_id, sku_code, transfer_date);
 ```
 
+```sql
+CREATE TABLE IF NOT EXISTS psi.channel_transfers (
+  session_id uuid NOT NULL REFERENCES psi.sessions(id) ON DELETE CASCADE,
+  sku_code text NOT NULL,
+  warehouse_name text NOT NULL,
+  transfer_date date NOT NULL,
+  from_channel text NOT NULL,
+  to_channel text NOT NULL,
+  qty numeric(20,6) NOT NULL,
+  note text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (session_id, sku_code, warehouse_name, transfer_date, from_channel, to_channel),
+  UNIQUE (session_id, sku_code, warehouse_name, transfer_date, from_channel, to_channel)
+);
+```
+
 ### 2.4 需要計画（日別）
 
 ```sql


### PR DESCRIPTION
## Summary
- add an Alembic migration that creates the channel_transfers table with timestamps and key constraints
- define the ChannelTransfer ORM model, relationships, and Pydantic schemas
- expose the model for autogeneration and document the new table in the database specification

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ced1c23a60832eb5fad08322b1ad04