### PR TITLE
Add channel transfer export and modal download

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1609,6 +1609,13 @@ button.danger {
   gap: 24px;
 }
 
+.channel-move-modal__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
 .channel-move-modal__summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));


### PR DESCRIPTION
## Summary
- add a streaming CSV export endpoint for channel transfer records with date, SKU, warehouse, and channel filters
- render a download button in the channel move modal that fetches the filtered export and names the file with the active context
- style the new modal action area for consistent spacing

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68ced7ebab60832ea91339f22d76bc7c