### PR TITLE
Ensure channel transfer table exists before queries

### DIFF
--- a/backend/app/routers/psi.py
+++ b/backend/app/routers/psi.py
@@ -18,6 +18,13 @@ from ..deps import get_db
 
 router = APIRouter()
 
+def _ensure_channel_transfer_table(db: DBSession) -> None:
+    """Create the channel transfers table when migrations haven't run."""
+
+    bind = db.get_bind()
+    if bind is not None:
+        models.ensure_channel_transfers_table(bind)
+
 
 def _normalise_header(header: str) -> str:
     """Normalize CSV header names for lookups.
@@ -284,6 +291,7 @@ def daily_psi(
     """
 
     _get_session_or_404(db, session_id)
+    _ensure_channel_transfer_table(db)
 
     base_alias = models.PSIBase
     edit_alias = models.PSIEdit


### PR DESCRIPTION
## Summary
- add a helper to create the channel_transfers table when it is missing
- call the helper from channel transfer endpoints so legacy databases avoid UndefinedTable errors
- ensure the PSI daily aggregation also creates the table before executing queries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cedaae55f8832e848c5ae0f08aa66a