### PR TITLE
Handle existing channel_transfers table in migration

### DIFF
--- a/backend/alembic/versions/0003_create_channel_transfers_table.py
+++ b/backend/alembic/versions/0003_create_channel_transfers_table.py
@@ -17,6 +17,12 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table("channel_transfers", schema=settings.db_schema):
+        return
+
     op.create_table(
         "channel_transfers",
         sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),


### PR DESCRIPTION
## Summary
- skip the channel_transfers migration when the table already exists to avoid duplicate table errors during deployment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ceddc02324832eb033447cc1db510d