### PR TITLE
Add Docs view for root markdown files

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Navigate, NavLink, Route, Routes, useLocation } from "react-router-dom"
 import SessionsPage from "./pages/SessionsPage";
 import PSITablePage from "./pages/PSITablePage";
 import MasterPage from "./pages/MasterPage";
+import DocsPage from "./pages/DocsPage";
 import "./App.css";
 import "./styles/psi-sticky.css";
 
@@ -86,6 +87,14 @@ export default function App() {
               ))}
             </ul>
           </li>
+          <li>
+            <NavLink to="/docs" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              <span className="menu-icon" aria-hidden="true">
+                📚
+              </span>
+              <span className="menu-label">Docs</span>
+            </NavLink>
+          </li>
         </ul>
       </nav>
       <main className="content">
@@ -94,6 +103,7 @@ export default function App() {
           <Route path="/sessions" element={<SessionsPage />} />
           <Route path="/masters/:masterId" element={<MasterPage />} />
           <Route path="/psi" element={<PSITablePage />} />
+          <Route path="/docs" element={<DocsPage />} />
           <Route path="/masters" element={<Navigate to={masters[0].path} replace />} />
         </Routes>
       </main>

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useMemo, useState } from "react";
+
+import "../styles/DocsPage.css";
+
+type DocEntry = {
+  id: string;
+  fileName: string;
+  title: string;
+  content: string;
+  searchableText: string;
+};
+
+const markdownModules = import.meta.glob("../../../*.md", {
+  eager: true,
+  query: "?raw",
+  import: "default"
+}) as Record<string, string>;
+
+const extractTitle = (content: string, fileName: string): string => {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) {
+      return trimmed.replace(/^#+\s*/, "").trim() || fileName.replace(/\.md$/i, "");
+    }
+  }
+  return fileName.replace(/\.md$/i, "");
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const formatInlineMarkdown = (value: string): string => {
+  const escaped = escapeHtml(value);
+  const withCode = escaped.replace(/`([^`]+)`/g, (_match, code) => `<code>${code}</code>`);
+  const withLinks = withCode.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) =>
+    `<a href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`
+  );
+  const withBold = withLinks
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/__([^_]+)__/g, "<strong>$1</strong>");
+  const withItalics = withBold
+    .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+    .replace(/_([^_]+)_/g, "<em>$1</em>");
+  const withStrikethrough = withItalics.replace(/~~([^~]+)~~/g, "<del>$1</del>");
+  return withStrikethrough;
+};
+
+const renderMarkdown = (markdown: string): string => {
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const htmlParts: string[] = [];
+  let inCodeBlock = false;
+  let codeLanguage = "";
+  const codeLines: string[] = [];
+  let openListType: "ul" | "ol" | null = null;
+  let paragraphLines: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length > 0) {
+      htmlParts.push(`<p>${formatInlineMarkdown(paragraphLines.join(" "))}</p>`);
+      paragraphLines = [];
+    }
+  };
+
+  const closeList = () => {
+    if (openListType) {
+      htmlParts.push(`</${openListType}>`);
+      openListType = null;
+    }
+  };
+
+  const closeCodeBlock = () => {
+    if (codeLines.length > 0) {
+      const codeHtml = escapeHtml(codeLines.join("\n"));
+      const languageClass = codeLanguage ? ` class="language-${codeLanguage}"` : "";
+      htmlParts.push(`<pre><code${languageClass}>${codeHtml}</code></pre>`);
+      codeLines.length = 0;
+      codeLanguage = "";
+    }
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine;
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("```")) {
+      if (inCodeBlock) {
+        closeCodeBlock();
+        inCodeBlock = false;
+      } else {
+        flushParagraph();
+        closeList();
+        inCodeBlock = true;
+        codeLanguage = trimmed.slice(3).trim();
+        codeLines.length = 0;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeLines.push(line);
+      continue;
+    }
+
+    if (!trimmed) {
+      flushParagraph();
+      closeList();
+      continue;
+    }
+
+    const headingMatch = trimmed.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      const level = Math.min(headingMatch[1].length, 6);
+      const headingText = headingMatch[2].trim();
+      flushParagraph();
+      closeList();
+      htmlParts.push(`<h${level}>${formatInlineMarkdown(headingText)}</h${level}>`);
+      continue;
+    }
+
+    if (/^(-{3,}|_{3,}|\*{3,})$/.test(trimmed)) {
+      flushParagraph();
+      closeList();
+      htmlParts.push("<hr />");
+      continue;
+    }
+
+    const listMatch = trimmed.match(/^([-*+]|\d+\.)\s+(.*)$/);
+    if (listMatch) {
+      const marker = listMatch[1];
+      const text = listMatch[2];
+      const listType: "ul" | "ol" = marker.endsWith(".") ? "ol" : "ul";
+      flushParagraph();
+      if (openListType && openListType !== listType) {
+        closeList();
+      }
+      if (!openListType) {
+        htmlParts.push(`<${listType}>`);
+        openListType = listType;
+      }
+      htmlParts.push(`<li>${formatInlineMarkdown(text)}</li>`);
+      continue;
+    }
+
+    if (trimmed.startsWith(">")) {
+      const quoteText = trimmed.replace(/^>\s?/, "");
+      flushParagraph();
+      closeList();
+      htmlParts.push(`<blockquote>${formatInlineMarkdown(quoteText)}</blockquote>`);
+      continue;
+    }
+
+    paragraphLines.push(line.trim());
+  }
+
+  if (inCodeBlock) {
+    closeCodeBlock();
+  }
+
+  flushParagraph();
+  closeList();
+
+  return htmlParts.join("\n");
+};
+
+const allDocs: DocEntry[] = Object.entries(markdownModules)
+  .map(([path, content]) => {
+    const fileName = path.split("/").pop() ?? path;
+    const title = extractTitle(content, fileName);
+    return {
+      id: path,
+      fileName,
+      title,
+      content,
+      searchableText: `${title}\n${fileName}\n${content}`.toLowerCase()
+    } satisfies DocEntry;
+  })
+  .sort((a, b) => a.title.localeCompare(b.title));
+
+export default function DocsPage() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(allDocs[0]?.id ?? null);
+
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+
+  const filteredDocs = useMemo(() => {
+    if (!normalizedSearch) {
+      return allDocs;
+    }
+    return allDocs.filter((doc) => doc.searchableText.includes(normalizedSearch));
+  }, [normalizedSearch]);
+
+  useEffect(() => {
+    if (filteredDocs.length === 0) {
+      return;
+    }
+    if (!selectedDocId || !filteredDocs.some((doc) => doc.id === selectedDocId)) {
+      setSelectedDocId(filteredDocs[0].id);
+    }
+  }, [filteredDocs, selectedDocId]);
+
+  const activeDoc = useMemo(() => {
+    if (!filteredDocs.length) {
+      return null;
+    }
+    return filteredDocs.find((doc) => doc.id === selectedDocId) ?? filteredDocs[0];
+  }, [filteredDocs, selectedDocId]);
+
+  return (
+    <div className="docs-page">
+      <div className="docs-header">
+        <h1>Docs</h1>
+        <p className="docs-description">Browse project markdown files from the repository root.</p>
+        <input
+          type="search"
+          className="docs-search"
+          placeholder="Search titles, filenames, or content..."
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
+      </div>
+      <div className="docs-content">
+        <aside className="docs-list-panel">
+          {filteredDocs.length > 0 ? (
+            <ul className="docs-list">
+              {filteredDocs.map((doc) => (
+                <li key={doc.id}>
+                  <button
+                    type="button"
+                    className={`docs-list-item${activeDoc?.id === doc.id ? " active" : ""}`}
+                    onClick={() => setSelectedDocId(doc.id)}
+                  >
+                    <span className="docs-list-title">{doc.title}</span>
+                    <span className="docs-list-filename">{doc.fileName}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="docs-empty">No documents match your search.</div>
+          )}
+        </aside>
+        <section className="docs-viewer">
+          {activeDoc ? (
+            <article className="docs-article">
+              <header className="docs-article-header">
+                <h2>{activeDoc.title}</h2>
+                <span className="docs-article-filename">{activeDoc.fileName}</span>
+              </header>
+              <div
+                className="docs-markdown"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(activeDoc.content) }}
+              />
+            </article>
+          ) : (
+            <div className="docs-empty">No markdown files were found in the repository root.</div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/DocsPage.css
+++ b/frontend/src/styles/DocsPage.css
@@ -1,0 +1,221 @@
+.docs-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.docs-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.docs-header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.docs-description {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.docs-search {
+  background-color: var(--surface-input);
+  border: 1px solid var(--border-input);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  color: var(--text-primary);
+}
+
+.docs-search:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
+}
+
+.docs-content {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.docs-list-panel {
+  background-color: var(--surface-panel);
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  max-height: calc(100vh - 220px);
+  overflow: auto;
+}
+
+.docs-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.docs-list-item {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.docs-list-item:hover {
+  background-color: rgba(148, 163, 184, 0.1);
+}
+
+.docs-list-item.active {
+  border-color: var(--accent-blue);
+  background-color: rgba(59, 130, 246, 0.15);
+}
+
+.docs-list-title {
+  font-weight: 600;
+}
+
+.docs-list-filename {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.docs-viewer {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.docs-article {
+  background-color: var(--surface-panel);
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.docs-article-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.docs-article-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.docs-article-filename {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.docs-markdown {
+  color: var(--text-primary);
+  line-height: 1.75;
+  display: grid;
+  gap: 1rem;
+  overflow-wrap: anywhere;
+}
+
+.docs-markdown h1,
+.docs-markdown h2,
+.docs-markdown h3,
+.docs-markdown h4,
+.docs-markdown h5,
+.docs-markdown h6 {
+  margin: 0;
+}
+
+.docs-markdown h1 {
+  font-size: 2rem;
+}
+
+.docs-markdown h2 {
+  font-size: 1.65rem;
+}
+
+.docs-markdown h3 {
+  font-size: 1.3rem;
+}
+
+.docs-markdown ul,
+.docs-markdown ol {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.docs-markdown li {
+  margin: 0;
+}
+
+.docs-markdown pre {
+  background-color: #0f172a;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow: auto;
+  border: 1px solid var(--border-default);
+}
+
+.docs-markdown code {
+  background-color: rgba(148, 163, 184, 0.12);
+  border-radius: 0.35rem;
+  padding: 0.2rem 0.4rem;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 0.9rem;
+}
+
+.docs-markdown pre code {
+  background: none;
+  padding: 0;
+}
+
+.docs-markdown blockquote {
+  border-left: 4px solid var(--accent-blue);
+  padding-left: 1rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.docs-markdown table {
+  border-collapse: collapse;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 0.5rem;
+}
+
+.docs-markdown th,
+.docs-markdown td {
+  border: 1px solid var(--border-default);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.docs-empty {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 1024px) {
+  .docs-content {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-list-panel {
+    max-height: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Docs page that indexes markdown files from the repository root, offers filtering, and renders them for reading
- style the Docs page and expose it from the sidebar navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf45d7dcb8832eac6e30b04806ee18