### PR TITLE
refactor: centralize color palette

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,23 +1,8 @@
 :root {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.5;
-  color: #e5e7eb;
-  background-color: #0b1220;
-  --surface-panel: #111827;
-  --surface-table: #0f172a;
-  --surface-table-zebra: #101c2e;
-  --surface-table-header: #0d1b2a;
-  --surface-sticky-col: #0e1625;
-  --surface-input: #1f2937;
-  --border-default: #1f2937;
-  --border-input: #334155;
-  --text-primary: #e5e7eb;
-  --text-secondary: #aab4c0;
-  --text-muted: #94a3b8;
-  --accent-blue: #3b82f6;
-  --accent-green: #22c55e;
-  --accent-amber: #f59e0b;
-  --accent-red: #ef4444;
+  color: var(--text-primary);
+  background-color: var(--surface-body);
   --psi-col-sku-width: clamp(10ch, 14ch, 20ch);
   --psi-col-sku-name-width: clamp(12ch, 18ch, 24ch);
   --psi-col-warehouse-width: clamp(10ch, 14ch, 20ch);
@@ -39,12 +24,12 @@
   --psi-today-border: rgba(96, 165, 250, 0.4);
   --psi-row-selected-bg: rgba(34, 197, 94, 0.12);
   --psi-row-selected-border: rgba(34, 197, 94, 0.35);
-  --psi-row-selected-fg: #e5e7eb;
+  --psi-row-selected-fg: var(--text-primary);
 }
 
 body {
   margin: 0;
-  background-color: #0b1220;
+  background-color: var(--surface-body);
   color: var(--text-primary);
 }
 
@@ -57,8 +42,8 @@ body {
 .sidebar {
   width: 240px;
   padding: 1.5rem;
-  background: #111827;
-  color: #f9fafb;
+  background: var(--surface-panel);
+  color: var(--text-on-panel);
   transition: width 0.2s ease;
   display: flex;
   flex-direction: column;
@@ -80,7 +65,7 @@ body {
 
 .sidebar-toggle {
   background: transparent;
-  border: 1px solid #374151;
+  border: 1px solid var(--border-subtle);
   color: inherit;
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
@@ -127,7 +112,7 @@ body {
 .sidebar a.active,
 .sidebar a:hover,
 .submenu-toggle:hover {
-  background-color: #374151;
+  background-color: var(--surface-sidebar-hover);
 }
 
 .sidebar.collapsed .app-title,
@@ -471,8 +456,8 @@ textarea:focus {
 }
 
 button {
-  background-color: var(--accent-blue);
-  color: #ffffff;
+  background-color: var(--button-primary-bg);
+  color: var(--button-contrast-text);
   border: none;
   cursor: pointer;
   justify-self: start;
@@ -497,19 +482,19 @@ button.psi-button {
 }
 
 button.psi-button.primary {
-  background-color: #2563eb;
-  color: #ffffff;
+  background-color: var(--button-primary-bg);
+  color: var(--button-contrast-text);
 }
 
 button.psi-button.secondary {
-  background-color: #475569;
-  color: #ffffff;
+  background-color: var(--button-neutral-bg);
+  color: var(--button-contrast-text);
   box-shadow: 0 6px 12px rgba(71, 85, 105, 0.25);
 }
 
 button.psi-button.today {
-  background-color: #0ea5e9;
-  color: #0f172a;
+  background-color: var(--button-info-bg);
+  color: var(--button-bright-text);
   box-shadow: 0 8px 18px rgba(14, 165, 233, 0.25);
 }
 
@@ -518,16 +503,16 @@ button.psi-button:hover:not([disabled]) {
 }
 
 button.psi-button.primary:hover:not([disabled]) {
-  background-color: #1d4ed8;
+  background-color: var(--button-primary-hover-bg);
 }
 
 button.psi-button.secondary:hover:not([disabled]) {
-  background-color: #334155;
+  background-color: var(--button-neutral-hover-bg);
 }
 
 button.psi-button.today:hover:not([disabled]) {
-  background-color: #0284c7;
-  color: #f8fafc;
+  background-color: var(--button-info-hover-bg);
+  color: var(--badge-info-text);
 }
 
 button.psi-button:focus-visible {
@@ -675,8 +660,8 @@ button.icon-button:focus-visible {
 .psi-table thead th {
   position: sticky;
   top: var(--psi-table-header-offset, 0px);
-  background: var(--surface-panel, #111827);
-  color: var(--text-high, #f3f4f6);
+  background: var(--surface-panel);
+  color: var(--text-high);
   font-weight: 700;
   font-size: 0.8rem;
   z-index: 30;
@@ -759,18 +744,18 @@ button.icon-button:focus-visible {
 .psi-table .sticky-col {
   position: sticky;
   left: 0;
-  background: var(--surface-panel, #111827);
+  background: var(--surface-panel);
   z-index: 20;
   box-shadow: 1px 0 0 var(--border-default);
 }
 
 .psi-table tbody tr:nth-child(even) .sticky-col {
-  background: #0f1a2c;
+  background: var(--surface-panel-soft);
 }
 
 .psi-table thead .sticky-col {
   z-index: 30;
-  background: var(--surface-panel, #111827);
+  background: var(--surface-panel);
   box-shadow: 1px 0 0 var(--border-default);
   top: var(--psi-table-header-offset, 0px);
 }
@@ -888,7 +873,7 @@ button.icon-button:focus-visible {
 }
 
 .metric-selector input[type="checkbox"] {
-  accent-color: #2563eb;
+  accent-color: var(--accent-blue-strong);
 }
 
 .psi-edit-input {
@@ -966,23 +951,23 @@ button.icon-button:focus-visible {
   flex: 1 0 calc(25% - 0.5rem);
   min-width: 140px;
   padding: 0.5rem 0.75rem;
-  border: 1px solid #c8d1dc;
+  border: 1px solid var(--border-muted);
   border-radius: 20px;
-  background-color: #ffffff;
-  color: #1f2937;
+  background-color: var(--surface-inverted);
+  color: var(--text-on-light);
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .psi-warehouse-tab.active {
-  background-color: #1f7ae0;
-  color: #ffffff;
-  border-color: #1f7ae0;
+  background-color: var(--badge-primary-bg);
+  color: var(--text-contrast);
+  border-color: var(--badge-primary-bg);
 }
 
 .psi-warehouse-tab:hover:not(.active) {
-  background-color: #f3f8ff;
+  background-color: var(--surface-info);
 }
 
 .psi-grid-container {
@@ -1004,13 +989,13 @@ button.icon-button:focus-visible {
   --psi-grid-warning: rgba(190, 24, 38, 0.38);
   --psi-grid-warning-hover: rgba(190, 24, 38, 0.48);
   --psi-grid-warning-selection: rgba(190, 24, 38, 0.6);
-  --psi-grid-warning-text: #f8fafc;
+  --psi-grid-warning-text: var(--badge-info-text);
   --psi-grid-success: rgba(22, 163, 74, 0.32);
-  --psi-grid-success-text: #f8fafc;
+  --psi-grid-success-text: var(--badge-info-text);
   --psi-grid-negative: rgba(248, 113, 113, 0.35);
   --psi-grid-negative-hover: rgba(248, 113, 113, 0.45);
   --psi-grid-negative-selection: rgba(248, 113, 113, 0.55);
-  --psi-grid-negative-text: #ffffff;
+  --psi-grid-negative-text: var(--text-contrast);
   border: 1px solid var(--psi-grid-border);
   border-radius: 0.5rem;
   background-color: var(--surface-table);
@@ -1527,7 +1512,7 @@ button.secondary {
 }
 
 button.secondary:hover {
-  background-color: #273244;
+  background-color: var(--card-background);
 }
 
 button.danger {
@@ -1560,7 +1545,7 @@ button.danger {
 }
 
 .channel-move-modal {
-  background: var(--psi-surface, #ffffff);
+  background: var(--psi-surface, var(--surface-inverted));
   color: inherit;
   border-radius: 12px;
   width: min(760px, 100%);
@@ -1582,7 +1567,7 @@ button.danger {
 .channel-move-modal__subtitle {
   margin: 8px 0 0;
   line-height: 1.5;
-  color: #4a5568;
+  color: var(--card-muted-text);
   font-size: 14px;
 }
 
@@ -1629,7 +1614,7 @@ button.danger {
   display: block;
   font-size: 12px;
   letter-spacing: 0.02em;
-  color: #4a5568;
+  color: var(--card-muted-text);
   margin-bottom: 4px;
 }
 
@@ -1643,7 +1628,7 @@ button.danger {
 
 .channel-move-modal__summary-delta {
   font-size: 12px;
-  color: #0b7285;
+  color: var(--text-info);
 }
 
 .channel-move-modal__section {
@@ -1662,7 +1647,7 @@ button.danger {
 .channel-move-modal__status {
   margin: 0;
   font-size: 14px;
-  color: #4a5568;
+  color: var(--card-muted-text);
 }
 
 .channel-move-modal__table {
@@ -1673,14 +1658,14 @@ button.danger {
 
 .channel-move-modal__table th,
 .channel-move-modal__table td {
-  border: 1px solid #d0d7de;
+  border: 1px solid var(--border-soft);
   padding: 8px 10px;
   text-align: left;
   vertical-align: middle;
 }
 
 .channel-move-modal__table th {
-  background: #f6f8fa;
+  background: var(--layout-page-background);
   font-weight: 600;
 }
 
@@ -1697,7 +1682,7 @@ button.danger {
   display: block;
   margin-top: 4px;
   font-size: 12px;
-  color: #c92a2a;
+  color: var(--text-warning);
 }
 
 .channel-move-modal__content input,
@@ -1705,22 +1690,22 @@ button.danger {
   width: 100%;
   min-height: 32px;
   padding: 6px 8px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--border-muted);
   border-radius: 4px;
   font-size: 14px;
 }
 
 .channel-move-modal__content input:focus,
 .channel-move-modal__content select:focus {
-  outline: 2px solid #0b7285;
+  outline: 2px solid var(--border-focus);
   outline-offset: 1px;
 }
 
 .channel-move-modal__error {
   margin: 0;
   padding: 12px 16px;
-  background: #fff5f5;
-  color: #c92a2a;
+  background: var(--surface-warning);
+  color: var(--text-warning);
   border-radius: 8px;
   font-size: 14px;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
+import "./styles/palette.css";
 import "./App.css";
 import "react-data-grid/lib/styles.css";
 

--- a/frontend/src/styles/DocsPage.css
+++ b/frontend/src/styles/DocsPage.css
@@ -164,7 +164,7 @@
 }
 
 .docs-markdown pre {
-  background-color: #0f172a;
+  background-color: var(--surface-table);
   border-radius: 0.75rem;
   padding: 1rem;
   overflow: auto;

--- a/frontend/src/styles/palette.css
+++ b/frontend/src/styles/palette.css
@@ -1,0 +1,105 @@
+:root {
+  /* Base palette */
+  --palette-midnight-1000: #0b1220;
+  --palette-midnight-950: #0f172a;
+  --palette-midnight-925: #0f1a2c;
+  --palette-midnight-900: #101c2e;
+  --palette-midnight-875: #0e1625;
+  --palette-midnight-850: #0d1b2a;
+  --palette-midnight-825: #111827;
+  --palette-slate-900: #1f2937;
+  --palette-slate-850: #273244;
+  --palette-slate-800: #334155;
+  --palette-slate-750: #374151;
+  --palette-slate-700: #475569;
+  --palette-slate-650: #4a5568;
+  --palette-slate-500: #94a3b8;
+  --palette-slate-450: #aab4c0;
+  --palette-slate-400: #c8d1dc;
+  --palette-slate-375: #cbd5e1;
+  --palette-slate-350: #d0d7de;
+  --palette-slate-250: #e5e7eb;
+  --palette-slate-200: #f3f4f6;
+  --palette-slate-150: #f6f8fa;
+  --palette-slate-125: #f8fafc;
+  --palette-slate-100: #f9fafb;
+  --palette-ice-100: #f3f8ff;
+  --palette-rose-50: #fff5f5;
+  --palette-white: #ffffff;
+
+  --palette-blue-500: #3b82f6;
+  --palette-blue-575: #1f7ae0;
+  --palette-blue-600: #2563eb;
+  --palette-blue-650: #1d4ed8;
+  --palette-sky-500: #0ea5e9;
+  --palette-sky-600: #0284c7;
+  --palette-teal-600: #0b7285;
+
+  --palette-green-500: #22c55e;
+  --palette-amber-500: #f59e0b;
+  --palette-red-500: #ef4444;
+  --palette-red-600: #c92a2a;
+
+  /* Semantic tokens */
+  --surface-body: var(--palette-midnight-1000);
+  --surface-panel: var(--palette-midnight-825);
+  --surface-panel-strong: var(--palette-midnight-850);
+  --surface-panel-soft: var(--palette-midnight-925);
+  --surface-table: var(--palette-midnight-950);
+  --surface-table-zebra: var(--palette-midnight-900);
+  --surface-table-header: var(--palette-midnight-850);
+  --surface-sticky-col: var(--palette-midnight-875);
+  --surface-input: var(--palette-slate-900);
+  --surface-sidebar-hover: var(--palette-slate-750);
+  --surface-card: var(--palette-slate-850);
+  --surface-inverted: var(--palette-white);
+  --surface-info: var(--palette-ice-100);
+  --surface-warning: var(--palette-rose-50);
+
+  --border-default: var(--palette-slate-900);
+  --border-subtle: var(--palette-slate-750);
+  --border-input: var(--border-default);
+  --border-muted: var(--palette-slate-375);
+  --border-soft: var(--palette-slate-350);
+  --border-focus: var(--palette-teal-600);
+  --border-highlight: var(--palette-blue-575);
+
+  --text-primary: var(--palette-slate-250);
+  --text-secondary: var(--palette-slate-450);
+  --text-muted: var(--palette-slate-500);
+  --text-high: var(--palette-slate-200);
+  --text-contrast: var(--palette-white);
+  --text-on-panel: var(--palette-slate-100);
+  --text-on-light: var(--palette-slate-900);
+  --text-on-bright: var(--palette-midnight-950);
+  --text-info: var(--palette-teal-600);
+  --text-warning: var(--palette-red-600);
+
+  --accent-blue: var(--palette-blue-500);
+  --accent-blue-strong: var(--palette-blue-600);
+  --accent-blue-contrast: var(--palette-blue-650);
+  --accent-green: var(--palette-green-500);
+  --accent-amber: var(--palette-amber-500);
+  --accent-red: var(--palette-red-500);
+  --accent-info: var(--palette-sky-500);
+  --accent-info-strong: var(--palette-sky-600);
+
+  --button-primary-bg: var(--palette-blue-600);
+  --button-primary-hover-bg: var(--palette-blue-650);
+  --button-neutral-bg: var(--palette-slate-700);
+  --button-neutral-hover-bg: var(--palette-slate-800);
+  --button-info-bg: var(--palette-sky-500);
+  --button-info-hover-bg: var(--palette-sky-600);
+  --button-contrast-text: var(--text-contrast);
+  --button-bright-text: var(--palette-midnight-950);
+
+  --badge-primary-bg: var(--palette-blue-575);
+  --badge-muted-bg: var(--palette-slate-800);
+  --badge-info-bg: var(--palette-sky-600);
+  --badge-info-text: var(--palette-slate-125);
+
+  --card-background: var(--palette-slate-850);
+  --card-muted-text: var(--palette-slate-650);
+
+  --layout-page-background: var(--palette-slate-150);
+}

--- a/frontend/src/styles/psi-sticky.css
+++ b/frontend/src/styles/psi-sticky.css
@@ -8,7 +8,7 @@
   position: sticky;
   top: var(--psi-table-header-offset, 0px);
   z-index: 50;
-  background: var(--surface-panel, #111827);
+  background: var(--surface-panel);
   border-bottom: 1px solid var(--border-default);
 }
 


### PR DESCRIPTION
## Summary
- add a shared palette stylesheet that defines the base color swatches and semantic tokens for the app
- refactor core layout, table, and modal styling to consume the semantic tokens instead of hard-coded hex values
- update auxiliary styles and the main entrypoint to load the palette so documentation and sticky grid components stay in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf65391144832ea0c13fcecfa691df