### PR TITLE
Improve channel move modal layout and preview

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1545,8 +1545,8 @@ button.danger {
 }
 
 .channel-move-modal {
-  background: var(--psi-surface, var(--surface-inverted));
-  color: inherit;
+  background: #fff;
+  color: #000;
   border-radius: 12px;
   width: min(760px, 100%);
   max-height: 90vh;
@@ -1564,11 +1564,25 @@ button.danger {
   padding: 24px 24px 0;
 }
 
-.channel-move-modal__subtitle {
-  margin: 8px 0 0;
-  line-height: 1.5;
-  color: var(--card-muted-text);
-  font-size: 14px;
+.channel-move-modal__metadata {
+  margin-top: 12px;
+  display: grid;
+  gap: 4px;
+}
+
+.channel-move-modal__metadata > div {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.channel-move-modal__metadata-label {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.channel-move-modal__metadata-value {
+  font-size: 13px;
 }
 
 .channel-move-modal__close {
@@ -1614,7 +1628,7 @@ button.danger {
   display: block;
   font-size: 12px;
   letter-spacing: 0.02em;
-  color: var(--card-muted-text);
+  color: #000;
   margin-bottom: 4px;
 }
 
@@ -1637,6 +1651,19 @@ button.danger {
   gap: 12px;
 }
 
+.channel-move-modal__inventory-preview {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.channel-move-modal__inventory-preview h4 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
 .channel-move-modal__section-header {
   display: flex;
   align-items: center;
@@ -1647,7 +1674,7 @@ button.danger {
 .channel-move-modal__status {
   margin: 0;
   font-size: 14px;
-  color: var(--card-muted-text);
+  color: #000;
 }
 
 .channel-move-modal__table {
@@ -1693,6 +1720,7 @@ button.danger {
   border: 1px solid var(--border-muted);
   border-radius: 4px;
   font-size: 14px;
+  box-sizing: border-box;
 }
 
 .channel-move-modal__content input:focus,

--- a/frontend/src/pages/PSITablePage.tsx
+++ b/frontend/src/pages/PSITablePage.tsx
@@ -459,6 +459,24 @@ export default function PSITablePage() {
     return Array.from(unique).sort((a, b) => a.localeCompare(b));
   }, [channelMoveSelection, tableData]);
 
+  const inventorySnapshot = useMemo(() => {
+    if (!channelMoveSelection) {
+      return [];
+    }
+
+    const { row, date } = channelMoveSelection;
+
+    return tableData
+      .filter((item) => item.sku_code === row.sku_code && item.warehouse_name === row.warehouse_name)
+      .map((item) => {
+        const entry = item.daily.find((daily) => daily.date === date);
+        return {
+          channel: item.channel,
+          stockClosing: entry?.stock_closing ?? null,
+        };
+      });
+  }, [channelMoveSelection, tableData]);
+
   const channelMoveModalContext = useMemo(() => {
     if (!channelMoveSelection || !selectedChannelForMove) {
       return null;
@@ -892,6 +910,7 @@ export default function PSITablePage() {
           formatNumber={formatNumber}
           currentNetMove={currentNetMove}
           channelMoveValue={currentChannelMoveValue}
+          inventorySnapshot={inventorySnapshot}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle the channel move modal header and typography to improve readability
- enforce channel selection via dropdowns and simplify delete actions while showing a per-channel inventory preview
- compute channel inventory snapshots in the PSI table page for the modal preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf9086f5a4832e83eca7cae2737c3c