### PR TITLE
Adjust summary table column width

### DIFF
--- a/frontend/src/components/PSISummaryTable.tsx
+++ b/frontend/src/components/PSISummaryTable.tsx
@@ -74,7 +74,7 @@ const rowsPerGroup = metricGroupPositions.length + 1;
 const maxVisibleRows = rowsPerGroup * 3;
 const defaultHeaderHeight = 36;
 const defaultRowHeight = 36;
-const baseColumnWidth = 132;
+const baseColumnWidth = 112;
 const metricColumnWidth = 152;
 const skuColumnWidth = baseColumnWidth * 3;
 


### PR DESCRIPTION
## Summary
- shrink the base summary table column width so channel columns better match their labels

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cff952ba7c832e9dceb328e170ad3c