### PR TITLE
Fix warning styling for negative inventory

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1067,6 +1067,8 @@ button.icon-button:focus-visible {
   --psi-grid-warning-hover: var(--psi-bg-warning-hover);
   --psi-grid-warning-selection: var(--psi-bg-warning-select);
   --psi-grid-warning-text: var(--psi-fg-warning);
+  --surface-warning: var(--psi-bg-warning);
+  --surface-inverted: var(--surface-table);
   --psi-grid-success: rgba(22, 163, 74, 0.32);
   --psi-grid-success-text: var(--badge-info-text);
   --psi-grid-negative: rgba(248, 113, 113, 0.35);
@@ -1372,6 +1374,11 @@ button.icon-button:focus-visible {
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
+.psi-rdg .rdg-cell.rdg-cell-focus.psi-grid-stock-warning {
+  background-color: var(--psi-bg-warning-hover) !important;
+  color: var(--psi-fg-warning);
+}
+
 .psi-grid-stock-warning:hover,
 .psi-grid-stock-warning:focus,
 .psi-grid-stock-warning:focus-within {
@@ -1385,6 +1392,11 @@ button.icon-button:focus-visible {
 }
 
 .psi-rdg .rdg-cell[aria-selected="true"].psi-grid-stock-warning {
+  background-color: var(--psi-bg-warning-select) !important;
+  color: var(--psi-fg-warning);
+}
+
+.psi-rdg .rdg-cell.rdg-cell-copied.psi-grid-stock-warning {
   background-color: var(--psi-bg-warning-select) !important;
   color: var(--psi-fg-warning);
 }

--- a/frontend/src/styles/palette.css
+++ b/frontend/src/styles/palette.css
@@ -54,7 +54,7 @@
   --surface-card: var(--palette-slate-850);
   --surface-inverted: var(--palette-white);
   --surface-info: var(--palette-ice-100);
-  --surface-warning: var(--palette-rose-50);
+  --surface-warning: #3b2f0c;
 
   --psi-bg-warning: #3b2f0c;
   --psi-bg-warning-hover: #4a3911;
@@ -110,6 +110,7 @@
 }
 
 :root[data-theme="dark"] {
+  --surface-warning: #3b2f0c;
   --psi-bg-warning: #3b2f0c;
   --psi-bg-warning-hover: #4a3911;
   --psi-bg-warning-select: #5c4718;
@@ -117,6 +118,7 @@
 }
 
 :root[data-theme="light"] {
+  --surface-warning: #fef3c7;
   --psi-bg-warning: #fef3c7;
   --psi-bg-warning-hover: #fde68a;
   --psi-bg-warning-select: #fcd34d;


### PR DESCRIPTION
## Summary
- align surface warning tokens with PSI warning palette per theme to avoid washed out backgrounds
- scope data grid variables so negative inventory cells keep PSI warning colors across hover, focus, selection, and copy states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d00b84e568832eb203120ea1ce4e69