### PR TITLE
Remove negative highlighting from PSI summary grid

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1442,6 +1442,22 @@ button.icon-button:focus-visible {
   z-index: 1;
 }
 
+.psi-summary-data-grid .rdg-row .rdg-cell {
+  background-color: var(--surface-table);
+}
+
+.psi-summary-data-grid
+  .rdg-row:nth-child(even):not(.psi-summary-row-selected)
+  .rdg-cell:not(.psi-summary-cell-selected) {
+  background-color: var(--surface-table-zebra);
+}
+
+.psi-summary-data-grid
+  .rdg-row:hover:not(.psi-summary-row-selected)
+  .rdg-cell:not(.psi-summary-cell-selected):not(.rdg-cell-editing):not([aria-selected="true"]) {
+  background-color: var(--psi-grid-hover);
+}
+
 .psi-summary-row-placeholder {
   background-color: transparent;
 }

--- a/frontend/src/components/PSISummaryTable.tsx
+++ b/frontend/src/components/PSISummaryTable.tsx
@@ -350,17 +350,10 @@ const PSISummaryTable = memo(function PSISummaryTable({
         return classNames("psi-grid-value-cell", "psi-summary-cell-placeholder");
       }
 
-      const rawValue = row[key];
-      const numericValue = typeof rawValue === "number" ? rawValue : null;
-      const isStockClosing = row.metricKey === "last_closing";
-      const isNegative = numericValue !== null && numericValue < 0;
-
       return classNames(
         "psi-grid-value-cell",
         row.groupPosition && `psi-grid-group-${row.groupPosition}`,
         row.isSelected && "psi-summary-cell-selected",
-        isNegative && "psi-grid-value-negative",
-        isStockClosing && isNegative && "psi-grid-stock-warning"
       );
     },
     []


### PR DESCRIPTION
## Summary
- stop applying the negative warning classes to PSI summary value cells so the grid no longer overrides zebra stripes
- add summary-grid-specific zebra and hover rules so the aggregate table keeps its alternating and hover styling without the highlight classes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0908c8fec832e81e719d19d1db772