### PR TITLE
Add PSI summary filtering UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -330,6 +330,74 @@ button.collapse-toggle:focus-visible {
   margin-bottom: 8px;
 }
 
+.psi-summary-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.psi-summary-subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-subtle);
+}
+
+.psi-summary-filter-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  min-width: min(320px, 100%);
+}
+
+.psi-summary-filter-label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-weight: 600;
+  width: 100%;
+}
+
+.psi-summary-filter-select {
+  width: 100%;
+  min-width: 220px;
+  background: var(--surface-body);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.psi-summary-filter-hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-subtle);
+  text-align: right;
+}
+
+.psi-summary-filter-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.psi-summary-filter-token {
+  background: rgba(59, 130, 246, 0.16);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+}
+
+.psi-summary-clear-filters {
+  align-self: flex-end;
+  padding-inline: 0.75rem;
+}
+
 .psi-pager,
 .psi-toolbar-pager {
   display: flex;

--- a/frontend/src/utils/psiSummaryFilters.ts
+++ b/frontend/src/utils/psiSummaryFilters.ts
@@ -1,0 +1,85 @@
+import { SummaryRow } from "./psiSummary";
+
+export type SummaryFilterDefinition = {
+  id: string;
+  label: string;
+  description: string;
+  predicate: (row: SummaryRow) => boolean;
+};
+
+const getChannelValues = (row: SummaryRow) => Object.values(row.channels);
+
+const sumOutbound = (row: SummaryRow) =>
+  getChannelValues(row).reduce((total, channel) => total + (channel.outbound_sum ?? 0), 0);
+
+const hasNegativeClosing = (row: SummaryRow) =>
+  getChannelValues(row).some((channel) => (channel.last_closing ?? 0) < 0);
+
+const hasSafetyShortage = (row: SummaryRow) =>
+  getChannelValues(row).some((channel) => {
+    const closing = channel.last_closing;
+    const safety = channel.last_safety_stock;
+    if (closing === null || safety === null) {
+      return false;
+    }
+    return closing < safety;
+  });
+
+const hasMovableStock = (row: SummaryRow) =>
+  getChannelValues(row).some((channel) => {
+    const movable = channel.last_movable_stock;
+    if (movable === null || movable === undefined) {
+      return false;
+    }
+    return movable > 0;
+  });
+
+export const summaryFilters: SummaryFilterDefinition[] = [
+  {
+    id: "outboundTotal>=1",
+    label: "出庫数量が1以上",
+    description: "いずれかのチャネルで出庫実績があるSKUを表示します。",
+    predicate: (row) => sumOutbound(row) >= 1,
+  },
+  {
+    id: "hasNegativeStockClosing",
+    label: "在庫残がマイナス",
+    description: "最新の在庫残高がマイナスのチャネルを含むSKUを表示します。",
+    predicate: (row) => hasNegativeClosing(row),
+  },
+  {
+    id: "safetyStockShortage",
+    label: "安全在庫を下回る",
+    description: "在庫残高が安全在庫を下回っているSKUを表示します。",
+    predicate: (row) => hasSafetyShortage(row),
+  },
+  {
+    id: "hasMovableStock",
+    label: "移動可能在庫あり",
+    description: "移動可能在庫が正の値のSKUを表示します。",
+    predicate: (row) => hasMovableStock(row),
+  },
+];
+
+const summaryFilterMap = new Map(summaryFilters.map((filter) => [filter.id, filter]));
+
+export function resolveSummaryFilter(id: string): SummaryFilterDefinition | undefined {
+  return summaryFilterMap.get(id);
+}
+
+export function applySummaryFilters(rows: SummaryRow[], filterIds: string[]): SummaryRow[] {
+  if (!filterIds.length) {
+    return rows;
+  }
+
+  const predicates = filterIds
+    .map((id) => summaryFilterMap.get(id))
+    .filter((filter): filter is SummaryFilterDefinition => Boolean(filter))
+    .map((filter) => filter.predicate);
+
+  if (!predicates.length) {
+    return rows;
+  }
+
+  return rows.filter((row) => predicates.every((predicate) => predicate(row)));
+}


### PR DESCRIPTION
## Summary
- add reusable PSI summary filter definitions and helpers for summary rows
- integrate multi-select filter controls into the PSI summary card and reset pagination/selection on filter changes
- style the new filter controls to match existing card layout and provide Japanese guidance text

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d091917378832eb41ef90ac860b4fc