### PR TITLE
Improve PSI summary filters dropdown

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -359,14 +359,92 @@ button.collapse-toggle:focus-visible {
   width: 100%;
 }
 
-.psi-summary-filter-select {
+.psi-summary-filter-dropdown {
+  position: relative;
+  width: 100%;
+}
+
+.psi-summary-filter-trigger {
   width: 100%;
   min-width: 220px;
-  background: var(--surface-body);
-  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
-  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  background: var(--surface-panel-soft);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.psi-summary-filter-trigger:hover {
+  background: var(--surface-panel);
+}
+
+.psi-summary-filter-trigger:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.psi-summary-filter-trigger-label {
+  flex: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.psi-summary-filter-trigger-icon {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.psi-summary-filter-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  gap: 0.5rem;
+  min-width: min(320px, 100%);
+  max-height: 240px;
+  padding: 0.75rem;
+  background: var(--surface-panel);
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
+  overflow-y: auto;
+  z-index: 40;
+}
+
+.psi-summary-filter-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-weight: 500;
+}
+
+.psi-summary-filter-option input {
+  margin-top: 0.2rem;
+}
+
+.psi-summary-filter-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.psi-summary-filter-option-label {
+  line-height: 1.3;
+}
+
+.psi-summary-filter-option-description {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
 }
 
 .psi-summary-filter-hint {


### PR DESCRIPTION
## Summary
- replace the summary filter list with a compact multi-select dropdown using checkboxes
- ensure SKU selections persist unless filters actually change and close the dropdown on outside interaction
- refresh the filter styles for the new dropdown menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d094ef3768832eaef841dfddd11190