### PR TITLE
Simplify PSI summary filter controls layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -320,11 +320,12 @@ button.collapse-toggle:focus-visible {
   display: grid;
   gap: 1rem;
   align-content: start;
+  text-align: left;
 }
 
 .psi-summary-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start !important;
   align-items: center;
   gap: 12px;
   margin-bottom: 8px;
@@ -344,29 +345,23 @@ button.collapse-toggle:focus-visible {
 
 .psi-summary-filter-controls {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 8px;
-  min-width: min(320px, 100%);
+  justify-content: flex-start;
+  align-items: center;
 }
 
-.psi-summary-filter-label {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-  font-weight: 600;
-  width: 100%;
+.psi-summary-filter-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .psi-summary-filter-dropdown {
   position: relative;
-  width: 100%;
 }
 
 .psi-summary-filter-trigger {
-  width: 100%;
   min-width: 220px;
+  width: auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -447,32 +442,12 @@ button.collapse-toggle:focus-visible {
   color: var(--text-secondary);
 }
 
-.psi-summary-filter-hint {
-  margin: 0;
-  font-size: 0.8125rem;
-  color: var(--text-subtle);
-  text-align: right;
-}
-
+.psi-summary-filter-hint,
 .psi-summary-filter-tokens {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  justify-content: flex-end;
-  width: 100%;
-}
-
-.psi-summary-filter-token {
-  background: rgba(59, 130, 246, 0.16);
-  border: 1px solid rgba(59, 130, 246, 0.35);
-  border-radius: 999px;
-  padding: 0.15rem 0.6rem;
-  font-size: 0.8125rem;
-  color: var(--text-primary);
+  display: none !important;
 }
 
 .psi-summary-clear-filters {
-  align-self: flex-end;
   padding-inline: 0.75rem;
 }
 

--- a/frontend/src/components/PSITableControls.tsx
+++ b/frontend/src/components/PSITableControls.tsx
@@ -103,8 +103,6 @@ const PSITableControls = forwardRef(function PSITableControls(
   const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(false);
   const pageSize = 3;
   const filterButtonId = useId();
-  const filterLabelId = `${filterButtonId}-label`;
-  const filterHintId = `${filterButtonId}-hint`;
   const filterDropdownRef = useRef<HTMLDivElement | null>(null);
   const filterButtonRef = useRef<HTMLButtonElement | null>(null);
   const firstFilterInputRef = useRef<HTMLInputElement | null>(null);
@@ -367,8 +365,7 @@ const PSITableControls = forwardRef(function PSITableControls(
                 <div className="psi-summary-title">
                 </div>
                 <div className="psi-summary-filter-controls">
-                  <div className="psi-summary-filter-label">
-                    <span id={filterLabelId}></span>
+                  <div className="psi-summary-filter-inline">
                     <div className="psi-summary-filter-dropdown" ref={filterDropdownRef}>
                       <button
                         type="button"
@@ -377,8 +374,7 @@ const PSITableControls = forwardRef(function PSITableControls(
                         className="psi-summary-filter-trigger"
                         aria-haspopup="true"
                         aria-expanded={isFilterMenuOpen}
-                        aria-labelledby={`${filterLabelId} ${filterButtonId}`}
-                        aria-describedby={selectedFilterDetails.length === 0 ? filterHintId : undefined}
+                        aria-label="フィルタを開く"
                         onClick={handleFilterMenuToggle}
                       >
                         <span className="psi-summary-filter-trigger-label">{filterSummaryLabel}</span>
@@ -387,7 +383,7 @@ const PSITableControls = forwardRef(function PSITableControls(
                         </span>
                       </button>
                       {isFilterMenuOpen && (
-                        <div className="psi-summary-filter-menu" role="group" aria-labelledby={filterLabelId}>
+                        <div className="psi-summary-filter-menu" role="group" aria-label="利用可能なフィルタ">
                           {summaryFilters.map((filter, index) => {
                             const checked = activeFilters.includes(filter.id);
                             return (
@@ -408,28 +404,16 @@ const PSITableControls = forwardRef(function PSITableControls(
                         </div>
                       )}
                     </div>
+                    {selectedFilterDetails.length > 0 && (
+                      <button
+                        type="button"
+                        className="psi-button secondary psi-summary-clear-filters"
+                        onClick={handleClearFilters}
+                      >
+                        フィルタをクリア
+                      </button>
+                    )}
                   </div>
-                  {selectedFilterDetails.length > 0 ? (
-                    <div className="psi-summary-filter-tokens" role="list">
-                      {selectedFilterDetails.map((filter) => (
-                        <span key={filter.id} className="psi-summary-filter-token" role="listitem" title={filter.description}>
-                          {filter.label}
-                        </span>
-                      ))}
-                    </div>
-                  ) : (
-                    <p id={filterHintId} className="psi-summary-filter-hint">
-                    </p>
-                  )}
-                  {selectedFilterDetails.length > 0 && (
-                    <button
-                      type="button"
-                      className="psi-button secondary psi-summary-clear-filters"
-                      onClick={handleClearFilters}
-                    >
-                      フィルタをクリア
-                    </button>
-                  )}
                 </div>
               </div>
               {sorted.length > 0 ? (


### PR DESCRIPTION
## Summary
- hide the PSI summary filter token UI and simplify the filter trigger accessibility attributes
- place the filter trigger and clear button together in a left-aligned inline layout
- update summary styles to enforce left alignment and hide legacy filter token elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0c3f72858832e93507ee618c99c3c