### PR TITLE
Configure CORS origins via settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,11 +12,40 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _split_csv_env(value: str | None) -> list[str]:
+    """Return a list of non-empty values from a comma separated string."""
+
+    if not value:
+        return []
+
+    parts = [item.strip() for item in value.split(",")]
+    return [item for item in parts if item]
+
+
+def _default_cors_allow_origins() -> list[str]:
+    """Return the default set of allowed CORS origins."""
+
+    env_value = os.getenv("CORS_ALLOW_ORIGINS")
+    if env_value is None:
+        return [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ]
+
+    return _split_csv_env(env_value)
+
+
 class Settings(BaseModel):
     """Runtime configuration loaded from environment variables."""
 
     database_url: str = Field(default_factory=lambda: os.getenv("DATABASE_URL", ""))
     db_schema: str = Field(default_factory=lambda: os.getenv("DB_SCHEMA", "public"))
+    cors_allow_origins: list[str] = Field(default_factory=_default_cors_allow_origins)
+    cors_allow_origin_regex: str | None = Field(
+        default_factory=lambda: os.getenv("CORS_ALLOW_ORIGIN_REGEX")
+    )
 
     @field_validator("database_url", mode="before")
     @classmethod

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -18,7 +18,7 @@
 - **ORM / DB アクセス**: SQLAlchemy 2 系 Declarative。
 - **マイグレーション**: Alembic。
 - **設定**: `pydantic` + `.env` 読み込み (python-dotenv)。
-- **API**: RESTful。CORS 設定はワイルドカード許容でフロントエンドのホスト制限なし。
+- **API**: RESTful。CORS 設定は `CORS_ALLOW_ORIGINS` / `CORS_ALLOW_ORIGIN_REGEX` で管理し、既定ではローカル開発用オリジンのみを許可。
 - **静的配信**: `backend/static/` 配下にビルド成果物を配置すると、FastAPI アプリが SPA として配信 (SPA ルーティングフォールバックあり)。
 
 ### データベース


### PR DESCRIPTION
## Summary
- load CORS origin settings from environment variables with sensible local defaults
- adjust FastAPI middleware setup to enable credentials only for explicit origins or fall back to regex/closed policies
- document the new configuration knobs in the system overview

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0cf6643d8832e872bc442138b8d57