### PR TITLE
Add cookie-based authentication and frontend login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Backend configuration
+DATABASE_URL=postgresql+psycopg2://user:password@localhost:5432/psi_erp
+DB_SCHEMA=psi
+SESSION_SIGN_KEY=change-this-session-signing-key
+SECRET_KEY=change-this-secret
+ALLOWED_ORIGINS=http://localhost:5173
+SESSION_COOKIE_NAME=session
+SESSION_COOKIE_DOMAIN=
+SESSION_COOKIE_SAMESITE=lax
+SESSION_COOKIE_SECURE=false
+SESSION_TTL_SECONDS=3600
+CSRF_ENABLED=false
+LOGIN_MAX_ATTEMPTS=5
+LOGIN_BLOCK_SECONDS=300
+
+# Frontend configuration
+VITE_API_BASE_URL=http://127.0.0.1:8000

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: cd backend && alembic upgrade head
-web: gunicorn -k uvicorn.workers.UvicornWorker --chdir backend app.main:app --bind 0.0.0.0:$PORT --timeout 120
+web: uvicorn app.main:app --host=0.0.0.0 --port=${PORT} --proxy-headers

--- a/backend/alembic/versions/0004_create_users_table.py
+++ b/backend/alembic/versions/0004_create_users_table.py
@@ -1,0 +1,41 @@
+"""create users table for authentication"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from app.config import settings
+
+# revision identifiers, used by Alembic.
+revision = "0004_create_users_table"
+down_revision = "0003_create_channel_transfers_table"
+branch_labels = None
+depends_on = None
+
+SCHEMA = settings.db_schema or None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("username", sa.String(length=150), nullable=False),
+        sa.Column("password_hash", sa.Text(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_users_username",
+        "users",
+        ["username"],
+        unique=True,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_users_username", table_name="users", schema=SCHEMA)
+    op.drop_table("users", schema=SCHEMA)

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,20 +1,22 @@
-# backend/app/deps.py
-
 """Shared FastAPI dependencies."""
 from __future__ import annotations
 
 from collections.abc import Generator
-import os
-from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
+import uuid
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from . import models
 from .config import settings
+from .security import load_session, session_signature_from_hash
 
 connect_args = (
     {"options": f"-c search_path={settings.db_schema},public"}
-    if settings.db_schema else {}
+    if settings.db_schema
+    else {}
 )
 
 # ✅ DB URL 正規化（Heroku の postgres:// → postgresql+psycopg://）
@@ -40,8 +42,41 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, futu
 
 def get_db() -> Generator[Session, None, None]:
     """Yield a SQLAlchemy session scoped to the request."""
+
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
+
+def get_current_user(
+    request: Request, db: Session = Depends(get_db)
+) -> models.User:
+    """Return the authenticated user derived from the session cookie."""
+
+    token = request.cookies.get(settings.session_cookie_name)
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="not authenticated")
+
+    data = load_session(token)
+    if not data:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid session")
+
+    user_id = data.get("uid")
+    password_signature = data.get("pwd")
+
+    try:
+        uuid_val = uuid.UUID(str(user_id))
+    except (ValueError, TypeError):  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid session")
+
+    user = db.get(models.User, uuid_val)
+    if not user or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid session")
+
+    expected_signature = session_signature_from_hash(user.password_hash)
+    if password_signature != expected_signature:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid session")
+
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,18 +3,29 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, FileResponse, PlainTextResponse
+from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
 
-from .routers import channel_transfers, masters, psi, sessions
+from .config import settings
+from .middleware import CSRFMiddleware, SecurityHeadersMiddleware
+from .routers import auth, channel_transfers, masters, psi, sessions
 
 app = FastAPI(title="GEN-like PSI API")
 
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+app.add_middleware(SecurityHeadersMiddleware)
+if settings.csrf_enabled:
+    app.add_middleware(CSRFMiddleware)
+
+cors_origins = settings.allowed_origins
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=cors_origins,
+    allow_origin_regex=None,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -22,6 +33,7 @@ app.add_middleware(
 
 # ========= 1) API を最初に登録 =========
 # 既存の互換エンドポイント
+app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(sessions.router, prefix="/sessions", tags=["sessions"])
 app.include_router(masters.router,  prefix="/masters",  tags=["masters"])
 app.include_router(psi.router,      prefix="/psi",      tags=["psi"])
@@ -32,6 +44,7 @@ app.include_router(
 )
 
 # /api 配下にもミラー（フロントが /api/* を叩いてもOKに）
+app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(sessions.router, prefix="/api/sessions", tags=["sessions"])
 app.include_router(masters.router,  prefix="/api/masters",  tags=["masters"])
 app.include_router(psi.router,      prefix="/api/psi",      tags=["psi"])
@@ -75,6 +88,7 @@ API_PREFIXES = (
     "masters",
     "psi",
     "channel-transfers",
+    "auth",
     "health",
     "assets",
     "favicon.ico",

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,54 @@
+"""Custom FastAPI middlewares for security headers and CSRF."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .config import settings
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach a strict set of security related headers to all responses."""
+
+    def __init__(self, app, *, csp: str | None = None) -> None:  # type: ignore[override]
+        super().__init__(app)
+        self.csp = csp or "default-src 'self'; frame-ancestors 'none'; form-action 'self'"
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        response: Response = await call_next(request)
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload"
+        )
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        response.headers.setdefault("Content-Security-Policy", self.csp)
+        return response
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Minimal double submit cookie CSRF protection."""
+
+    safe_methods: Iterable[str] = {"GET", "HEAD", "OPTIONS"}
+
+    def __init__(self, app):  # type: ignore[override]
+        super().__init__(app)
+        self.header_name = settings.csrf_header.lower()
+        self.cookie_name = settings.csrf_cookie_name
+        self.exempt_paths = {
+            "/auth/login",
+            "/api/auth/login",
+        }
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if (
+            request.method.upper() not in self.safe_methods
+            and request.url.path not in self.exempt_paths
+        ):
+            cookie_token = request.cookies.get(self.cookie_name)
+            header_token = request.headers.get(self.header_name)
+            if not cookie_token or not header_token or cookie_token != header_token:
+                return Response(status_code=403, content="CSRF validation failed")
+        return await call_next(request)

--- a/backend/app/requirements.txt
+++ b/backend/app/requirements.txt
@@ -1,5 +1,7 @@
 alembic==1.13.3
+argon2-cffi==23.1.0
 fastapi==0.115.0
+passlib[argon2]==1.7.4
 psycopg2-binary==2.9.9
 python-dotenv==1.0.1
 python-multipart==0.0.9

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,119 @@
+"""Authentication endpoints for username/password login."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..config import settings
+from ..deps import get_current_user, get_db
+from ..security import (
+    LoginRateLimiter,
+    create_session_payload,
+    generate_csrf_token,
+    rate_limiter_factory,
+    sign_session,
+    verify_password,
+)
+
+router = APIRouter()
+_login_rate_limiter: LoginRateLimiter = rate_limiter_factory()
+
+
+def _client_key(request: Request, username: str) -> str:
+    host = request.client.host if request.client else "unknown"
+    return f"{host}:{username.lower()}"
+
+
+@router.post("/login", response_model=schemas.LoginResult)
+def login(
+    payload: schemas.LoginRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> schemas.LoginResult:
+    """Validate credentials and issue a signed session cookie."""
+
+    key = _client_key(request, payload.username)
+    if not _login_rate_limiter.can_attempt(key):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="too many failed attempts, please try again later",
+        )
+
+    stmt = select(models.User).where(models.User.username == payload.username)
+    user = db.scalars(stmt).first()
+
+    if not user or not user.is_active or not verify_password(payload.password, user.password_hash):
+        _login_rate_limiter.register_failure(key)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid credentials")
+
+    _login_rate_limiter.reset(key)
+
+    user.last_login_at = datetime.now(timezone.utc)
+    db.add(user)
+    db.commit()
+
+    payload_data = create_session_payload(str(user.id), user.password_hash)
+    token = sign_session(payload_data)
+
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=token,
+        max_age=settings.session_ttl_seconds,
+        httponly=True,
+        secure=settings.session_cookie_secure,
+        samesite=settings.normalized_samesite,
+        domain=settings.session_cookie_domain,
+        path="/",
+    )
+
+    csrf_token: str | None = None
+    if settings.csrf_enabled:
+        csrf_token = generate_csrf_token()
+        response.set_cookie(
+            key=settings.csrf_cookie_name,
+            value=csrf_token,
+            max_age=settings.session_ttl_seconds,
+            httponly=False,
+            secure=settings.session_cookie_secure,
+            samesite=settings.normalized_samesite,
+            domain=settings.session_cookie_domain,
+            path="/",
+        )
+        response.headers[settings.csrf_header] = csrf_token
+
+    return schemas.LoginResult(next="authenticated", csrf_token=csrf_token)
+
+
+@router.get("/me", response_model=schemas.UserProfile)
+def me(current_user: models.User = Depends(get_current_user)) -> schemas.UserProfile:
+    """Return the profile of the authenticated user."""
+
+    return schemas.UserProfile(
+        id=current_user.id,
+        username=current_user.username,
+        is_active=current_user.is_active,
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+def logout(response: Response) -> Response:
+    """Invalidate the session cookie for the current browser."""
+
+    response.delete_cookie(
+        key=settings.session_cookie_name,
+        domain=settings.session_cookie_domain,
+        path="/",
+    )
+    if settings.csrf_enabled:
+        response.delete_cookie(
+            key=settings.csrf_cookie_name,
+            domain=settings.session_cookie_domain,
+            path="/",
+        )
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -173,3 +173,27 @@ class ChannelTransferRead(ChannelTransferBase):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class LoginRequest(BaseModel):
+    """Login payload for username/password authentication."""
+
+    username: Annotated[str, Field(min_length=1, max_length=150)]
+    password: Annotated[str, Field(min_length=1, max_length=256)]
+
+
+class LoginResult(BaseModel):
+    """Response returned after a successful login attempt."""
+
+    next: str = "authenticated"
+    csrf_token: str | None = None
+
+
+class UserProfile(BaseModel):
+    """Authenticated user information."""
+
+    id: UUID
+    username: str
+    is_active: bool
+
+    model_config = {"from_attributes": True}

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,159 @@
+"""Authentication helpers (password hashing, session handling, rate limiting)."""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import secrets
+import threading
+import time
+from typing import Any
+
+from passlib.context import CryptContext
+
+from .config import settings
+
+_pwd_context = CryptContext(schemes=["argon2", "bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Return a secure hash for ``password``."""
+
+    return _pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Return ``True`` if ``password`` matches ``hashed``."""
+
+    try:
+        return _pwd_context.verify(password, hashed)
+    except ValueError:
+        return False
+
+
+def _password_signature(password_hash: str) -> str:
+    digest = hashlib.sha256(password_hash.encode("utf-8")).hexdigest()
+    return digest[:32]
+
+
+def session_signature_from_hash(password_hash: str) -> str:
+    """Return the deterministic signature stored in session tokens."""
+
+    return _password_signature(password_hash)
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode((data + padding).encode("ascii"))
+
+
+def _sign_payload(payload: bytes) -> bytes:
+    key = settings.session_sign_key.encode("utf-8")
+    return hmac.new(key, payload, hashlib.sha256).digest()
+
+
+def sign_session(data: dict[str, Any]) -> str:
+    """Return a signed session string."""
+
+    payload = json.dumps(data, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    signature = _sign_payload(payload)
+    return f"{_b64encode(payload)}.{_b64encode(signature)}"
+
+
+def create_session_payload(user_id: str, password_hash: str) -> dict[str, Any]:
+    """Return the payload embedded inside the signed session token."""
+
+    return {
+        "uid": user_id,
+        "sid": secrets.token_urlsafe(16),
+        "pwd": _password_signature(password_hash),
+        "iat": int(time.time()),
+    }
+
+
+def load_session(token: str) -> dict[str, Any] | None:
+    """Decode and verify ``token`` returning the original payload."""
+
+    try:
+        payload_b64, signature_b64 = token.split(".", 1)
+        payload_bytes = _b64decode(payload_b64)
+        signature_bytes = _b64decode(signature_b64)
+    except (ValueError, binascii.Error):
+        return None
+
+    expected_signature = _sign_payload(payload_bytes)
+    if not hmac.compare_digest(expected_signature, signature_bytes):
+        return None
+
+    try:
+        data = json.loads(payload_bytes)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    issued_at = data.get("iat")
+    if not isinstance(issued_at, (int, float)):
+        return None
+
+    if time.time() - float(issued_at) > settings.session_ttl_seconds:
+        return None
+
+    return data
+
+
+def generate_csrf_token() -> str:
+    """Return a cryptographically random CSRF token."""
+
+    return secrets.token_urlsafe(32)
+
+
+class LoginRateLimiter:
+    """In-memory rate limiter intended for login attempts."""
+
+    def __init__(self, max_attempts: int, block_seconds: int) -> None:
+        self.max_attempts = max_attempts
+        self.block_seconds = block_seconds
+        self._lock = threading.Lock()
+        self._attempts: dict[str, list[float]] = {}
+
+    def _cleanup(self, now: float) -> None:
+        expire_before = now - self.block_seconds
+        for key, timestamps in list(self._attempts.items()):
+            filtered = [ts for ts in timestamps if ts > expire_before]
+            if filtered:
+                self._attempts[key] = filtered
+            else:
+                self._attempts.pop(key, None)
+
+    def can_attempt(self, key: str, now: float | None = None) -> bool:
+        """Return ``True`` if ``key`` is allowed to attempt a login."""
+
+        current = now or time.monotonic()
+        with self._lock:
+            self._cleanup(current)
+            attempts = self._attempts.get(key, [])
+            return len(attempts) < self.max_attempts
+
+    def register_failure(self, key: str, now: float | None = None) -> None:
+        current = now or time.monotonic()
+        with self._lock:
+            self._cleanup(current)
+            self._attempts.setdefault(key, []).append(current)
+
+    def reset(self, key: str) -> None:
+        with self._lock:
+            self._attempts.pop(key, None)
+
+
+def rate_limiter_factory() -> LoginRateLimiter:
+    """Return a configured :class:`LoginRateLimiter` instance."""
+
+    return LoginRateLimiter(settings.login_max_attempts, settings.login_block_seconds)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,147 @@
+"""Authentication flow tests without relying on httpx."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+DB_FILE = Path(__file__).parent / "auth_test.db"
+if DB_FILE.exists():
+    DB_FILE.unlink()
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("DATABASE_URL", f"sqlite+pysqlite:///{DB_FILE}")
+os.environ.setdefault("DB_SCHEMA", "")
+os.environ.setdefault("SESSION_SIGN_KEY", "test-sign-key")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("ALLOWED_ORIGINS", "http://testserver")
+os.environ.setdefault("SESSION_COOKIE_SECURE", "false")
+os.environ.setdefault("SESSION_COOKIE_SAMESITE", "lax")
+os.environ.setdefault("SESSION_TTL_SECONDS", "300")
+os.environ.setdefault("CSRF_ENABLED", "false")
+os.environ.setdefault("LOGIN_MAX_ATTEMPTS", "3")
+os.environ.setdefault("LOGIN_BLOCK_SECONDS", "60")
+
+for module in list(sys.modules):
+    if module.startswith("backend.app"):
+        sys.modules.pop(module)
+
+from backend.app import models
+from backend.app.config import settings
+from backend.app.deps import SessionLocal, engine, get_current_user
+from backend.app.routers import auth
+from backend.app.schemas import LoginRequest
+from backend.app.security import hash_password
+
+models.Base.metadata.drop_all(bind=engine)
+models.Base.metadata.create_all(bind=engine)
+
+
+def create_user(username: str, password: str) -> None:
+    with SessionLocal() as session:
+        session.add(models.User(username=username, password_hash=hash_password(password)))
+        session.commit()
+
+
+def make_request(path: str, method: str = "POST", cookie: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if cookie:
+        headers.append((b"cookie", cookie.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers,
+        "query_string": b"",
+        "client": ("127.0.0.1", 12345),
+    }
+
+    async def receive() -> dict[str, str]:  # pragma: no cover - FastAPI expects async callable
+        return {"type": "http.request"}
+
+    return Request(scope, receive)
+
+
+def extract_session_cookie(header_value: str) -> str:
+    parts = header_value.split(",")
+    for part in parts:
+        if part.strip().startswith(f"{settings.session_cookie_name}="):
+            return part.split(";", 1)[0]
+    raise AssertionError("session cookie not present")
+
+
+def test_login_and_me_flow():
+    create_user("alice", "wonderland")
+
+    response = Response()
+    request = make_request("/auth/login")
+    with SessionLocal() as session:
+        login_result = auth.login(
+            payload=LoginRequest(username="alice", password="wonderland"),
+            request=request,
+            response=response,
+            db=session,
+        )
+
+    assert login_result.next == "authenticated"
+    cookie_header = response.headers.get("set-cookie")
+    assert cookie_header is not None
+    cookie_kv = extract_session_cookie(cookie_header)
+
+    me_request = make_request("/auth/me", method="GET", cookie=cookie_kv)
+    with SessionLocal() as session:
+        current_user = get_current_user(me_request, db=session)
+    profile = auth.me(current_user=current_user)
+    assert profile.username == "alice"
+    assert profile.is_active is True
+
+    logout_response = Response()
+    auth.logout(logout_response)
+    assert settings.session_cookie_name in logout_response.headers.get("set-cookie", "")
+
+    unauth_request = make_request("/auth/me", method="GET")
+    try:
+        with SessionLocal() as session:
+            get_current_user(unauth_request, db=session)
+    except Exception as exc:  # noqa: BLE001
+        assert "invalid session" in str(exc)
+    else:  # pragma: no cover - should not happen
+        raise AssertionError("Expected authentication failure")
+
+
+def test_rate_limiting_blocks_after_failures():
+    create_user("bob", "builder")
+    for _ in range(3):
+        response = Response()
+        request = make_request("/auth/login")
+        try:
+            with SessionLocal() as session:
+                auth.login(
+                    payload=LoginRequest(username="bob", password="wrong"),
+                    request=request,
+                    response=response,
+                    db=session,
+                )
+        except Exception as exc:  # noqa: BLE001
+            assert "invalid credentials" in str(exc)
+
+    blocked_response = Response()
+    blocked_request = make_request("/auth/login")
+    try:
+        with SessionLocal() as session:
+            auth.login(
+                payload=LoginRequest(username="bob", password="wrong"),
+                request=blocked_request,
+                response=blocked_response,
+                db=session,
+            )
+    except Exception as exc:  # noqa: BLE001
+        assert "too many failed attempts" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected rate limiting to trigger")

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -38,6 +38,15 @@ body {
   min-height: 100vh;
 }
 
+.app-loading {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.125rem;
+  color: var(--text-secondary, var(--text-primary));
+}
+
 
 .sidebar {
   width: 240px;
@@ -56,11 +65,48 @@ body {
   padding: 1.5rem 0.75rem;
 }
 
+.sidebar.collapsed .sidebar-user {
+  align-items: center;
+}
+
+.sidebar.collapsed .sidebar-user .user-name {
+  display: none;
+}
+
 .sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+}
+
+.sidebar-user {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.sidebar-user .user-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.logout-button {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.logout-button:hover {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .sidebar-toggle {

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,118 @@
+import { AxiosError } from "axios";
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  fetchMe,
+  login as loginRequest,
+  logout as logoutRequest,
+  LoginPayload,
+  UserProfile,
+} from "../lib/auth";
+
+interface AuthContextValue {
+  user: UserProfile | null;
+  isLoading: boolean;
+  error: string | null;
+  login: (payload: LoginPayload) => Promise<void>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function normalizeError(error: unknown): string {
+  if (error instanceof AxiosError) {
+    return (
+      (error.response?.data as { detail?: string } | undefined)?.detail ??
+      error.message
+    );
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "An unknown error occurred";
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function bootstrap() {
+      try {
+        const profile = await fetchMe();
+        if (!cancelled) {
+          setUser(profile);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setUser(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+    bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const profile = await fetchMe();
+      setUser(profile);
+      setError(null);
+    } catch (err) {
+      const message = normalizeError(err);
+      setUser(null);
+      setError(message);
+      throw new Error(message);
+    }
+  }, []);
+
+  const login = useCallback(async (payload: LoginPayload) => {
+    setError(null);
+    try {
+      await loginRequest(payload);
+      await refresh();
+    } catch (err) {
+      const message = normalizeError(err);
+      setError(message);
+      throw new Error(message);
+    }
+  }, [refresh]);
+
+  const logout = useCallback(async () => {
+    await logoutRequest();
+    setUser(null);
+    setError(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({ user, isLoading, error, login, logout, refresh }),
+    [user, isLoading, error, login, logout, refresh],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,5 +16,9 @@ if (typeof console !== "undefined") {
 
 export const api = axios.create({
   baseURL,
-  headers: { "Content-Type": "application/json" }
+  headers: { "Content-Type": "application/json" },
+  withCredentials: true,
 });
+
+api.defaults.xsrfCookieName = "csrf_token";
+api.defaults.xsrfHeaderName = "X-CSRF-Token";

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,31 @@
+import { api } from "./api";
+
+export interface LoginPayload {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  next: string;
+  csrf_token?: string;
+}
+
+export interface UserProfile {
+  id: string;
+  username: string;
+  is_active: boolean;
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  const { data } = await api.post<LoginResponse>("/auth/login", payload);
+  return data;
+}
+
+export async function fetchMe(): Promise<UserProfile> {
+  const { data } = await api.get<UserProfile>("/auth/me");
+  return data;
+}
+
+export async function logout(): Promise<void> {
+  await api.post("/auth/logout");
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import App from "./App";
 import "./styles/palette.css";
 import "./App.css";
 import "react-data-grid/lib/styles.css";
+import { AuthProvider } from "./hooks/useAuth";
 
 const queryClient = new QueryClient();
 
@@ -14,7 +15,9 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,74 @@
+import { FormEvent, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useAuth } from "../hooks/useAuth";
+import "../styles/forms.css";
+
+interface LocationState {
+  from?: string;
+}
+
+export default function LoginPage() {
+  const { login, error, isLoading } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const fromState = (location.state as LocationState | undefined)?.from;
+  const redirectTo = fromState && !fromState.startsWith("/login") ? fromState : "/sessions";
+
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setLocalError(null);
+    try {
+      await login({ username, password });
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      setLocalError((err as Error).message ?? "Login failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const message = localError ?? error;
+
+  return (
+    <div className="login-page">
+      <form className="login-form" onSubmit={handleSubmit}>
+        <h1>PSI ERP Login</h1>
+        <label htmlFor="username">
+          Username
+          <input
+            id="username"
+            name="username"
+            type="text"
+            autoComplete="username"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            required
+          />
+        </label>
+        <label htmlFor="password">
+          Password
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </label>
+        {message ? <p className="form-error" role="alert">{message}</p> : null}
+        <button type="submit" disabled={submitting || isLoading}>
+          {submitting ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -1,0 +1,77 @@
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(14, 116, 144, 0.16));
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.login-form {
+  width: min(360px, 100%);
+  background: rgba(17, 24, 39, 0.92);
+  color: #fff;
+  padding: 2.5rem 2rem;
+  border-radius: 1rem;
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.login-form h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.login-form label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.login-form input {
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.85);
+  color: inherit;
+  font: inherit;
+}
+
+.login-form input:focus {
+  outline: 2px solid rgba(129, 140, 248, 0.75);
+  outline-offset: 2px;
+}
+
+.login-form button {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #4f46e5, #0ea5e9);
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.login-form button:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.login-form button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.35);
+}
+
+.form-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+  font-size: 0.95rem;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,7 @@ websockets==15.0.1
 gunicorn==21.2.0
 uvicorn[standard]==0.30.6   # なければ入れておくと安心
 psycopg[binary]==3.2.3
+passlib[argon2]==1.7.4
+argon2-cffi==23.1.0
 
 ##


### PR DESCRIPTION
## Summary
- implement configurable session, CORS, and security settings plus new auth router for login, profile, and logout
- add Argon2 password hashing, signed cookie sessions, rate limiting, and Alembic migration for psi.users
- introduce React auth context, login page, protected routes, and axios client updates for credentialed requests
- document environment variables, setup flow, and provide pytest coverage and curl-based verification steps

## Testing
- `pytest backend/tests/test_auth.py` *(fails: missing passlib dependency due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d8342a7c832ea430e622a9539ad4