### PR TITLE
Fix local auth session cookies and CORS handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_API_BASE=http://127.0.0.1:8000
+VITE_API_BASE=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ node_modules/
 dist/
 frontend/node_modules/
 frontend/dist/
+.auth_test.db
+backend/tests/auth_test.db
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
    | `DATABASE_URL` | PostgreSQL connection string (SQLAlchemy compatible). |
    | `DB_SCHEMA` | Database schema (defaults to `psi`). |
    | `SESSION_SIGN_KEY` / `SECRET_KEY` | Random strings used to sign session payloads. |
-   | `ALLOWED_ORIGINS` | Comma separated list of front-end origins (e.g. `http://localhost:5173`). |
-   | `SESSION_COOKIE_SECURE` | Set to `false` for local HTTP, keep `true` for HTTPS/Heroku. |
+   | `ALLOWED_ORIGINS` | Comma separated list of front-end origins (e.g. `http://localhost:5173,http://localhost:5174`). |
+   | `SESSION_COOKIE_SECURE` | Defaults to `false` locally. Set to `true` only when serving over HTTPS. |
 
 2. **Install backend dependencies**
 
@@ -84,31 +84,31 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
    npm run dev
    ```
 
-   The Vite dev server runs on <http://localhost:5173>. Ensure this origin is present in `ALLOWED_ORIGINS` so that cookies can be shared when using `credentials: 'include'`.
+   The Vite dev server runs on <http://localhost:5173>. If you open a second instance (e.g. Vite preview) it usually listens on <http://localhost:5174>. Ensure both origins are present in `ALLOWED_ORIGINS` so that cookies can be shared when using `credentials: 'include'`.
 
 ## Authentication API quick check
 
 1. **Login**
 
    ```bash
-   curl -i -X POST http://127.0.0.1:8000/auth/login \
+   curl -i -X POST http://localhost:8000/auth/login \
      -H "Content-Type: application/json" \
      -d '{"username":"admin","password":"changeme!"}'
    ```
 
-   A `Set-Cookie: session=...; HttpOnly; Secure` header is returned on success.
+   A `Set-Cookie: session=...; HttpOnly; Path=/; SameSite=Lax` header is returned on success.
 
 2. **Fetch the profile**
 
    ```bash
-   curl -i http://127.0.0.1:8000/auth/me \
+   curl -i http://localhost:8000/auth/me \
      --cookie "session=<value from login>"
    ```
 
 3. **Logout**
 
    ```bash
-   curl -i -X POST http://127.0.0.1:8000/auth/logout \
+   curl -i -X POST http://localhost:8000/auth/logout \
      --cookie "session=<value from login>"
    ```
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,6 +27,15 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from .config import settings
 
 
+def _qualified(table: str, column: str = "id") -> str:
+    """Return a fully qualified table reference respecting the schema."""
+
+    schema = settings.db_schema.strip()
+    if schema:
+        return f"{schema}.{table}.{column}"
+    return f"{table}.{column}"
+
+
 class Base(DeclarativeBase):
     """Declarative base that is aware of the configured schema."""
 
@@ -135,7 +144,7 @@ class PSIBase(Base, SchemaMixin):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     session_id: Mapped[uuid.UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey(f"{settings.db_schema}.sessions.id", ondelete="CASCADE"),
+        ForeignKey(_qualified("sessions"), ondelete="CASCADE"),
         nullable=False,
     )
     sku_code: Mapped[str] = mapped_column(Text, nullable=False)
@@ -168,7 +177,7 @@ class PSIEdit(Base, SchemaMixin, TimestampMixin):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     session_id: Mapped[uuid.UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey(f"{settings.db_schema}.sessions.id", ondelete="CASCADE"),
+        ForeignKey(_qualified("sessions"), ondelete="CASCADE"),
         nullable=False,
     )
     sku_code: Mapped[str] = mapped_column(Text, nullable=False)
@@ -190,7 +199,7 @@ class PSIEditLog(Base, SchemaMixin):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     session_id: Mapped[uuid.UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey(f"{settings.db_schema}.sessions.id", ondelete="CASCADE"),
+        ForeignKey(_qualified("sessions"), ondelete="CASCADE"),
         nullable=False,
     )
     sku_code: Mapped[str] = mapped_column(Text, nullable=False)
@@ -225,7 +234,7 @@ class ChannelTransfer(Base, SchemaMixin, TimestampMixin):
 
     session_id: Mapped[uuid.UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey(f"{settings.db_schema}.sessions.id", ondelete="CASCADE"),
+        ForeignKey(_qualified("sessions"), ondelete="CASCADE"),
         primary_key=True,
         nullable=False,
     )


### PR DESCRIPTION
## Summary
- default CORS settings now include localhost dev ports and normalize SameSite and cookie domain handling
- add a simple password hashing fallback and schema-qualified FK helper so auth flows run in lightweight test environments
- extend auth tests and docs to validate cookie attributes, localhost CORS preflight and localhost API base URL

## Testing
- pytest backend/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e25917f8832e81d5eb553aa28c81