### PR TITLE
Handle invalid password hashes gracefully

### DIFF
--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -50,7 +50,7 @@ def verify_password(password: str, hashed: str) -> bool:
 
     try:
         return _pwd_context.verify(password, hashed)
-    except ValueError:
+    except (TypeError, ValueError):
         return False
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -40,7 +40,7 @@ from backend.app.config import settings
 from backend.app.deps import SessionLocal, engine, get_current_user
 from backend.app.routers import auth
 from backend.app.schemas import LoginRequest
-from backend.app.security import hash_password
+from backend.app.security import hash_password, verify_password
 from backend.app.main import app
 import asyncio
 
@@ -193,3 +193,8 @@ def test_cors_preflight_allows_localhost_origins():
     assert start_message["status"] == 200
     assert headers.get("access-control-allow-origin") == "http://localhost:5173"
     assert headers.get("access-control-allow-credentials") == "true"
+
+
+def test_verify_password_handles_invalid_hash_gracefully():
+    # ``verify_password`` should not propagate exceptions for malformed hashes
+    assert verify_password("any", "argon2$invalid") is False


### PR DESCRIPTION
## Summary
- prevent verify_password from raising TypeError when passlib cannot parse an invalid hash
- add a regression test ensuring malformed hashes are treated as authentication failures

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d0e468281c832ebcd535d9c1cbaf9f