### PR TITLE
Expand default CORS origins and document LAN setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ DATABASE_URL=postgresql+psycopg2://user:password@localhost:5432/psi_erp
 DB_SCHEMA=psi
 SESSION_SIGN_KEY=change-this-session-signing-key
 SECRET_KEY=change-this-secret
-ALLOWED_ORIGINS=http://localhost:5173
+# Include any LAN-accessible Vite origins here (e.g. http://192.168.11.64:5174)
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174,http://127.0.0.1:5173,http://127.0.0.1:5174
 SESSION_COOKIE_NAME=session
 SESSION_COOKIE_DOMAIN=
 SESSION_COOKIE_SAMESITE=lax

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
    | `DB_SCHEMA` | Database schema (defaults to `psi`). |
    | `SESSION_SIGN_KEY` / `SECRET_KEY` | Random strings used to sign session payloads. |
    | `ALLOWED_ORIGINS` | Comma separated list of front-end origins (e.g. `http://localhost:5173,http://localhost:5174`). |
+
+   > 📡 When you access the frontend from another device on your LAN, you **must** include that device's Vite origin in
+   > `ALLOWED_ORIGINS` (for example: `http://localhost:5173,http://localhost:5174,http://127.0.0.1:5173,http://127.0.0.1:5174,http://192.168.11.64:5174`).
+   > Otherwise, cross-origin cookies and authentication requests will be blocked by the browser.
    | `SESSION_COOKIE_SECURE` | Defaults to `false` locally. Set to `true` only when serving over HTTPS. |
 
 2. **Install backend dependencies**
@@ -84,7 +88,7 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
    npm run dev
    ```
 
-   The Vite dev server runs on <http://localhost:5173>. If you open a second instance (e.g. Vite preview) it usually listens on <http://localhost:5174>. Ensure both origins are present in `ALLOWED_ORIGINS` so that cookies can be shared when using `credentials: 'include'`.
+   The Vite dev server runs on <http://localhost:5173>. If you open a second instance (e.g. Vite preview) it usually listens on <http://localhost:5174>. Ensure both origins are present in `ALLOWED_ORIGINS` so that cookies can be shared when using `credentials: 'include'`. When exposing the dev server over your LAN (e.g. <http://192.168.11.64:5174>), append that host to `ALLOWED_ORIGINS` as well.
 
 ## Authentication API quick check
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -136,14 +136,21 @@ class Settings(BaseModel):
     def allowed_origins(self) -> list[str]:
         """Return a sanitized list of allowed CORS origins."""
 
+        default_origins = [
+            "http://localhost:5173",
+            "http://localhost:5174",
+            "http://127.0.0.1:5173",
+            "http://127.0.0.1:5174",
+        ]
+
         if not self.allowed_origins_raw:
-            return ["http://localhost:5173", "http://localhost:5174"]
+            return default_origins
 
         parts = [part.strip() for part in self.allowed_origins_raw.split(",")]
         origins = [part for part in parts if part]
 
         if not origins:
-            return ["http://localhost:5173", "http://localhost:5174"]
+            return default_origins
 
         return origins
 


### PR DESCRIPTION
## Summary
- extend the default FastAPI CORS origins to cover localhost and 127.0.0.1 Vite ports
- document the need to set ALLOWED_ORIGINS when serving the frontend over LAN and include examples
- expand the sample environment file with LAN guidance and default localhost/127 origins

## Testing
- pytest backend/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e64ec3f0832ebd90b8bd2ce519b1