### PR TITLE
Ensure axios sends credentials for session-based auth

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,5 +16,7 @@ if (typeof console !== "undefined") {
 
 export const api = axios.create({
   baseURL,
-  headers: { "Content-Type": "application/json" }
+  headers: { "Content-Type": "application/json" },
+  // Cookie ベースのセッションを利用するため、常に `credentials` を送る
+  withCredentials: true
 });


### PR DESCRIPTION
## Summary
- add axios `withCredentials` configuration to always include cookies when calling the API, enabling session-based authentication

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0e7439d84832e9bd842aeb8d6b54d