### PR TITLE
Improve development password hashing fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
 
    ```sql
    INSERT INTO psi.users (username, password_hash)
-   VALUES (
-     'admin',
-     '$argon2id$v=19$m=102400,t=2,p=8$wR3AbBVlcrEpcPGJ6cN4dg$oT0yrNqC6JGAu8Kqf5B95Q'
-   );
+    VALUES (
+      'admin',
+      'pbkdf2_sha256$390000$xLZMCnQn7qjW030LISFGMw$wmdKegibCSwbuMOl6MQ8UhqKEMUqwdSzLdePUgVveNQ'
+    );
    ```
 
    > ℹ️ The hash above corresponds to the password `changeme!`. Generate fresh hashes with:
@@ -72,6 +72,9 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
    > print(hash_password("your-secret"))
    > PY
    > ```
+   > The fallback implementation uses PBKDF2-SHA256 when optional dependencies
+   > aren't installed, so the command works even in lightweight development
+   > environments.
    > (Refer to `docs/totp-auth-guide.md` for additional operational guidance.)
 
 5. **Start the FastAPI app**

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -202,11 +202,20 @@ def test_verify_password_handles_invalid_hash_gracefully():
     assert verify_password("any", "argon2$invalid") is False
 
 
-def test_verify_password_accepts_readme_argon2_hash():
-    pytest.importorskip("argon2")
+def test_pbkdf2_fallback_round_trip(monkeypatch):
+    monkeypatch.setattr("backend.app.security._pwd_context", None)
+    monkeypatch.setattr("backend.app.security._argon2_hasher", None)
 
+    hashed = hash_password("fallback")
+    assert hashed.startswith("pbkdf2_sha256$")
+    assert verify_password("fallback", hashed) is True
+    assert verify_password("other", hashed) is False
+
+
+def test_verify_password_accepts_readme_pbkdf2_hash():
     hash_from_readme = (
-        "$argon2id$v=19$m=102400,t=2,p=8$wR3AbBVlcrEpcPGJ6cN4dg$oT0yrNqC6JGAu8Kqf5B95Q"
+        "pbkdf2_sha256$390000$xLZMCnQn7qjW030LISFGMw$"
+        "wmdKegibCSwbuMOl6MQ8UhqKEMUqwdSzLdePUgVveNQ"
     )
 
     assert verify_password("changeme!", hash_from_readme) is True


### PR DESCRIPTION
## Summary
- add a PBKDF2-SHA256 based fallback so password hashing and verification work without optional dependencies
- update the README quick-start user seed to use the new fallback hash and mention the dependency-free behaviour
- extend authentication tests to cover the PBKDF2 fallback and validate the README example

## Testing
- pytest backend/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e9edb9f8832e80cf42747dab9171