### PR TITLE
Normalize database URL for psycopg2 on Heroku

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -84,7 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = driver://user:pass@localhost/dbname
+sqlalchemy.url =
 
 
 [post_write_hooks]

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -27,7 +27,9 @@ def _normalize_db_url(url: str | None) -> str | None:
         return url
     # Herokuは postgres:// を渡す → SQLAlchemyは postgresql(+driver) を要求
     if url.startswith("postgres://"):
-        return url.replace("postgres://", "postgresql+psycopg://", 1)
+        return url.replace("postgres://", "postgresql+psycopg2://", 1)
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg2://", 1)
     return url
 
 DB_URL = _normalize_db_url(settings.database_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ itsdangerous==2.2.0
 Mako==1.3.10
 MarkupSafe==3.0.2
 passlib==1.7.4
-psycopg-binary==3.2.1
 psycopg2-binary==2.9.9
 pycparser==2.23
 pydantic==2.11.9


### PR DESCRIPTION
## Summary
- normalize the DATABASE_URL in Alembic to use the psycopg2 driver expected on Heroku
- rely on env.py for URL configuration by clearing the default alembic.ini value
- drop the unused psycopg-binary dependency from requirements

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d0fa7e9dd4832eb890371dcd01b2a0