### PR TITLE
Add admin user management via masters

### DIFF
--- a/backend/alembic/versions/0006_add_is_admin_column.py
+++ b/backend/alembic/versions/0006_add_is_admin_column.py
@@ -1,0 +1,69 @@
+"""add is_admin flag to users"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.config import settings
+
+# revision identifiers, used by Alembic.
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+SCHEMA = settings.db_schema or None
+
+
+def _column_exists(inspector: sa.Inspector, table: str, column: str) -> bool:
+    columns = inspector.get_columns(table, schema=SCHEMA)
+    return any(col["name"] == column for col in columns)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_name = "users"
+    column_name = "is_admin"
+
+    if not inspector.has_table(table_name, schema=SCHEMA):
+        return
+
+    if not _column_exists(inspector, table_name, column_name):
+        op.add_column(
+            table_name,
+            sa.Column(
+                column_name,
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+            schema=SCHEMA,
+        )
+
+    metadata = sa.MetaData()
+    users_table = sa.Table(
+        table_name,
+        metadata,
+        sa.Column("username", sa.String),
+        sa.Column(column_name, sa.Boolean),
+        schema=SCHEMA,
+    )
+    op.execute(
+        users_table.update()
+        .where(users_table.c.username == "admin")
+        .values({column_name: True})
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_name = "users"
+    column_name = "is_admin"
+
+    if not inspector.has_table(table_name, schema=SCHEMA):
+        return
+
+    if _column_exists(inspector, table_name, column_name):
+        op.drop_column(table_name, column_name, schema=SCHEMA)

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -69,3 +69,14 @@ def get_current_user(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid session")
 
     return user
+
+
+def get_admin_user(
+    request: Request, db: Session = Depends(get_db)
+) -> models.User:
+    """Return the authenticated user ensuring they have admin privileges."""
+
+    user = get_current_user(request, db)
+    if not user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin access required")
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from .config import settings
 from .middleware import CSRFMiddleware, SecurityHeadersMiddleware
-from .routers import auth, channel_transfers, masters, psi, sessions
+from .routers import auth, channel_transfers, masters, psi, sessions, users
 
 app = FastAPI(title="GEN-like PSI API")
 
@@ -43,6 +43,7 @@ app.include_router(
     prefix="/channel-transfers",
     tags=["channel-transfers"],
 )
+app.include_router(users.router, prefix="/users", tags=["users"])
 
 # /api 配下にもミラー（フロントが /api/* を叩いてもOKに）
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
@@ -54,6 +55,7 @@ app.include_router(
     prefix="/api/channel-transfers",
     tags=["channel-transfers"],
 )
+app.include_router(users.router, prefix="/api/users", tags=["users"])
 
 @app.get("/health")
 def health() -> dict[str, bool]:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine import Connection, Engine
@@ -83,6 +84,7 @@ class User(Base, SchemaMixin):
     is_active: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=func.true()
     )
+    is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     last_login_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -97,6 +97,7 @@ def me(current_user: models.User = Depends(get_current_user)) -> schemas.UserPro
         id=current_user.id,
         username=current_user.username,
         is_active=current_user.is_active,
+        is_admin=current_user.is_admin,
     )
 
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,57 @@
+"""Administrative endpoints for managing application users."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..deps import get_admin_user, get_db
+from ..security import hash_password
+
+router = APIRouter()
+
+
+@router.post(
+    "",
+    response_model=schemas.UserCreateResult,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_user(
+    payload: schemas.UserCreateRequest,
+    _: models.User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+) -> schemas.UserCreateResult:
+    """Create a new application user.
+
+    The authenticated user must be an administrator. Usernames are treated as
+    case-sensitive strings to match login behaviour.
+    """
+
+    username = payload.username.strip()
+    if not username:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="username required")
+
+    stmt = select(models.User).where(models.User.username == username)
+    if db.scalars(stmt).first() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="username already exists",
+        )
+
+    user = models.User(
+        username=username,
+        password_hash=hash_password(payload.password),
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    return schemas.UserCreateResult(
+        id=user.id,
+        username=user.username,
+        is_active=user.is_active,
+        is_admin=user.is_admin,
+        created_at=user.created_at,
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -195,5 +195,23 @@ class UserProfile(BaseModel):
     id: UUID
     username: str
     is_active: bool
+    is_admin: bool
 
     model_config = {"from_attributes": True}
+
+
+class UserCreateRequest(BaseModel):
+    """Payload for creating a new user."""
+
+    username: Annotated[str, Field(min_length=1, max_length=150)]
+    password: Annotated[str, Field(min_length=8, max_length=256)]
+
+
+class UserCreateResult(BaseModel):
+    """Response returned after successfully creating a user."""
+
+    id: UUID
+    username: str
+    is_active: bool
+    is_admin: bool
+    created_at: datetime

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -236,6 +236,18 @@ body {
   font-weight: 600;
 }
 
+.credential-preview {
+  background: var(--surface-panel, #f5f5f7);
+  border: 1px solid var(--border-subtle, #d1d5db);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-family: "Menlo", "Consolas", "Courier New", monospace;
+  font-size: 0.95rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0 0 0.75rem;
+}
+
 .psi-controls {
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Navigate,
   NavLink,
@@ -32,11 +32,20 @@ function ProtectedLayout() {
     }
   }, [location.pathname]);
 
-  const masters = [
-    { path: "/masters/products", label: "Product Master", icon: "📦" },
-    { path: "/masters/customers", label: "Customer Master", icon: "🧑" },
-    { path: "/masters/suppliers", label: "Supplier Master", icon: "🚚" },
-  ];
+  const masters = useMemo(() => {
+    const baseMasters = [
+      { path: "/masters/products", label: "Product Master", icon: "📦" },
+      { path: "/masters/customers", label: "Customer Master", icon: "🧑" },
+      { path: "/masters/suppliers", label: "Supplier Master", icon: "🚚" },
+    ];
+    if (user?.is_admin) {
+      return [
+        { path: "/masters/users", label: "User Management", icon: "👥" },
+        ...baseMasters,
+      ];
+    }
+    return baseMasters;
+  }, [user?.is_admin]);
 
   const handleLogout = async () => {
     await logout();
@@ -83,6 +92,14 @@ function ProtectedLayout() {
               <span className="menu-label">PSI Table</span>
             </NavLink>
           </li>
+          <li>
+            <NavLink to="/docs" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              <span className="menu-icon" aria-hidden="true">
+                📚
+              </span>
+              <span className="menu-label">Docs</span>
+            </NavLink>
+          </li>
           <li className={`has-children ${isMasterMenuOpen ? "open" : ""}`}>
             <button
               type="button"
@@ -112,14 +129,6 @@ function ProtectedLayout() {
                 </li>
               ))}
             </ul>
-          </li>
-          <li>
-            <NavLink to="/docs" className={({ isActive }) => (isActive ? "active" : undefined)}>
-              <span className="menu-icon" aria-hidden="true">
-                📚
-              </span>
-              <span className="menu-label">Docs</span>
-            </NavLink>
           </li>
         </ul>
       </nav>

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -14,6 +14,7 @@ export interface UserProfile {
   id: string;
   username: string;
   is_active: boolean;
+  is_admin: boolean;
 }
 
 export async function login(payload: LoginPayload): Promise<LoginResponse> {

--- a/frontend/src/pages/MasterPage.tsx
+++ b/frontend/src/pages/MasterPage.tsx
@@ -4,7 +4,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 
 import api from "../lib/api";
-import type { MasterRecord } from "../types";
+import { useAuth } from "../hooks/useAuth";
+import type { MasterRecord, UserAccount } from "../types";
 
 type FieldType = "text" | "number";
 
@@ -24,6 +25,11 @@ interface MasterConfig {
 
 type MasterFormState = Record<string, string>;
 type MasterPayload = Record<string, string | number | null>;
+type StatusMessage = { type: "success" | "error"; text: string };
+interface CreateUserFormState {
+  username: string;
+  password: string;
+}
 
 const masterConfigs: Record<string, MasterConfig> = {
   products: {
@@ -130,8 +136,34 @@ const formatValue = (value: unknown): string => {
   return String(value);
 };
 
-export default function MasterPage() {
-  const { masterId } = useParams<{ masterId: string }>();
+const PASSWORD_CHARSET =
+  "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%&*?";
+
+const generateRandomPassword = (length = 12): string => {
+  const characters = PASSWORD_CHARSET;
+  const result: string[] = [];
+  const cryptoObj = typeof window !== "undefined" ? window.crypto : undefined;
+
+  if (cryptoObj?.getRandomValues) {
+    const values = new Uint32Array(length);
+    cryptoObj.getRandomValues(values);
+    for (let index = 0; index < length; index += 1) {
+      result.push(characters[values[index] % characters.length]);
+    }
+  } else {
+    for (let index = 0; index < length; index += 1) {
+      const randomIndex = Math.floor(Math.random() * characters.length);
+      result.push(characters[randomIndex]);
+    }
+  }
+
+  return result.join("");
+};
+
+const buildCredentialMessage = (username: string, password: string): string =>
+  `Username；${username}\nPASS；${password}`;
+
+function MasterRecordsPage({ masterId }: { masterId?: string }) {
   const queryClient = useQueryClient();
 
   const config = useMemo(() => {
@@ -143,7 +175,7 @@ export default function MasterPage() {
   const [editState, setEditState] = useState<MasterFormState>({});
   const [editingId, setEditingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  const [status, setStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
 
   useEffect(() => {
     if (config) {
@@ -416,4 +448,162 @@ export default function MasterPage() {
       </section>
     </div>
   );
+}
+
+function UserManagementSection({ isAdmin }: { isAdmin: boolean }) {
+  const [formState, setFormState] = useState<CreateUserFormState>({
+    username: "",
+    password: generateRandomPassword(),
+  });
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [createdCredentials, setCreatedCredentials] = useState<CreateUserFormState | null>(null);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "error">("idle");
+
+  const createUser = useMutation<UserAccount, unknown, CreateUserFormState>({
+    mutationFn: async (payload) => {
+      const { data } = await api.post<UserAccount>("/users", payload);
+      return data;
+    },
+    onSuccess: (data, variables) => {
+      setStatus({ type: "success", text: `Created user "${data.username}".` });
+      setCreatedCredentials({ username: data.username, password: variables.password });
+      setFormState({ username: "", password: generateRandomPassword() });
+      setCopyStatus("idle");
+    },
+    onError: (error) => {
+      setStatus({
+        type: "error",
+        text: getErrorMessage(error, "Unable to create user. Try again."),
+      });
+    },
+    onMutate: () => {
+      setStatus(null);
+      setCopyStatus("idle");
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedUsername = formState.username.trim();
+    if (!trimmedUsername) {
+      setStatus({ type: "error", text: "Enter a username before creating the user." });
+      return;
+    }
+    if (formState.password.length < 8) {
+      setStatus({ type: "error", text: "Password must be at least 8 characters." });
+      return;
+    }
+
+    createUser.mutate({ username: trimmedUsername, password: formState.password });
+  };
+
+  const handleGeneratePassword = () => {
+    setFormState((previous) => ({ ...previous, password: generateRandomPassword() }));
+    setCopyStatus("idle");
+    setStatus(null);
+  };
+
+  const credentialMessage =
+    createdCredentials?.username && createdCredentials?.password
+      ? buildCredentialMessage(createdCredentials.username, createdCredentials.password)
+      : "";
+
+  const handleCopy = async () => {
+    if (!credentialMessage) return;
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      setCopyStatus("error");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(credentialMessage);
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("error");
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="page master-page">
+        <header>
+          <h1>User Management</h1>
+          <p>Administrator privileges are required to manage user accounts.</p>
+        </header>
+        <p>You are signed in without admin rights. Contact an administrator if you need access.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page master-page">
+      <header>
+        <h1>User Management</h1>
+        <p>Create login credentials for new team members.</p>
+      </header>
+
+      <section>
+        <h2>Create New User</h2>
+        <form onSubmit={handleSubmit} className="form-grid">
+          <label>
+            Username
+            <input
+              type="text"
+              value={formState.username}
+              onChange={(event) =>
+                setFormState((previous) => ({ ...previous, username: event.target.value }))
+              }
+              autoComplete="off"
+              required
+            />
+            <small>Displayed when signing in.</small>
+          </label>
+          <label>
+            Password
+            <input
+              type="text"
+              value={formState.password}
+              onChange={(event) =>
+                setFormState((previous) => ({ ...previous, password: event.target.value }))
+              }
+              required
+            />
+            <small>Minimum 8 characters. Use the generator for a strong value.</small>
+          </label>
+          <button type="button" className="secondary" onClick={handleGeneratePassword}>
+            Generate secure password
+          </button>
+          <button type="submit" disabled={createUser.isPending}>
+            {createUser.isPending ? "Creating..." : "Create user"}
+          </button>
+        </form>
+        {status && <p className={status.type === "error" ? "error" : "success"}>{status.text}</p>}
+      </section>
+
+      {credentialMessage && (
+        <section>
+          <h2>Share Credentials</h2>
+          <p>Send the template below to the new user.</p>
+          <pre className="credential-preview">{credentialMessage}</pre>
+          <button type="button" onClick={handleCopy}>
+            Copy credentials to clipboard
+          </button>
+          {copyStatus === "copied" && <p className="success">Copied to clipboard.</p>}
+          {copyStatus === "error" && (
+            <p className="error">Unable to access the clipboard. Copy manually instead.</p>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default function MasterPage() {
+  const { masterId } = useParams<{ masterId: string }>();
+  const { user } = useAuth();
+
+  if (masterId === "users") {
+    return <UserManagementSection isAdmin={Boolean(user?.is_admin)} />;
+  }
+
+  return <MasterRecordsPage masterId={masterId} />;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -64,3 +64,11 @@ export interface MasterRecord {
   created_at: string;
   updated_at: string;
 }
+
+export interface UserAccount {
+  id: string;
+  username: string;
+  is_active: boolean;
+  is_admin: boolean;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- add an `is_admin` flag and protected user creation endpoint on the backend
- expose an admin-only user management view under the Masters menu with clipboard-ready credentials
- move the Docs entry above the Masters section in the sidebar navigation

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d107445268832e8f38bff5ec762f2c