### PR TITLE
Add admin-only user registration master

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,10 +33,17 @@ function ProtectedLayout() {
     }
   }, [location.pathname]);
 
-  const masters = useMemo(
-    () => [{ path: "/masters/psi-metrics", label: "PSI Metrics Master", icon: "🧮" }],
-    [],
-  );
+  const masters = useMemo(() => {
+    const items = [
+      { path: "/masters/psi-metrics", label: "PSI Metrics Master", icon: "🧮" },
+    ];
+
+    if (user?.is_admin) {
+      items.push({ path: "/masters/users", label: "User Accounts", icon: "👤" });
+    }
+
+    return items;
+  }, [user?.is_admin]);
 
   const handleLogout = async () => {
     await logout();


### PR DESCRIPTION
## Summary
- add an admin-only "User Accounts" master screen that lets administrators create dashboard users
- reorganize the master page to keep PSI metric management and reuse shared utilities
- expose the new master entry in the sidebar for administrators only

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23aa2df08832eabadb186f9cc496a