### PR TITLE
Add session audit fields with authentication

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -124,6 +124,9 @@ class Settings(BaseModel):
     login_block_seconds: int = Field(
         default_factory=lambda: int(os.getenv("LOGIN_BLOCK_SECONDS", "300"))
     )
+    expose_audit_fields: bool = Field(
+        default_factory=lambda: _env_flag("EXPOSE_AUDIT_FIELDS", default=False)
+    )
 
     @field_validator("database_url", mode="before")
     @classmethod

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -133,6 +133,16 @@ class Session(Base, SchemaMixin, TimestampMixin, UserTrackingMixin):
     channel_transfers: Mapped[list["ChannelTransfer"]] = relationship(
         back_populates="session", cascade="all, delete-orphan"
     )
+    created_by_user: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys="Session.created_by",
+        lazy="selectin",
+    )
+    updated_by_user: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys="Session.updated_by",
+        lazy="selectin",
+    )
 
 
 class MasterRecord(Base, SchemaMixin, TimestampMixin):

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -7,76 +7,139 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select, update
-from sqlalchemy.orm import Session as DBSession
+from sqlalchemy.orm import Session as DBSession, selectinload
 
 from .. import models, schemas
-from ..deps import get_db
+from ..config import settings
+from ..deps import get_current_user, get_db
 
 router = APIRouter()
 
 # ---- collection（/sessions と /sessions/ の両方を許容） ----
-@router.get("", response_model=list[schemas.SessionRead])
-@router.get("/", response_model=list[schemas.SessionRead])
-def list_sessions(db: DBSession = Depends(get_db)) -> list[schemas.SessionRead]:
+@router.get(
+    "",
+    response_model=list[schemas.SessionRead],
+    response_model_exclude_none=True,
+)
+@router.get(
+    "/",
+    response_model=list[schemas.SessionRead],
+    response_model_exclude_none=True,
+)
+def list_sessions(
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> list[schemas.SessionRead]:
     """セッション一覧を返す。"""
+    _ = current_user
     stmt = select(models.Session).order_by(models.Session.created_at.desc())
-    return db.scalars(stmt).all()
+    stmt = _with_audit_options(stmt)
+    sessions = db.scalars(stmt).all()
+    return [_serialize_session(session) for session in sessions]
 
 
-@router.post("", response_model=schemas.SessionRead, status_code=status.HTTP_201_CREATED)
-@router.post("/", response_model=schemas.SessionRead, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=schemas.SessionRead,
+    status_code=status.HTTP_201_CREATED,
+    response_model_exclude_none=True,
+)
+@router.post(
+    "/",
+    response_model=schemas.SessionRead,
+    status_code=status.HTTP_201_CREATED,
+    response_model_exclude_none=True,
+)
 def create_session(
-    payload: schemas.SessionCreate, db: DBSession = Depends(get_db)
+    payload: schemas.SessionCreate,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
 ) -> schemas.SessionRead:
     """新しいセッションを作成。"""
     session = models.Session(title=payload.title, description=payload.description)
+    session.created_by = current_user.id
+    session.updated_by = current_user.id
     db.add(session)
     db.commit()
     db.refresh(session)
-    return session
+    _refresh_audit_relationships(db, session)
+    return _serialize_session(session)
 
 
 # ---- static path は dynamic path より前に置く！ ----
-@router.get("/leader", response_model=Optional[schemas.SessionRead])
-def get_leader_session(db: DBSession = Depends(get_db)) -> Optional[schemas.SessionRead]:
+@router.get(
+    "/leader",
+    response_model=Optional[schemas.SessionRead],
+    response_model_exclude_none=True,
+)
+def get_leader_session(
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Optional[schemas.SessionRead]:
     """
     現在のリーダーセッションを返す。無ければ null を返す。
     """
+    _ = current_user
     stmt = (
         select(models.Session)
         .where(models.Session.is_leader.is_(True))
         .order_by(models.Session.updated_at.desc())
         .limit(1)
     )
-    return db.scalars(stmt).first()
+    stmt = _with_audit_options(stmt)
+    session = db.scalars(stmt).first()
+    if session is None:
+        return None
+    return _serialize_session(session)
 
 
 # ---- item ----
 def _get_session_or_404(db: DBSession, session_id: UUID) -> models.Session:
-    session = db.get(models.Session, session_id)
+    stmt = select(models.Session).where(models.Session.id == session_id).limit(1)
+    stmt = _with_audit_options(stmt)
+    session = db.scalars(stmt).first()
     if session is None:
         raise HTTPException(status_code=404, detail="session not found")
     return session
 
 
-@router.get("/{session_id}", response_model=schemas.SessionRead)
-def get_session(session_id: UUID, db: DBSession = Depends(get_db)) -> schemas.SessionRead:
+@router.get(
+    "/{session_id}",
+    response_model=schemas.SessionRead,
+    response_model_exclude_none=True,
+)
+def get_session(
+    session_id: UUID,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.SessionRead:
     """セッション詳細を取得。"""
-    return _get_session_or_404(db, session_id)
+    _ = current_user
+    session = _get_session_or_404(db, session_id)
+    return _serialize_session(session)
 
 
-@router.put("/{session_id}", response_model=schemas.SessionRead)
+@router.put(
+    "/{session_id}",
+    response_model=schemas.SessionRead,
+    response_model_exclude_none=True,
+)
 def update_session(
-    session_id: UUID, payload: schemas.SessionUpdate, db: DBSession = Depends(get_db)
+    session_id: UUID,
+    payload: schemas.SessionUpdate,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
 ) -> schemas.SessionRead:
     """セッションを更新。"""
     session = _get_session_or_404(db, session_id)
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(session, field, value)
+    session.updated_by = current_user.id
     db.add(session)
     db.commit()
     db.refresh(session)
-    return session
+    _refresh_audit_relationships(db, session)
+    return _serialize_session(session)
 
 
 @router.delete(
@@ -84,33 +147,72 @@ def update_session(
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,  # 204 はボディ無し
 )
-def delete_session(session_id: UUID, db: DBSession = Depends(get_db)) -> Response:
+def delete_session(
+    session_id: UUID,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
     """セッションを削除。"""
+    _ = current_user
     session = _get_session_or_404(db, session_id)
     db.delete(session)
     db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.patch("/{session_id}/leader", response_model=schemas.SessionRead)
-def set_leader(session_id: UUID, db: DBSession = Depends(get_db)) -> schemas.SessionRead:
+@router.patch(
+    "/{session_id}/leader",
+    response_model=schemas.SessionRead,
+    response_model_exclude_none=True,
+)
+def set_leader(
+    session_id: UUID,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.SessionRead:
     """指定セッションをリーダーに設定（他はすべて False）。"""
-    _ = _get_session_or_404(db, session_id)
+    _ = current_user
 
     # 全ての is_leader を False に
     db.execute(update(models.Session).values(is_leader=False))
 
-    # 指定IDを True に
-    result = (
-        db.execute(
-            update(models.Session)
-            .where(models.Session.id == session_id)
-            .values(is_leader=True)
-            .returning(models.Session.id)
-        ).first()
-    )
-    if not result:
-        raise HTTPException(status_code=404, detail="session not found")
-
+    session = _get_session_or_404(db, session_id)
+    session.is_leader = True
+    session.updated_by = current_user.id
+    db.add(session)
     db.commit()
-    return db.get(models.Session, session_id)
+    db.refresh(session)
+    _refresh_audit_relationships(db, session)
+    return _serialize_session(session)
+
+
+def _with_audit_options(stmt):
+    if settings.expose_audit_fields:
+        return stmt.options(
+            selectinload(models.Session.created_by_user),
+            selectinload(models.Session.updated_by_user),
+        )
+    return stmt
+
+
+def _refresh_audit_relationships(db: DBSession, session: models.Session) -> None:
+    if settings.expose_audit_fields:
+        db.refresh(session, attribute_names=["created_by_user", "updated_by_user"])
+
+
+def _serialize_session(session: models.Session) -> schemas.SessionRead:
+    data = schemas.SessionRead.model_validate(session, from_attributes=True)
+    if settings.expose_audit_fields:
+        data.created_by_username = (
+            session.created_by_user.username if session.created_by_user else None
+        )
+        data.updated_by_username = (
+            session.updated_by_user.username if session.updated_by_user else None
+        )
+        return data
+
+    data.created_by = None
+    data.updated_by = None
+    data.created_by_username = None
+    data.updated_by_username = None
+    return data

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -37,6 +37,10 @@ class SessionRead(SessionBase):
     is_leader: bool
     created_at: datetime
     updated_at: datetime
+    created_by: UUID | None = None
+    updated_by: UUID | None = None
+    created_by_username: str | None = None
+    updated_by_username: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/tests/test_sessions_api.py
+++ b/backend/tests/test_sessions_api.py
@@ -1,0 +1,266 @@
+"""Session router behavioural tests."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _perform_request(
+    app,
+    method: str,
+    path: str,
+    json_body: dict[str, object] | None = None,
+    headers: list[tuple[str, str]] | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    body = b""
+    header_list: list[tuple[bytes, bytes]] = []
+    if headers:
+        header_list.extend(
+            (key.lower().encode("latin-1"), value.encode("latin-1"))
+            for key, value in headers
+        )
+    if json_body is not None:
+        body = json.dumps(json_body).encode("utf-8")
+        header_list.append((b"content-type", b"application/json"))
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "scheme": "http",
+        "headers": header_list,
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+
+    messages: list[dict[str, object]] = []
+    body_sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.disconnect"}
+        body_sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    asyncio.run(app(scope, receive, send))
+
+    start = next(msg for msg in messages if msg["type"] == "http.response.start")
+    response_headers = {
+        key.decode("latin-1"): value.decode("latin-1")
+        for key, value in start.get("headers", [])
+    }
+    body_bytes = b"".join(
+        msg.get("body", b"")
+        for msg in messages
+        if msg["type"] == "http.response.body"
+    )
+    return start["status"], response_headers, body_bytes
+
+
+def _perform_json_request(
+    app,
+    method: str,
+    path: str,
+    json_body: dict[str, object] | None = None,
+) -> tuple[int, dict[str, str], object | None]:
+    status, headers, body = _perform_request(app, method, path, json_body=json_body)
+    if body:
+        return status, headers, json.loads(body.decode("utf-8"))
+    return status, headers, None
+
+
+def _create_user(env: SimpleNamespace, username: str = "auditor"):
+    with env.SessionLocal() as session:
+        user = env.models.User(
+            username=username,
+            password_hash="x",
+            is_active=True,
+            is_admin=False,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return user
+
+
+@pytest.fixture(scope="module")
+def app_env(tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
+    db_path = tmp_path_factory.mktemp("sessions") / "sessions_test.db"
+    os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+    os.environ["DB_SCHEMA"] = ""
+    os.environ.setdefault("SESSION_SIGN_KEY", "test-sign-key")
+    os.environ.setdefault("SECRET_KEY", "test-secret")
+    os.environ.setdefault(
+        "ALLOWED_ORIGINS",
+        "http://testserver,http://localhost:5173,http://localhost:5174",
+    )
+    os.environ.setdefault("SESSION_COOKIE_SECURE", "false")
+    os.environ.setdefault("SESSION_COOKIE_SAMESITE", "lax")
+    os.environ.setdefault("SESSION_TTL_SECONDS", "300")
+    os.environ.setdefault("CSRF_ENABLED", "false")
+    os.environ.setdefault("LOGIN_MAX_ATTEMPTS", "3")
+    os.environ.setdefault("LOGIN_BLOCK_SECONDS", "60")
+    os.environ.setdefault("EXPOSE_AUDIT_FIELDS", "false")
+
+    for module in list(sys.modules):
+        if module.startswith("backend.app"):
+            sys.modules.pop(module)
+
+    from backend.app import models
+    from backend.app.config import settings
+    from backend.app.deps import SessionLocal, engine, get_current_user
+    from backend.app.main import app
+
+    assert settings.db_schema == ""
+
+    with engine.begin() as connection:
+        models.Session.__table__.drop(bind=connection, checkfirst=True)
+        models.User.__table__.drop(bind=connection, checkfirst=True)
+        models.User.__table__.create(bind=connection, checkfirst=True)
+        models.Session.__table__.create(bind=connection, checkfirst=True)
+
+    asyncio.run(app.router.startup())
+
+    return SimpleNamespace(
+        app=app,
+        models=models,
+        settings=settings,
+        SessionLocal=SessionLocal,
+        engine=engine,
+        get_current_user=get_current_user,
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_database(app_env: SimpleNamespace) -> None:
+    with app_env.engine.begin() as connection:
+        connection.execute(app_env.models.Session.__table__.delete())
+        connection.execute(app_env.models.User.__table__.delete())
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clear_overrides(app_env: SimpleNamespace) -> None:
+    yield
+    app_env.app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth_user(app_env: SimpleNamespace):
+    user = _create_user(app_env)
+
+    def override_current_user():
+        return user
+
+    app_env.app.dependency_overrides[app_env.get_current_user] = override_current_user
+    return user
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("GET", "/sessions", None),
+        ("GET", "/sessions/leader", None),
+        ("GET", f"/sessions/{uuid.uuid4()}", None),
+        ("POST", "/sessions", {"title": "Blocked"}),
+        ("PUT", f"/sessions/{uuid.uuid4()}", {"title": "Blocked"}),
+        ("DELETE", f"/sessions/{uuid.uuid4()}", None),
+        ("PATCH", f"/sessions/{uuid.uuid4()}/leader", {}),
+    ],
+)
+def test_sessions_require_authentication(
+    app_env: SimpleNamespace, method: str, path: str, payload: dict[str, object] | None
+) -> None:
+    status, _, _ = _perform_request(app_env.app, method, path, json_body=payload)
+    assert status == 401
+
+
+def test_create_session_stamps_audit_fields_without_exposing(
+    app_env: SimpleNamespace, auth_user
+) -> None:
+    user = auth_user
+    payload = {"title": "Sprint 1", "description": "Initial"}
+
+    status, _, body = _perform_json_request(app_env.app, "POST", "/sessions", payload)
+    assert status == 201
+    assert isinstance(body, dict)
+    assert body["title"] == "Sprint 1"
+    assert "created_by" not in body
+    assert "updated_by" not in body
+    assert "created_by_username" not in body
+    assert "updated_by_username" not in body
+
+    session_id = uuid.UUID(body["id"])
+    with app_env.SessionLocal() as session:
+        stored = session.get(app_env.models.Session, session_id)
+        assert stored is not None
+        assert stored.created_by == user.id
+        assert stored.updated_by == user.id
+
+
+def test_session_responses_include_audit_fields_when_enabled(
+    app_env: SimpleNamespace, auth_user, monkeypatch
+) -> None:
+    user = auth_user
+    new_settings = app_env.settings.model_copy(update={"expose_audit_fields": True})
+    monkeypatch.setattr("backend.app.config.settings", new_settings, raising=False)
+    monkeypatch.setattr("backend.app.routers.sessions.settings", new_settings, raising=False)
+
+    payload = {"title": "Sprint 2", "description": "Audit"}
+    status, _, created = _perform_json_request(app_env.app, "POST", "/sessions", payload)
+    assert status == 201
+    assert isinstance(created, dict)
+    assert created["created_by"] == str(user.id)
+    assert created["updated_by"] == str(user.id)
+    assert created["created_by_username"] == user.username
+    assert created["updated_by_username"] == user.username
+
+    session_id = created["id"]
+
+    status, _, updated = _perform_json_request(
+        app_env.app, "PUT", f"/sessions/{session_id}", {"description": "Updated"}
+    )
+    assert status == 200
+    assert isinstance(updated, dict)
+    assert updated["updated_by"] == str(user.id)
+    assert updated["updated_by_username"] == user.username
+
+    status, _, leader = _perform_json_request(
+        app_env.app, "PATCH", f"/sessions/{session_id}/leader", {}
+    )
+    assert status == 200
+    assert isinstance(leader, dict)
+    assert leader["is_leader"] is True
+    assert leader["updated_by"] == str(user.id)
+
+    status, _, listing = _perform_json_request(app_env.app, "GET", "/sessions")
+    assert status == 200
+    assert isinstance(listing, list)
+    assert listing
+    assert listing[0]["created_by_username"] == user.username
+    assert listing[0]["updated_by_username"] == user.username
+
+    with app_env.SessionLocal() as session:
+        stored = session.get(app_env.models.Session, uuid.UUID(session_id))
+        assert stored is not None
+        assert stored.created_by == user.id
+        assert stored.updated_by == user.id


### PR DESCRIPTION
## Summary
* require authentication on session endpoints and conditionally serialize audit metadata for responses
* add creator/updater relationships plus optional audit fields on session schemas controlled by `EXPOSE_AUDIT_FIELDS`
* cover behaviour with API-level tests for authentication failures and audit flag toggling

## Testing
* pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d245bbdc4c832eba7675b22dfe48c8