### PR TITLE
Add audit metadata convenience accessor

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -148,6 +148,12 @@ class Settings(BaseModel):
         return self.db_schema
 
     @property
+    def audit_metadata_enabled(self) -> bool:
+        """Return whether audit metadata should be exposed in API responses."""
+
+        return self.expose_audit_fields
+
+    @property
     def allowed_origins(self) -> list[str]:
         """Return a sanitized list of allowed CORS origins."""
 

--- a/backend/app/routers/psi.py
+++ b/backend/app/routers/psi.py
@@ -745,7 +745,7 @@ def apply_edits(
         db.add_all(logs)
     db.commit()
 
-    expose_audit = settings.expose_audit_fields
+    expose_audit = settings.audit_metadata_enabled
     last_edited_by: UUID | None = None
     last_edited_by_username: str | None = None
     last_edited_at: datetime | None = None

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -187,7 +187,7 @@ def set_leader(
 
 
 def _with_audit_options(stmt):
-    if settings.expose_audit_fields:
+    if settings.audit_metadata_enabled:
         return stmt.options(
             selectinload(models.Session.created_by_user),
             selectinload(models.Session.updated_by_user),
@@ -196,13 +196,13 @@ def _with_audit_options(stmt):
 
 
 def _refresh_audit_relationships(db: DBSession, session: models.Session) -> None:
-    if settings.expose_audit_fields:
+    if settings.audit_metadata_enabled:
         db.refresh(session, attribute_names=["created_by_user", "updated_by_user"])
 
 
 def _serialize_session(session: models.Session) -> schemas.SessionRead:
     data = schemas.SessionRead.model_validate(session, from_attributes=True)
-    if settings.expose_audit_fields:
+    if settings.audit_metadata_enabled:
         data.created_by_username = (
             session.created_by_user.username if session.created_by_user else None
         )


### PR DESCRIPTION
## Summary
- add an audit_metadata_enabled accessor to the runtime settings
- switch session, PSI, and channel transfer routers to the accessor for audit checks

## Testing
- pytest backend/tests/test_sessions_api.py backend/tests/test_psi_api.py backend/tests/test_channel_transfers_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d25859dfb4832ebbde95b6ea1a0dc3