### PR TITLE
Add operator tracking columns to sessions

### DIFF
--- a/backend/alembic/versions/0007_add_session_operator_columns.py
+++ b/backend/alembic/versions/0007_add_session_operator_columns.py
@@ -1,0 +1,54 @@
+"""add session operator columns"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.config import settings
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: Union[str, Sequence[str], None] = "0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = settings.db_schema or None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        schema=SCHEMA,
+    )
+    op.add_column(
+        "sessions",
+        sa.Column("updated_by", postgresql.UUID(as_uuid=True), nullable=True),
+        schema=SCHEMA,
+    )
+
+    op.create_index(
+        "idx_sessions_created_by",
+        "sessions",
+        ["created_by"],
+        unique=False,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_sessions_updated_by",
+        "sessions",
+        ["updated_by"],
+        unique=False,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_sessions_updated_by", table_name="sessions", schema=SCHEMA)
+    op.drop_index("idx_sessions_created_by", table_name="sessions", schema=SCHEMA)
+
+    op.drop_column("sessions", "updated_by", schema=SCHEMA)
+    op.drop_column("sessions", "created_by", schema=SCHEMA)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -106,12 +106,24 @@ class Session(Base, SchemaMixin, TimestampMixin):
 
     __tablename__ = "sessions"
 
+    __table_args__ = (
+        Index("idx_sessions_created_by", "created_by"),
+        Index("idx_sessions_updated_by", "updated_by"),
+        SchemaMixin.__table_args__ if SchemaMixin.__table_args__ else {},
+    )
+
     id: Mapped[uuid.UUID] = mapped_column(
         PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_leader: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    updated_by: Mapped[uuid.UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
 
     psi_base_records: Mapped[list["PSIBase"]] = relationship(
         back_populates="session", cascade="all, delete-orphan"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -35,6 +35,8 @@ class SessionRead(SessionBase):
     #id: str
     id: UUID
     is_leader: bool
+    created_by: UUID | None = None
+    updated_by: UUID | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/frontend/src/lib/shape.ts
+++ b/frontend/src/lib/shape.ts
@@ -1,17 +1,21 @@
 // src/lib/shape.ts
 export type SessionApi = {
   id: string; title: string; description: string | null;
-  is_leader: boolean; created_at: string; updated_at: string;
+  is_leader: boolean; created_by: string | null; updated_by: string | null;
+  created_at: string; updated_at: string;
 };
 export type SessionView = {
   id: string; title: string; description: string | null;
-  isLeader: boolean; createdAt: string; updatedAt: string;
+  isLeader: boolean; createdBy: string | null; updatedBy: string | null;
+  createdAt: string; updatedAt: string;
 };
 export const toSessionView = (s: SessionApi): SessionView => ({
   id: s.id,
   title: s.title,
   description: s.description,
   isLeader: s.is_leader,
+  createdBy: s.created_by,
+  updatedBy: s.updated_by,
   createdAt: s.created_at,
   updatedAt: s.updated_at,
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,6 +3,8 @@ export interface Session {
   title: string;
   description?: string | null;
   is_leader: boolean;
+  created_by: string | null;
+  updated_by: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- add nullable created_by and updated_by UUID columns to the sessions table with indexes via Alembic
- expose operator identifiers on the SQLAlchemy model and Pydantic schema for API consumers
- update frontend session types and mappers to surface the new fields in the UI layer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d29900a9e0832ea2af45aa54707de0