### PR TITLE
Ensure Alembic migrations target psi schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: migrate stamp
+
+migrate:
+	alembic -c backend/alembic.ini upgrade head
+
+ifndef REV
+REV_ERROR := REV is required, e.g. make stamp REV=0008
+endif
+
+stamp:
+ifdef REV_ERROR
+	$(error $(REV_ERROR))
+endif
+	alembic -c backend/alembic.ini stamp $(REV)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: alembic -c backend/alembic.ini upgrade head
-web: uvicorn backend.app.main:app --host 0.0.0.0 --port $PORT --proxy-headers
+web: uvicorn backend.app.main:app --host=0.0.0.0 --port=${PORT:-5000} --proxy-headers

--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
 3. **Run database migrations**
 
    ```bash
-   alembic upgrade head
+   make migrate
    ```
+
+   The helper invokes `alembic -c backend/alembic.ini upgrade head` so that the
+   migrations always target the `psi` schema.
 
 4. **Create an initial user (no UI)**
 
@@ -141,7 +144,26 @@ The suite provisions a throwaway SQLite database and covers happy-path login + `
   | `SESSION_COOKIE_SECURE` | `true` (default) |
 
 - Deploy the frontend build artefacts (`frontend/dist`) to `backend/static` (or configure a CDN) so the SPA is served alongside the API.
-- Apply database migrations on release: `heroku run alembic upgrade head` (already wired via the `release` process type).
+- Apply database migrations on release: the `Procfile` defines a `release`
+  process which executes `alembic -c backend/alembic.ini upgrade head` so the
+  latest migrations are applied automatically during deploys.
+- Manual execution (if needed):
+
+  ```bash
+  heroku run --app <APP> 'alembic -c backend/alembic.ini upgrade head'
+  ```
+
+- Grab a backup before running structural changes:
+
+  ```bash
+  heroku pg:backups:capture --app <APP>
+  ```
+
+- Roll back to a captured backup if necessary:
+
+  ```bash
+  heroku pg:backups:restore <BACKUP_ID> DATABASE_URL --app <APP>
+  ```
 
 ## CSV format reminder
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -6,6 +6,7 @@
 # format, relative to the token %(here)s which refers to the location of this
 # ini file
 script_location = %(here)s/alembic
+version_table_schema = psi
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -12,17 +12,33 @@ from sqlalchemy import engine_from_config, pool, text
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
 from app.config import settings
 from app.models import Base
 
+DEFAULT_SCHEMA = "psi"
+
+
+def _normalized_schema(schema_name: str | None) -> str:
+    """Return the schema name Alembic should target."""
+
+    if not schema_name:
+        return DEFAULT_SCHEMA
+
+    coerced = schema_name.strip()
+    return coerced or DEFAULT_SCHEMA
+
+
 config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# --- 追加: URL正規化ヘルパ ---
+
 def _normalize_db_url(url: str | None) -> str | None:
+    """Normalize PostgreSQL URLs for SQLAlchemy/psycopg2 usage."""
+
     if not url:
         return url
     # Herokuは postgres:// を渡す → SQLAlchemyは postgresql(+driver) を要求
@@ -32,7 +48,9 @@ def _normalize_db_url(url: str | None) -> str | None:
         return url.replace("postgresql://", "postgresql+psycopg2://", 1)
     return url
 
+
 DB_URL = _normalize_db_url(settings.database_url)
+TARGET_SCHEMA = _normalized_schema(getattr(settings, "db_schema", DEFAULT_SCHEMA))
 
 # alembic.ini の設定を上書き
 config.set_main_option("sqlalchemy.url", DB_URL or "")
@@ -48,7 +66,7 @@ def run_migrations_offline() -> None:
         literal_binds=True,
         compare_type=True,
         include_schemas=True,
-        version_table_schema=settings.db_schema,
+        version_table_schema=TARGET_SCHEMA,
     )
     with context.begin_transaction():
         context.run_migrations()
@@ -62,17 +80,16 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         # スキーマが指定されている場合のみ作成＆search_path設定
-        if settings.db_schema:
-            schema = settings.db_schema
-            connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
-            connection.execute(text(f'SET search_path TO "{schema}", public'))
+        if TARGET_SCHEMA:
+            connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{TARGET_SCHEMA}"'))
+            connection.execute(text(f'SET search_path TO "{TARGET_SCHEMA}", public'))
 
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
             compare_type=True,
             include_schemas=True,
-            version_table_schema=settings.db_schema,
+            version_table_schema=TARGET_SCHEMA,
         )
         with context.begin_transaction():
             context.run_migrations()

--- a/backend/alembic/versions/0008_hardening_audit_triggers.py
+++ b/backend/alembic/versions/0008_hardening_audit_triggers.py
@@ -1,0 +1,179 @@
+"""Hardening audit metadata for psi schema."""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0008"
+down_revision: Union[str, Sequence[str], None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "psi"
+AUDIT_COLUMNS = ("created_by", "updated_by")
+AUDITED_TABLES = (
+    "sessions",
+    "psi_edits",
+    "psi_edit_log",
+    "channel_transfers",
+)
+TRIGGER_TEMPLATE = "set_{table}_updated_at"
+
+
+def _qualified_table(table_name: str) -> str:
+    return f'{SCHEMA}."{table_name}"'
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text(f'SET search_path TO "{SCHEMA}", public'))
+
+    op.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION psi.update_updated_at_column()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                NEW.updated_at = NOW();
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+
+    for table_name in AUDITED_TABLES:
+        qualified_table = _qualified_table(table_name)
+
+        for column in AUDIT_COLUMNS:
+            op.execute(
+                sa.text(
+                    f"ALTER TABLE IF EXISTS {qualified_table} "
+                    f'ADD COLUMN IF NOT EXISTS "{column}" UUID'
+                )
+            )
+
+            index_name = f"idx_{table_name}_{column}"
+            op.execute(
+                sa.text(
+                    f"CREATE INDEX IF NOT EXISTS {index_name} "
+                    f"ON {qualified_table} (\"{column}\")"
+                )
+            )
+
+            constraint_name = f"{table_name}_{column}_fkey"
+            op.execute(
+                sa.text(
+                    f"""
+                    DO $$
+                    BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1
+                            FROM pg_constraint
+                            WHERE conrelid = '{SCHEMA}.{table_name}'::regclass
+                              AND conname = '{constraint_name}'
+                        ) THEN
+                            ALTER TABLE {qualified_table}
+                            ADD CONSTRAINT {constraint_name}
+                            FOREIGN KEY (\"{column}\")
+                            REFERENCES {SCHEMA}.users(id)
+                            ON DELETE SET NULL
+                            NOT VALID;
+                        END IF;
+                    END;
+                    $$;
+                    """
+                )
+            )
+
+            op.execute(
+                sa.text(
+                    f"""
+                    DO $$
+                    BEGIN
+                        IF EXISTS (
+                            SELECT 1
+                            FROM pg_constraint
+                            WHERE conrelid = '{SCHEMA}.{table_name}'::regclass
+                              AND conname = '{constraint_name}'
+                              AND NOT convalidated
+                        ) THEN
+                            ALTER TABLE {qualified_table}
+                            VALIDATE CONSTRAINT {constraint_name};
+                        END IF;
+                    END;
+                    $$;
+                    """
+                )
+            )
+
+        trigger_name = TRIGGER_TEMPLATE.format(table=table_name)
+        op.execute(
+            sa.text(
+                f"DROP TRIGGER IF EXISTS {trigger_name} ON {qualified_table};"
+            )
+        )
+        op.execute(
+            sa.text(
+                f"""
+                CREATE TRIGGER {trigger_name}
+                BEFORE UPDATE ON {qualified_table}
+                FOR EACH ROW EXECUTE FUNCTION psi.update_updated_at_column();
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text(f'SET search_path TO "{SCHEMA}", public'))
+
+    for table_name in AUDITED_TABLES:
+        qualified_table = _qualified_table(table_name)
+
+        trigger_name = TRIGGER_TEMPLATE.format(table=table_name)
+        op.execute(
+            sa.text(
+                f"DROP TRIGGER IF EXISTS {trigger_name} ON {qualified_table};"
+            )
+        )
+
+        for column in AUDIT_COLUMNS:
+            index_name = f"idx_{table_name}_{column}"
+            op.execute(
+                sa.text(
+                    f"DROP INDEX IF EXISTS {SCHEMA}.{index_name};"
+                )
+            )
+
+            constraint_name = f"{table_name}_{column}_fkey"
+            op.execute(
+                sa.text(
+                    f"""
+                    DO $$
+                    BEGIN
+                        IF EXISTS (
+                            SELECT 1
+                            FROM pg_constraint
+                            WHERE conrelid = '{SCHEMA}.{table_name}'::regclass
+                              AND conname = '{constraint_name}'
+                        ) THEN
+                            ALTER TABLE {qualified_table}
+                            DROP CONSTRAINT {constraint_name};
+                        END IF;
+                    END;
+                    $$;
+                    """
+                )
+            )
+
+    op.execute(
+        sa.text(
+            """
+            DROP FUNCTION IF EXISTS psi.update_updated_at_column();
+            """
+        )
+    )


### PR DESCRIPTION
## Summary
- force Alembic to target the psi schema, including search_path and version table configuration
- add revision 0008 to harden audit metadata columns, indexes, foreign keys, and triggers idempotently
- wire release-time upgrades, add helper make targets, and document Heroku migration/backup procedures

## Testing
- pytest backend/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a2de9d88832eac8269dea9b61711