### PR TITLE
Ensure Alembic targets psi schema and add hardened audit migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+ALEMBIC = alembic -c backend/alembic.ini
+REV ?= head
+
+.PHONY: migrate stamp downgrade
+
+migrate:
+	$(ALEMBIC) upgrade head
+
+stamp:
+	$(ALEMBIC) stamp $(REV)
+
+downgrade:
+	$(ALEMBIC) downgrade $(REV)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: alembic -c backend/alembic.ini upgrade head
-web: uvicorn backend.app.main:app --host 0.0.0.0 --port $PORT --proxy-headers
+web: uvicorn backend.app.main:app --host=0.0.0.0 --port=${PORT:-5000} --proxy-headers

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -5,7 +5,8 @@
 # this is typically a path given in POSIX (e.g. forward slashes)
 # format, relative to the token %(here)s which refers to the location of this
 # ini file
-script_location = %(here)s/alembic
+script_location = backend/alembic
+version_table_schema = psi
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -12,29 +12,45 @@ from sqlalchemy import engine_from_config, pool, text
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
 from app.config import settings
 from app.models import Base
 
+DEFAULT_SCHEMA = "psi"
+
+
+def _resolve_schema(value: str | None) -> str:
+    """Return the configured schema or the hard-coded default."""
+
+    if value:
+        candidate = value.strip()
+        if candidate:
+            return candidate
+    return DEFAULT_SCHEMA
+
+
 config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# --- 追加: URL正規化ヘルパ ---
+
 def _normalize_db_url(url: str | None) -> str | None:
+    """Normalise PostgreSQL URLs for SQLAlchemy/psycopg2."""
+
     if not url:
         return url
-    # Herokuは postgres:// を渡す → SQLAlchemyは postgresql(+driver) を要求
     if url.startswith("postgres://"):
         return url.replace("postgres://", "postgresql+psycopg2://", 1)
     if url.startswith("postgresql://"):
         return url.replace("postgresql://", "postgresql+psycopg2://", 1)
     return url
 
-DB_URL = _normalize_db_url(settings.database_url)
 
-# alembic.ini の設定を上書き
+DB_URL = _normalize_db_url(settings.database_url)
+SCHEMA = _resolve_schema(getattr(settings, "db_schema", DEFAULT_SCHEMA))
+
 config.set_main_option("sqlalchemy.url", DB_URL or "")
 
 target_metadata = Base.metadata
@@ -48,7 +64,7 @@ def run_migrations_offline() -> None:
         literal_binds=True,
         compare_type=True,
         include_schemas=True,
-        version_table_schema=settings.db_schema,
+        version_table_schema=SCHEMA,
     )
     with context.begin_transaction():
         context.run_migrations()
@@ -61,18 +77,16 @@ def run_migrations_online() -> None:
     connectable = engine_from_config(configuration, prefix="sqlalchemy.", poolclass=pool.NullPool)
 
     with connectable.connect() as connection:
-        # スキーマが指定されている場合のみ作成＆search_path設定
-        if settings.db_schema:
-            schema = settings.db_schema
-            connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
-            connection.execute(text(f'SET search_path TO "{schema}", public'))
+        quoted_schema = f'"{SCHEMA.replace("\"", "\"\"")}"'
+        connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {quoted_schema}"))
+        connection.execute(text(f"SET search_path TO {quoted_schema}, public"))
 
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
             compare_type=True,
             include_schemas=True,
-            version_table_schema=settings.db_schema,
+            version_table_schema=SCHEMA,
         )
         with context.begin_transaction():
             context.run_migrations()

--- a/backend/alembic/versions/0008_harden_audit_metadata.py
+++ b/backend/alembic/versions/0008_harden_audit_metadata.py
@@ -1,0 +1,142 @@
+"""Harden audit metadata and triggers"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0008"
+down_revision: Union[str, Sequence[str], None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "psi"
+USER_TABLE = "users"
+AUDIT_COLUMNS = ("created_by", "updated_by")
+AUDIT_TABLES = ("sessions", "psi_edits", "psi_edit_log", "channel_transfers")
+FUNCTION_NAME = "update_updated_at_column"
+
+
+def _qualify(identifier: str) -> str:
+    return f'"{SCHEMA}"."{identifier}"'
+
+
+def _qualify_index(index_name: str) -> str:
+    return f'"{SCHEMA}"."{index_name}"'
+
+
+def _qualified_function() -> str:
+    return f'"{SCHEMA}"."{FUNCTION_NAME}"'
+
+
+def _execute(sql: str) -> None:
+    op.execute(sa.text(sql))
+
+
+def _ensure_foreign_key(table: str, column: str) -> None:
+    constraint_name = f"fk_{table}_{column}_users"
+    constraint_exists_check = f"""
+SELECT 1
+  FROM pg_constraint con
+  JOIN pg_namespace nsp ON nsp.oid = con.connamespace
+  JOIN pg_class rel ON rel.oid = con.conrelid
+ WHERE nsp.nspname = '{SCHEMA}'
+   AND rel.relname = '{table}'
+   AND con.conname = '{constraint_name}'
+"""
+
+    _execute(
+        f"""
+DO $$
+BEGIN
+    IF NOT EXISTS ({constraint_exists_check}) THEN
+        EXECUTE format(
+            'ALTER TABLE %I.%I ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES %I.%I(%I) ON DELETE SET NULL NOT VALID',
+            '{SCHEMA}', '{table}', '{constraint_name}', '{column}', '{SCHEMA}', '{USER_TABLE}', 'id'
+        );
+    END IF;
+END$$;
+"""
+    )
+
+    _execute(
+        f"""
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_namespace nsp ON nsp.oid = con.connamespace
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE nsp.nspname = '{SCHEMA}'
+           AND rel.relname = '{table}'
+           AND con.conname = '{constraint_name}'
+           AND con.convalidated = false
+    ) THEN
+        EXECUTE format(
+            'ALTER TABLE %I.%I VALIDATE CONSTRAINT %I',
+            '{SCHEMA}', '{table}', '{constraint_name}'
+        );
+    END IF;
+END$$;
+"""
+    )
+
+
+def upgrade() -> None:
+    for table in AUDIT_TABLES:
+        for column in AUDIT_COLUMNS:
+            _execute(
+                f"ALTER TABLE {_qualify(table)} ADD COLUMN IF NOT EXISTS \"{column}\" uuid"
+            )
+
+    _execute(
+        f"""
+ALTER TABLE {_qualify("psi_edit_log")}
+    ADD COLUMN IF NOT EXISTS "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW();
+"""
+    )
+
+    for table in AUDIT_TABLES:
+        for column in AUDIT_COLUMNS:
+            index_name = f"ix_{table}_{column}"
+            _execute(
+                f"CREATE INDEX IF NOT EXISTS \"{index_name}\" ON {_qualify(table)} (\"{column}\")"
+            )
+            _ensure_foreign_key(table, column)
+
+    _execute(
+        f"""
+CREATE OR REPLACE FUNCTION {_qualified_function()}()
+RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+    )
+
+    for table in AUDIT_TABLES:
+        trigger_name = f"set_{table}_updated_at"
+        _execute(
+            f"DROP TRIGGER IF EXISTS \"{trigger_name}\" ON {_qualify(table)}"
+        )
+        _execute(
+            f"""
+CREATE TRIGGER "{trigger_name}"
+BEFORE UPDATE ON {_qualify(table)}
+FOR EACH ROW
+EXECUTE FUNCTION {_qualified_function()}();
+"""
+        )
+
+
+def downgrade() -> None:
+    for table in AUDIT_TABLES:
+        for column in AUDIT_COLUMNS:
+            index_name = f"ix_{table}_{column}"
+            _execute(f"DROP INDEX IF EXISTS {_qualify_index(index_name)}")


### PR DESCRIPTION
## Summary
- harden the Alembic environment so connections always target the psi schema and the version table lives there
- add revision 0008 to safely backfill audit columns, indexes, foreign keys, and triggers with idempotent PostgreSQL blocks
- document Heroku migration operations, wire the Procfile release phase, and provide simple Makefile helpers

## Testing
- pytest backend/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d2aa0a39dc832ebf5551810042d26d