### PR TITLE
Add username metadata search for sessions and transfers

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,10 @@ export interface Session {
   is_leader: boolean;
   created_at: string;
   updated_at: string;
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_by_username?: string | null;
+  updated_by_username?: string | null;
 }
 
 export interface PSIDailyEntry {
@@ -58,6 +62,10 @@ export interface ChannelTransferCreate extends ChannelTransferIdentifier {
 export interface ChannelTransfer extends ChannelTransferCreate {
   created_at: string;
   updated_at: string;
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_by_username?: string | null;
+  updated_by_username?: string | null;
 }
 
 export interface PSIMetricDefinition {


### PR DESCRIPTION
## Summary
- expose session usernames in API responses and support searching by title, description, or username
- surface audit usernames for channel transfers and add username-based filtering in listings and export
- update UI tables and filters to show creator/updater usernames and allow querying by them, with supporting tests and migration tweaks

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d2ad42cee4832ea3d73af006b1589d