### PR TITLE
Add PSI edit audit view and API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from .routers import (
     channel_transfers,
     masters,
     psi,
+    psi_edits,
     psi_metrics,
     sessions,
     users,
@@ -47,6 +48,7 @@ app.include_router(sessions.router, prefix="/sessions", tags=["sessions"])
 app.include_router(masters.router, prefix="/masters", tags=["masters"])
 app.include_router(psi_metrics.router, prefix="/psi-metrics", tags=["psi-metrics"])
 app.include_router(psi.router, prefix="/psi", tags=["psi"])
+app.include_router(psi_edits.router, prefix="/psi-edits", tags=["psi-edits"])
 app.include_router(
     channel_transfers.router,
     prefix="/channel-transfers",
@@ -62,6 +64,7 @@ app.include_router(
     psi_metrics.router, prefix="/api/psi-metrics", tags=["psi-metrics"]
 )
 app.include_router(psi.router, prefix="/api/psi", tags=["psi"])
+app.include_router(psi_edits.router, prefix="/api/psi-edits", tags=["psi-edits"])
 app.include_router(
     channel_transfers.router,
     prefix="/api/channel-transfers",
@@ -103,6 +106,7 @@ API_PREFIXES = (
     "masters",
     "psi-metrics",
     "psi",
+    "psi-edits",
     "channel-transfers",
     "auth",
     "health",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -229,6 +229,16 @@ class PSIEdit(Base, SchemaMixin, TimestampMixin, UserTrackingMixin):
     safety_stock: Mapped[Decimal | None] = mapped_column(Numeric(20, 6))
 
     session: Mapped[Session] = relationship(back_populates="psi_edits")
+    created_by_user: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys="PSIEdit.created_by",
+        lazy="selectin",
+    )
+    updated_by_user: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys="PSIEdit.updated_by",
+        lazy="selectin",
+    )
 
 
 class PSIEditLog(Base, SchemaMixin, TimestampMixin, UserTrackingMixin):

--- a/backend/app/routers/psi_edits.py
+++ b/backend/app/routers/psi_edits.py
@@ -1,0 +1,275 @@
+"""API endpoints exposing manual PSI edits."""
+from __future__ import annotations
+
+import csv
+from datetime import date
+from io import StringIO
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import Session as DBSession, aliased, contains_eager, selectinload
+from sqlalchemy.sql import Select
+
+from .. import models, schemas
+from ..config import settings
+from ..deps import get_current_user, get_db
+
+router = APIRouter()
+
+
+def _with_audit_options(
+    query: Select, *, join_users: bool
+) -> tuple[Select, Any, Any]:
+    """Apply eager loading for audit user relationships when required."""
+
+    creator_alias = None
+    updater_alias = None
+
+    if join_users:
+        creator_alias = aliased(models.User)
+        updater_alias = aliased(models.User)
+        query = query.outerjoin(
+            creator_alias, models.PSIEdit.created_by == creator_alias.id
+        )
+        query = query.outerjoin(
+            updater_alias, models.PSIEdit.updated_by == updater_alias.id
+        )
+        query = query.options(
+            contains_eager(models.PSIEdit.created_by_user, alias=creator_alias),
+            contains_eager(models.PSIEdit.updated_by_user, alias=updater_alias),
+        )
+    else:
+        query = query.options(
+            selectinload(models.PSIEdit.created_by_user),
+            selectinload(models.PSIEdit.updated_by_user),
+        )
+
+    return query, creator_alias, updater_alias
+
+
+def _serialize_edit(edit: models.PSIEdit) -> schemas.PSIEditRead:
+    """Convert a PSI edit model into the API schema respecting feature flags."""
+
+    data = schemas.PSIEditRead.model_validate(edit, from_attributes=True)
+    data.created_by_username = (
+        edit.created_by_user.username if edit.created_by_user else None
+    )
+    data.updated_by_username = (
+        edit.updated_by_user.username if edit.updated_by_user else None
+    )
+    if not settings.audit_metadata_enabled:
+        data.created_by = None
+        data.updated_by = None
+    return data
+
+
+def _apply_username_search(
+    query: Select,
+    *,
+    username: str | None,
+    creator_alias: Any,
+    updater_alias: Any,
+) -> Select:
+    """Filter PSI edits by matching creator or updater usernames."""
+
+    if not username:
+        return query
+
+    if creator_alias is None or updater_alias is None:
+        raise RuntimeError("username filtering requires joined user aliases")
+
+    lowered = f"%{username.lower()}%"
+    return query.where(
+        or_(
+            func.lower(creator_alias.username).like(lowered),
+            func.lower(updater_alias.username).like(lowered),
+        )
+    )
+
+
+@router.get(
+    "",
+    response_model=list[schemas.PSIEditRead],
+    response_model_exclude_none=True,
+)
+@router.get(
+    "/",
+    response_model=list[schemas.PSIEditRead],
+    response_model_exclude_none=True,
+)
+def list_psi_edits(
+    *,
+    session_id: UUID | None = None,
+    sku_code: str | None = None,
+    warehouse_name: str | None = None,
+    updated_at: date | None = Query(None),
+    username: str | None = None,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> list[schemas.PSIEditRead]:
+    """Return PSI edit records matching the provided filters."""
+
+    _ = current_user
+
+    query = select(models.PSIEdit)
+    join_users = settings.audit_metadata_enabled or bool(username)
+    query, creator_alias, updater_alias = _with_audit_options(
+        query, join_users=join_users
+    )
+
+    if session_id is not None:
+        query = query.where(models.PSIEdit.session_id == session_id)
+    if sku_code:
+        lowered = f"%{sku_code.lower()}%"
+        query = query.where(func.lower(models.PSIEdit.sku_code).like(lowered))
+    if warehouse_name:
+        lowered = f"%{warehouse_name.lower()}%"
+        query = query.where(
+            func.lower(models.PSIEdit.warehouse_name).like(lowered)
+        )
+    if updated_at is not None:
+        query = query.where(func.date(models.PSIEdit.updated_at) == updated_at)
+
+    query = _apply_username_search(
+        query,
+        username=username,
+        creator_alias=creator_alias,
+        updater_alias=updater_alias,
+    )
+
+    query = query.order_by(
+        models.PSIEdit.date.asc(),
+        models.PSIEdit.sku_code.asc(),
+        models.PSIEdit.warehouse_name.asc(),
+        models.PSIEdit.channel.asc(),
+    )
+
+    edits = db.scalars(query).unique().all()
+    return [_serialize_edit(edit) for edit in edits]
+
+
+@router.get("/{session_id}/export")
+def export_psi_edits(
+    *,
+    session_id: UUID,
+    sku_code: str | None = None,
+    warehouse_name: str | None = None,
+    updated_at: date | None = Query(None),
+    username: str | None = None,
+    include_audit: bool = Query(False),
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> StreamingResponse:
+    """Stream PSI edits as a CSV download respecting provided filters."""
+
+    _ = current_user
+
+    session = db.get(models.Session, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    query = select(models.PSIEdit).where(models.PSIEdit.session_id == session_id)
+    join_users = settings.audit_metadata_enabled or include_audit or bool(username)
+    query, creator_alias, updater_alias = _with_audit_options(
+        query, join_users=join_users
+    )
+
+    if sku_code:
+        lowered = f"%{sku_code.lower()}%"
+        query = query.where(func.lower(models.PSIEdit.sku_code).like(lowered))
+    if warehouse_name:
+        lowered = f"%{warehouse_name.lower()}%"
+        query = query.where(
+            func.lower(models.PSIEdit.warehouse_name).like(lowered)
+        )
+    if updated_at is not None:
+        query = query.where(func.date(models.PSIEdit.updated_at) == updated_at)
+
+    query = _apply_username_search(
+        query,
+        username=username,
+        creator_alias=creator_alias,
+        updater_alias=updater_alias,
+    )
+
+    query = query.order_by(
+        models.PSIEdit.date.asc(),
+        models.PSIEdit.sku_code.asc(),
+        models.PSIEdit.warehouse_name.asc(),
+        models.PSIEdit.channel.asc(),
+    )
+
+    edits = db.scalars(query).unique().all()
+    include_audit_columns = include_audit and settings.audit_metadata_enabled
+
+    def iter_rows():
+        buffer = StringIO()
+        writer = csv.writer(buffer)
+
+        header = [
+            "session_title",
+            "date",
+            "sku_code",
+            "warehouse_name",
+            "channel",
+            "inbound_qty",
+            "outbound_qty",
+            "safety_stock",
+        ]
+        if include_audit_columns:
+            header.extend(
+                [
+                    "created_by",
+                    "created_by_username",
+                    "created_at",
+                    "updated_by",
+                    "updated_by_username",
+                    "updated_at",
+                ]
+            )
+
+        writer.writerow(header)
+        yield buffer.getvalue().encode("utf-8")
+        buffer.seek(0)
+        buffer.truncate(0)
+
+        for edit in edits:
+            data = _serialize_edit(edit)
+            row = [
+                session.title,
+                edit.date.isoformat(),
+                edit.sku_code,
+                edit.warehouse_name,
+                edit.channel,
+                str(edit.inbound_qty) if edit.inbound_qty is not None else "",
+                str(edit.outbound_qty) if edit.outbound_qty is not None else "",
+                str(edit.safety_stock) if edit.safety_stock is not None else "",
+            ]
+            if include_audit_columns:
+                row.extend(
+                    [
+                        str(data.created_by) if data.created_by else "",
+                        data.created_by_username or "",
+                        data.created_at.isoformat(),
+                        str(data.updated_by) if data.updated_by else "",
+                        data.updated_by_username or "",
+                        data.updated_at.isoformat(),
+                    ]
+                )
+
+            writer.writerow(row)
+            yield buffer.getvalue().encode("utf-8")
+            buffer.seek(0)
+            buffer.truncate(0)
+
+    filename = f"psi-edits-{session_id}.csv"
+    headers = {"Content-Disposition": f"attachment; filename=\"{filename}\""}
+
+    return StreamingResponse(
+        iter_rows(),
+        media_type="text/csv; charset=utf-8",
+        headers=headers,
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -105,6 +105,28 @@ class PSIEditApplyResult(BaseModel):
     last_edited_at: datetime | None = None
 
 
+class PSIEditRead(BaseModel):
+    """PSI edit entry returned by the API."""
+
+    id: int
+    session_id: UUID
+    sku_code: str
+    warehouse_name: str
+    channel: str
+    date: date
+    inbound_qty: float | None = None
+    outbound_qty: float | None = None
+    safety_stock: float | None = None
+    created_at: datetime
+    updated_at: datetime
+    created_by: UUID | None = None
+    updated_by: UUID | None = None
+    created_by_username: str | None = None
+    updated_by_username: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
 class PSISessionSummary(BaseModel):
     """High-level information about the available PSI data for a session."""
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -385,6 +385,7 @@ body {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .filter-actions button {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import SessionsPage from "./pages/SessionsPage";
 import PSITablePage from "./pages/PSITablePage";
 import MasterPage from "./pages/MasterPage";
 import TransferPage from "./pages/TransferPage";
+import EditsPage from "./pages/EditsPage";
 import DocsPage from "./pages/DocsPage";
 import LoginPage from "./pages/LoginPage";
 import { useAuth } from "./hooks/useAuth";
@@ -102,6 +103,14 @@ function ProtectedLayout() {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/edits" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              <span className="menu-icon" aria-hidden="true">
+                ✏️
+              </span>
+              <span className="menu-label">Edits</span>
+            </NavLink>
+          </li>
+          <li>
             <NavLink to="/docs" className={({ isActive }) => (isActive ? "active" : undefined)}>
               <span className="menu-icon" aria-hidden="true">
                 📚
@@ -149,6 +158,7 @@ function ProtectedLayout() {
           <Route path="/psi" element={<PSITablePage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/transfer" element={<TransferPage />} />
+          <Route path="/edits" element={<EditsPage />} />
           <Route path="/masters" element={<Navigate to={masters[0].path} replace />} />
         </Routes>
       </main>

--- a/frontend/src/pages/EditsPage.tsx
+++ b/frontend/src/pages/EditsPage.tsx
@@ -1,0 +1,319 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+import api from "../lib/api";
+import { useSessionsQuery } from "../hooks/usePsiQueries";
+import type { PSIEditRecord } from "../types";
+
+interface FilterState {
+  sku_code: string;
+  warehouse_name: string;
+  updated_at: string;
+  username: string;
+}
+
+type StatusMessage = { type: "success" | "error"; text: string };
+
+const getTodayIso = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const detail = (error.response?.data as { detail?: string } | undefined)?.detail;
+    if (detail) {
+      return detail;
+    }
+    if (error.message) {
+      return error.message;
+    }
+  } else if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+};
+
+const defaultFilters = (): FilterState => ({
+  sku_code: "",
+  warehouse_name: "",
+  updated_at: getTodayIso(),
+  username: "",
+});
+
+const fetchEdits = async (
+  sessionId: string,
+  filters: FilterState,
+): Promise<PSIEditRecord[]> => {
+  const params: Record<string, string> = { session_id: sessionId };
+  if (filters.sku_code.trim()) {
+    params.sku_code = filters.sku_code.trim();
+  }
+  if (filters.warehouse_name.trim()) {
+    params.warehouse_name = filters.warehouse_name.trim();
+  }
+  if (filters.updated_at) {
+    params.updated_at = filters.updated_at;
+  }
+  if (filters.username.trim()) {
+    params.username = filters.username.trim();
+  }
+
+  const { data } = await api.get<PSIEditRecord[]>("/psi-edits/", { params });
+  return data;
+};
+
+export default function EditsPage() {
+  const sessionsQuery = useSessionsQuery();
+  const sessions = sessionsQuery.data ?? [];
+  const leaderSession = useMemo(
+    () => sessions.find((session) => session.is_leader) ?? null,
+    [sessions],
+  );
+
+  const [selectedSessionId, setSelectedSessionId] = useState<string>("");
+  const [filterDraft, setFilterDraft] = useState<FilterState>(defaultFilters);
+  const [appliedFilters, setAppliedFilters] = useState<FilterState>(defaultFilters);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+
+  useEffect(() => {
+    if (!selectedSessionId && sessions.length) {
+      const fallback = leaderSession ?? sessions[0];
+      setSelectedSessionId(fallback.id);
+    }
+  }, [leaderSession, selectedSessionId, sessions]);
+
+  useEffect(() => {
+    const defaults = defaultFilters();
+    setFilterDraft(defaults);
+    setAppliedFilters(defaults);
+  }, [selectedSessionId]);
+
+  const editsQueryKey = useMemo(
+    () => [
+      "psi-edit-list",
+      selectedSessionId,
+      appliedFilters.sku_code,
+      appliedFilters.warehouse_name,
+      appliedFilters.updated_at,
+      appliedFilters.username,
+    ],
+    [selectedSessionId, appliedFilters],
+  );
+
+  const editsQuery = useQuery({
+    queryKey: editsQueryKey,
+    queryFn: () => fetchEdits(selectedSessionId, appliedFilters),
+    enabled: Boolean(selectedSessionId),
+  });
+
+  const edits = editsQuery.data ?? [];
+
+  const handleApplyFilters = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setAppliedFilters(filterDraft);
+    setStatus(null);
+  };
+
+  const handleResetFilters = () => {
+    const defaults = defaultFilters();
+    setFilterDraft(defaults);
+    setAppliedFilters(defaults);
+    setStatus(null);
+  };
+
+  const handleDownload = async () => {
+    if (!selectedSessionId) {
+      return;
+    }
+    try {
+      const params: Record<string, string> = {};
+      if (appliedFilters.sku_code.trim()) {
+        params.sku_code = appliedFilters.sku_code.trim();
+      }
+      if (appliedFilters.warehouse_name.trim()) {
+        params.warehouse_name = appliedFilters.warehouse_name.trim();
+      }
+      if (appliedFilters.updated_at) {
+        params.updated_at = appliedFilters.updated_at;
+      }
+      if (appliedFilters.username.trim()) {
+        params.username = appliedFilters.username.trim();
+      }
+
+      const response = await api.get<Blob>(`/psi-edits/${selectedSessionId}/export`, {
+        params,
+        responseType: "blob",
+      });
+
+      const blob = new Blob([response.data], {
+        type: response.headers["content-type"] ?? "text/csv;charset=utf-8",
+      });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      const disposition = response.headers["content-disposition"];
+      const match = typeof disposition === "string" ? disposition.match(/filename="?([^";]+)"?/i) : null;
+      const filename = match?.[1] ?? `psi-edits-${selectedSessionId}.csv`;
+      link.setAttribute("download", filename);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+      setStatus({ type: "success", text: "CSV download started." });
+    } catch (error) {
+      setStatus({ type: "error", text: getErrorMessage(error, "Unable to download CSV.") });
+    }
+  };
+
+  return (
+    <div className="page transfer-page">
+      <header>
+        <h1>PSI Edits</h1>
+        <p>Review manual PSI overrides and audit who made each change.</p>
+      </header>
+
+      {status ? <div className={`status-message ${status.type}`}>{status.text}</div> : null}
+
+      <section className="filters">
+        <h2>Filters</h2>
+        <form className="filter-form" onSubmit={handleApplyFilters}>
+          <label>
+            Session
+            <select
+              value={selectedSessionId}
+              onChange={(event) => {
+                setSelectedSessionId(event.target.value);
+                setStatus(null);
+              }}
+              required
+            >
+              <option value="" disabled>
+                Select session
+              </option>
+              {sessions.map((session) => (
+                <option key={session.id} value={session.id}>
+                  {session.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            SKU Code
+            <input
+              type="text"
+              value={filterDraft.sku_code}
+              onChange={(event) =>
+                setFilterDraft((previous) => ({ ...previous, sku_code: event.target.value }))
+              }
+              placeholder="Contains…"
+            />
+          </label>
+          <label>
+            Warehouse
+            <input
+              type="text"
+              value={filterDraft.warehouse_name}
+              onChange={(event) =>
+                setFilterDraft((previous) => ({ ...previous, warehouse_name: event.target.value }))
+              }
+              placeholder="Contains…"
+            />
+          </label>
+          <label>
+            Updated Date
+            <input
+              type="date"
+              value={filterDraft.updated_at}
+              onChange={(event) =>
+                setFilterDraft((previous) => ({ ...previous, updated_at: event.target.value }))
+              }
+            />
+          </label>
+          <label>
+            Username
+            <input
+              type="text"
+              value={filterDraft.username}
+              onChange={(event) =>
+                setFilterDraft((previous) => ({ ...previous, username: event.target.value }))
+              }
+              placeholder="Contains…"
+            />
+          </label>
+          <div className="filter-actions">
+            <button type="submit" disabled={!selectedSessionId}>
+              apply
+            </button>
+            <button type="button" className="secondary" onClick={handleResetFilters}>
+              reset
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={handleDownload}
+              disabled={!selectedSessionId}
+            >
+              DL
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section>
+        <h2>PSI Edit Records</h2>
+        {editsQuery.isLoading && !edits.length ? <p>Loading edits…</p> : null}
+        {editsQuery.error ? (
+          <p className="error-text">Failed to load PSI edits. Please try again.</p>
+        ) : null}
+        <div className="table-container">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>SKU</th>
+                <th>Warehouse</th>
+                <th>Channel</th>
+                <th>Inbound Qty</th>
+                <th>Outbound Qty</th>
+                <th>Safety Stock</th>
+                <th>Created By</th>
+                <th>Updated By</th>
+              </tr>
+            </thead>
+            <tbody>
+              {edits.map((edit) => (
+                <tr key={edit.id}>
+                  <td>{edit.date}</td>
+                  <td>{edit.sku_code}</td>
+                  <td>{edit.warehouse_name}</td>
+                  <td>{edit.channel}</td>
+                  <td>{edit.inbound_qty ?? "—"}</td>
+                  <td>{edit.outbound_qty ?? "—"}</td>
+                  <td>{edit.safety_stock ?? "—"}</td>
+                  <td>
+                    <div>{edit.created_by_username ?? "—"}</div>
+                    <small>{new Date(edit.created_at).toLocaleString()}</small>
+                  </td>
+                  <td>
+                    <div>{edit.updated_by_username ?? "—"}</div>
+                    <small>{new Date(edit.updated_at).toLocaleString()}</small>
+                  </td>
+                </tr>
+              ))}
+              {edits.length === 0 ? (
+                <tr>
+                  <td colSpan={9}>No edits match the selected filters.</td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/TransferPage.tsx
+++ b/frontend/src/pages/TransferPage.tsx
@@ -486,10 +486,10 @@ export default function TransferPage() {
           </label>
           <div className="filter-actions">
             <button type="submit" disabled={!selectedSessionId}>
-              Apply Filters
+              apply
             </button>
             <button type="button" className="secondary" onClick={handleResetFilters}>
-              Reset
+              reset
             </button>
             <button
               type="button"
@@ -497,7 +497,7 @@ export default function TransferPage() {
               onClick={handleDownload}
               disabled={!selectedSessionId}
             >
-              Download CSV
+              DL
             </button>
           </div>
         </form>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,6 +45,24 @@ export interface PSIEditApplyResult {
   last_edited_at?: string | null;
 }
 
+export interface PSIEditRecord {
+  id: number;
+  session_id: string;
+  sku_code: string;
+  warehouse_name: string;
+  channel: string;
+  date: string;
+  inbound_qty?: number | null;
+  outbound_qty?: number | null;
+  safety_stock?: number | null;
+  created_at: string;
+  updated_at: string;
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_by_username?: string | null;
+  updated_by_username?: string | null;
+}
+
 export interface ChannelTransferIdentifier {
   session_id: string;
   sku_code: string;


### PR DESCRIPTION
## Summary
- expose psi_edits records over new list and CSV export endpoints with audit metadata
- display PSI Edits table in the frontend with filtering, download, and navigation link
- simplify transfer filter button labels and align shared styling

## Testing
- npm --prefix frontend run build
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2b2462b78832e95e663b28c822613