### PR TITLE
Fix duplicate session audit properties

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,8 +7,6 @@ export interface Session {
   updated_by: string | null;
   created_at: string;
   updated_at: string;
-  created_by?: string | null;
-  updated_by?: string | null;
   created_by_username?: string | null;
   updated_by_username?: string | null;
 }


### PR DESCRIPTION
## Summary
- remove the duplicate optional audit field declarations from the `Session` interface so the TypeScript build can succeed

## Testing
- `cd frontend && npm ci`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d2b8158428832e8b2d983160511ad2