### PR TITLE
Fix Session audit relationships foreign keys

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -133,10 +133,10 @@ class Session(Base, SchemaMixin, TimestampMixin, UserTrackingMixin):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_leader: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        PGUUID(as_uuid=True), nullable=True
+        PGUUID(as_uuid=True), ForeignKey(_qualified("users")), nullable=True
     )
     updated_by: Mapped[uuid.UUID | None] = mapped_column(
-        PGUUID(as_uuid=True), nullable=True
+        PGUUID(as_uuid=True), ForeignKey(_qualified("users")), nullable=True
     )
 
     psi_base_records: Mapped[list["PSIBase"]] = relationship(


### PR DESCRIPTION
## Summary
- add missing foreign key constraints to Session.created_by and Session.updated_by so SQLAlchemy can configure audit relationships correctly

## Testing
- `pip install -r requirements.txt` *(fails: network proxy 403 prevents downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bb7df078832ebb947de3e458f0f6