### PR TITLE
Adjust sessions search form layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -236,6 +236,30 @@ body {
   font-weight: 600;
 }
 
+.search-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.search-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.search-form input[type="search"] {
+  min-width: min(320px, 100%);
+}
+
+.search-actions {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .checkbox-field {
   display: grid;
   grid-template-columns: auto 1fr;


### PR DESCRIPTION
## Summary
- lay out the sessions search input and action buttons on a single row
- add responsive flex styling so the search controls stay aligned while wrapping when space is limited

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2bcc8fbd4832ea379dd1259d50f5d