### PR TITLE
Remove PSI today highlight and fix CSV encoding

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -19,9 +19,6 @@
       var(--psi-col-channel-width) +
       var(--psi-col-div-width)
   );
-  --psi-today-bg: rgba(59, 130, 246, 0.14);
-  --psi-today-header-bg: rgba(59, 130, 246, 0.18);
-  --psi-today-border: rgba(96, 165, 250, 0.4);
   --psi-row-selected-bg: rgba(34, 197, 94, 0.12);
   --psi-row-selected-border: rgba(34, 197, 94, 0.35);
   --psi-row-selected-fg: var(--text-primary);
@@ -1144,19 +1141,8 @@ button.icon-button:focus-visible {
   border-left-color: var(--accent-green);
 }
 
-.psi-table-row.selected .today-column {
-  background:
-    linear-gradient(rgba(34, 197, 94, 0.12), rgba(34, 197, 94, 0.12)),
-    var(--psi-today-bg);
-  box-shadow: inset 1px 0 0 var(--psi-today-border), inset -1px 0 0 var(--psi-today-border), inset 0 0 0 1px var(--psi-row-selected-border);
-}
-
 .psi-table-row.selected:focus-visible td {
   box-shadow: inset 0 0 0 1px var(--psi-row-selected-border), inset 0 0 0 2px rgba(59, 130, 246, 0.55);
-}
-
-.psi-table-row.selected:focus-visible .today-column {
-  box-shadow: inset 1px 0 0 var(--psi-today-border), inset -1px 0 0 var(--psi-today-border), inset 0 0 0 1px var(--psi-row-selected-border), inset 0 0 0 2px rgba(59, 130, 246, 0.55);
 }
 
 .psi-table-row.selected .psi-edit-input:not(.edited) {
@@ -1169,18 +1155,7 @@ button.icon-button:focus-visible {
   box-shadow: 1px 0 0 var(--border-default), inset 0 0 0 1px var(--psi-row-selected-border);
 }
 
-.psi-table .today-column {
-  background: var(--psi-today-bg);
-  box-shadow: inset 1px 0 0 var(--psi-today-border), inset -1px 0 0 var(--psi-today-border);
-  z-index: 1;
-}
-
-.psi-table thead .today-column {
-  background: var(--psi-today-header-bg);
-  color: var(--text-primary);
-}
-
-.psi-table-row:not(.selected):hover td:not(.today-column) {
+.psi-table-row:not(.selected):hover td {
   background: rgba(148, 163, 184, 0.1);
 }
 
@@ -1583,7 +1558,7 @@ button.icon-button:focus-visible {
   background-color: var(--surface-table-zebra);
 }
 
-.psi-rdg .rdg-row:hover .rdg-cell:not(.psi-grid-cell-today):not(.rdg-cell-editing):not([aria-selected="true"]):not(.psi-grid-value-negative):not(.psi-grid-stock-warning):not(.psi-grid-value-surplus) {
+.psi-rdg .rdg-row:hover .rdg-cell:not(.rdg-cell-editing):not([aria-selected="true"]):not(.psi-grid-value-negative):not(.psi-grid-stock-warning):not(.psi-grid-value-surplus) {
   background-color: var(--psi-grid-hover);
 }
 
@@ -1723,18 +1698,6 @@ button.icon-button:focus-visible {
 
 .psi-grid-cell-editable {
   background-color: var(--psi-grid-editable);
-}
-
-.psi-grid-cell-today {
-  background-color: var(--psi-today-bg);
-  position: relative;
-  z-index: 1;
-}
-
-.psi-grid-header-today {
-  background-color: var(--psi-today-header-bg);
-  position: relative;
-  z-index: 2;
 }
 
 .psi-grid-stock-warning {
@@ -2008,7 +1971,6 @@ button.danger:hover {
 }
 
 @media print {
-  .psi-table .today-column,
   .psi-table-row.selected td,
   .psi-table .sticky-col.selected {
     background: transparent !important;

--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -25,7 +25,6 @@ interface PSITableContentProps {
   selectedSku: string | null;
   visibleMetrics: MetricDefinition[];
   allDates: string[];
-  todayIso: string;
   formatDisplayDate: (iso: string) => string;
   onDownload: () => void;
   canDownload: boolean;
@@ -129,7 +128,6 @@ const PSITableContent = ({
   selectedSku,
   visibleMetrics,
   allDates,
-  todayIso,
   formatDisplayDate,
   onDownload,
   canDownload,
@@ -392,17 +390,13 @@ const PSITableContent = ({
   const dateColumns = useMemo<Column<PSIGridRow>[]>(
     () =>
       allDates.map((date) => {
-        const isToday = date === todayIso;
         return {
           key: date,
           name: formatDisplayDate(date),
           width: 132,
           className: (row: PSIGridRow) => {
             if (row.rowType !== "metric") {
-              return classNames(
-                "psi-grid-group-cell",
-                isToday && "psi-grid-cell-today"
-              );
+              return "psi-grid-group-cell";
             }
 
             const cellValue = row[date] as number | null | undefined;
@@ -414,13 +408,12 @@ const PSITableContent = ({
             return classNames(
               "psi-grid-value-cell",
               row.metricEditable && "psi-grid-cell-editable",
-              isToday && "psi-grid-cell-today",
               isNegativeValue && "psi-grid-value-negative",
               showStockWarning && "psi-grid-stock-warning",
               showMovableSurplus && "psi-grid-value-surplus"
             );
           },
-          headerCellClass: classNames("psi-grid-date-header", isToday && "psi-grid-header-today"),
+          headerCellClass: "psi-grid-date-header",
           renderCell: ({ row }) =>
             row.rowType === "metric" ? formatNumber(row[date] as number | null | undefined) : null,
           renderEditCell: (props) => <NumberEditor {...props} />,
@@ -430,7 +423,7 @@ const PSITableContent = ({
           setHeaderRef: (element: HTMLDivElement | null) => handleHeaderRef(date, element),
         } satisfies Column<PSIGridRow>;
       }),
-    [allDates, formatDisplayDate, formatNumber, handleHeaderRef, todayIso]
+    [allDates, formatDisplayDate, formatNumber, handleHeaderRef]
   );
 
   const columns = useMemo(() => {

--- a/frontend/src/components/PSITableSplit.tsx
+++ b/frontend/src/components/PSITableSplit.tsx
@@ -21,7 +21,6 @@ interface PSITableSplitProps {
   onMetricVisibilityChange: (metricKey: MetricKey) => void;
   metricSelectorRef: MutableRefObject<HTMLDivElement | null>;
   allDates: string[];
-  todayIso: string;
   formatDisplayDate: (iso: string) => string;
   onEditableChange: (channelKey: string, date: string, field: EditableField, rawValue: string) => void;
   onPasteValues: (
@@ -68,7 +67,6 @@ const PSITableSplit = ({
   onMetricVisibilityChange,
   metricSelectorRef,
   allDates,
-  todayIso,
   formatDisplayDate,
   onEditableChange,
   onPasteValues,
@@ -313,11 +311,7 @@ const PSITableSplit = ({
                 <thead>
                   <tr>
                     {allDates.map((date) => (
-                      <th
-                        key={date}
-                        className={`date-header${date === todayIso ? " today-column" : ""}`}
-                        data-date={date}
-                      >
+                      <th key={date} className="date-header" data-date={date}>
                         {formatDisplayDate(date)}
                       </th>
                     ))}
@@ -411,11 +405,9 @@ const PSITableSplit = ({
                     {allDates.map((date) => {
                       const entry = dateMap.get(date);
                       const cellKey = `${channelKey}-${metric.key}-${date}`;
-                      const todayClass = date === todayIso ? " today-column" : "";
-
                       if (!entry) {
                         return (
-                          <td key={cellKey} className={`numeric${todayClass}`}>
+                          <td key={cellKey} className="numeric">
                             —
                           </td>
                         );
@@ -430,7 +422,7 @@ const PSITableSplit = ({
                         const isEdited = !valuesEqual(currentValue, baselineValue);
 
                         return (
-                          <td key={cellKey} className={`numeric${todayClass}`}>
+                          <td key={cellKey} className="numeric">
                             <input
                               type="text"
                               className={`psi-edit-input${isEdited ? " edited" : ""}`}
@@ -454,7 +446,7 @@ const PSITableSplit = ({
                       }
 
                       return (
-                        <td key={cellKey} className={`numeric${todayClass}`}>
+                        <td key={cellKey} className="numeric">
                           {formatNumber(value)}
                         </td>
                       );

--- a/frontend/src/pages/EditsPage.tsx
+++ b/frontend/src/pages/EditsPage.tsx
@@ -150,7 +150,7 @@ export default function EditsPage() {
         responseType: "blob",
       });
 
-      const blob = new Blob([response.data], {
+      const blob = new Blob(["\ufeff", response.data], {
         type: response.headers["content-type"] ?? "text/csv;charset=utf-8",
       });
       const url = window.URL.createObjectURL(blob);

--- a/frontend/src/pages/PSITablePage.tsx
+++ b/frontend/src/pages/PSITablePage.tsx
@@ -880,7 +880,6 @@ export default function PSITablePage() {
           selectedSku={selectedSku}
           visibleMetrics={visibleMetrics}
           allDates={allDates}
-          todayIso={todayIso}
           formatDisplayDate={formatDisplayDate}
           onDownload={handleDownload}
           canDownload={Boolean(displayedTableData.length && visibleMetrics.length)}

--- a/frontend/src/pages/TransferPage.tsx
+++ b/frontend/src/pages/TransferPage.tsx
@@ -390,7 +390,7 @@ export default function TransferPage() {
         responseType: "blob",
       });
 
-      const blob = new Blob([response.data], {
+      const blob = new Blob(["\ufeff", response.data], {
         type: response.headers["content-type"] ?? "text/csv;charset=utf-8",
       });
       const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- remove the PSI table logic and styles that highlighted the current day column
- prepend a UTF-8 BOM when generating PSI edit and channel transfer CSV downloads so Japanese text stays readable

## Testing
- npm --prefix frontend run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32e3cc594832e8d86b5fae5d12b95