### PR TITLE
feat: make PSI metric filter movable popup

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1523,19 +1523,73 @@ button.icon-button:focus-visible {
   flex-shrink: 0;
 }
 
-.psi-grid-metric-menu {
-  position: absolute;
-  top: calc(100% + 0.25rem);
-  right: 0;
-  z-index: 10;
+
+.psi-grid-metric-popup {
+  position: fixed;
+  z-index: 30;
   background-color: var(--surface-panel);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
-  box-shadow: 0 12px 28px rgba(8, 13, 23, 0.2);
-  padding: 0.5rem;
-  min-width: 220px;
-  max-height: 320px;
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 40px rgba(8, 13, 23, 0.32);
+  width: min(320px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.psi-grid-metric-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  cursor: move;
+  background-color: var(--surface-muted);
+  border-bottom: 1px solid var(--border-default);
+  user-select: none;
+}
+
+.psi-grid-metric-popup-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.psi-grid-metric-popup-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.psi-grid-metric-popup-close:hover,
+.psi-grid-metric-popup-close:focus-visible {
+  background-color: var(--surface-input);
+  border-color: var(--border-input);
+}
+
+.psi-grid-metric-popup-content {
+  padding: 0.75rem 1rem 0.5rem;
   overflow-y: auto;
+  flex: 1;
+}
+
+.psi-grid-metric-popup .psi-grid-metric-options {
+  max-height: none;
+}
+
+.psi-grid-metric-popup .psi-grid-metric-menu-actions {
+  margin-top: 0;
+  padding: 0.75rem 1rem 1rem;
+  border-top: 1px solid var(--border-default);
 }
 
 .psi-grid-metric-options {


### PR DESCRIPTION
## Summary
- convert the PSI metric selector into a draggable popup rendered independently from the grid header
- keep at least one metric selected by blocking the final checkbox and removing the bulk clear action
- refresh styling for the selector popup with a floating panel, close button, and viewport clamping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ef534430832ebe7aed409be282ce