### PR TITLE
Add PSI report generation and modal display

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -137,6 +137,26 @@ class PSISessionSummary(BaseModel):
     end_date: date | None = None
 
 
+class PSIReportSettings(BaseModel):
+    """Configuration snapshot returned with generated reports."""
+
+    lead_time_days: int
+    safety_buffer_days: float
+    min_move_qty: float
+    target_days_ahead: int
+    priority_channels: list[str] | None = None
+
+
+class PSIReportResponse(BaseModel):
+    """Markdown report produced for a SKU within a session."""
+
+    sku_code: str
+    sku_name: str | None = None
+    generated_at: datetime
+    report_markdown: str
+    settings: PSIReportSettings
+
+
 class MasterRecordBase(BaseModel):
     """Shared attributes for master record write models."""
 

--- a/backend/app/services/psi_report/__init__.py
+++ b/backend/app/services/psi_report/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for generating PSI markdown reports."""
+
+from .config import Settings
+from .data import PivotRow, build_pivot_rows
+from .analysis import detect_stockout_risk, first_stockout_date
+from .transfer import suggest_channel_transfers
+from .reporter import build_summary_md
+
+__all__ = [
+    "Settings",
+    "PivotRow",
+    "build_pivot_rows",
+    "detect_stockout_risk",
+    "first_stockout_date",
+    "suggest_channel_transfers",
+    "build_summary_md",
+]

--- a/backend/app/services/psi_report/analysis.py
+++ b/backend/app/services/psi_report/analysis.py
@@ -1,0 +1,65 @@
+"""Stockout risk calculations for PSI reports."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable
+
+from .config import Settings
+from .data import PivotRow
+
+
+@dataclass(frozen=True, slots=True)
+class StockoutRisk:
+    sku_code: str
+    sku_name: str | None
+    warehouse_name: str
+    date: date
+    channels_count: int
+    total_stock: float
+    total_deficit: float
+    total_surplus: float
+    has_deficit: bool
+    can_fully_cover: bool
+
+
+def detect_stockout_risk(rows: Iterable[PivotRow], cfg: Settings) -> list[StockoutRisk]:
+    _ = cfg  # placeholder for future tuning knobs
+    grouped: dict[tuple[str, str, date], list[PivotRow]] = defaultdict(list)
+    for row in rows:
+        grouped[(row.sku_code, row.warehouse_name, row.date)].append(row)
+
+    risks: list[StockoutRisk] = []
+    for (sku_code, warehouse_name, record_date), items in grouped.items():
+        sku_name = items[0].sku_name
+        total_stock = sum(item.stock_closing for item in items)
+        total_deficit = sum(max(0.0, -item.stock_closing) for item in items)
+        total_surplus = sum(max(0.0, item.stock_closing) for item in items)
+        has_deficit = total_deficit > 0
+        can_cover = has_deficit and total_surplus >= total_deficit
+        risks.append(
+            StockoutRisk(
+                sku_code=sku_code,
+                sku_name=sku_name,
+                warehouse_name=warehouse_name,
+                date=record_date,
+                channels_count=len(items),
+                total_stock=total_stock,
+                total_deficit=total_deficit,
+                total_surplus=total_surplus,
+                has_deficit=has_deficit,
+                can_fully_cover=can_cover,
+            )
+        )
+
+    risks.sort(key=lambda item: (item.date, item.warehouse_name))
+    return risks
+
+
+def first_stockout_date(risk_rows: Iterable[StockoutRisk], sku_code: str, warehouse_name: str) -> date | None:
+    for row in risk_rows:
+        if row.sku_code == sku_code and row.warehouse_name == warehouse_name and row.has_deficit:
+            return row.date
+    return None

--- a/backend/app/services/psi_report/config.py
+++ b/backend/app/services/psi_report/config.py
@@ -1,0 +1,45 @@
+"""Configuration models for PSI report generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+def _normalise_priority_channels(priority: Iterable[str] | None) -> list[str] | None:
+    if priority is None:
+        return None
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for channel in priority:
+        normalised = channel.strip()
+        if not normalised:
+            continue
+        lowered = normalised.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        ordered.append(lowered)
+    return ordered or None
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime tunables for the PSI report pipeline."""
+
+    lead_time_days: int = 2
+    safety_buffer_days: float = 0.0
+    min_move_qty: float = 0.0
+    target_days_ahead: int = 14
+    priority_channels: list[str] | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive validation
+        if self.lead_time_days < 0:
+            raise ValueError("lead_time_days must be >= 0")
+        if self.safety_buffer_days < 0:
+            raise ValueError("safety_buffer_days must be >= 0")
+        if self.min_move_qty < 0:
+            raise ValueError("min_move_qty must be >= 0")
+        if self.target_days_ahead <= 0:
+            raise ValueError("target_days_ahead must be > 0")
+        self.priority_channels = _normalise_priority_channels(self.priority_channels)

--- a/backend/app/services/psi_report/data.py
+++ b/backend/app/services/psi_report/data.py
@@ -1,0 +1,78 @@
+"""Transform PSI channel responses into pivot-style rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Iterable, Sequence
+
+from ... import schemas
+
+
+@dataclass(frozen=True, slots=True)
+class PivotRow:
+    """Single daily PSI observation for a SKU/channel."""
+
+    sku_code: str
+    sku_name: str | None
+    warehouse_name: str
+    channel: str
+    date: date
+    stock_closing: float
+    inbound_qty: float
+    outbound_qty: float
+    channel_move: float
+    safety_stock: float
+    inventory_days: float | None
+
+
+@dataclass(slots=True)
+class PivotResult:
+    rows: list[PivotRow]
+    start_date: date | None
+    end_date: date | None
+
+
+def _coerce_float(value: float | int | None) -> float:
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def build_pivot_rows(
+    channels: Sequence[schemas.ChannelDailyPSI],
+    *,
+    target_days_ahead: int,
+) -> PivotResult:
+    """Flatten PSI channel responses into per-day rows."""
+
+    rows: list[PivotRow] = []
+    for channel in channels:
+        for entry in channel.daily:
+            rows.append(
+                PivotRow(
+                    sku_code=channel.sku_code,
+                    sku_name=channel.sku_name,
+                    warehouse_name=channel.warehouse_name,
+                    channel=channel.channel,
+                    date=entry.date,
+                    stock_closing=_coerce_float(entry.stock_closing),
+                    inbound_qty=_coerce_float(entry.inbound_qty),
+                    outbound_qty=_coerce_float(entry.outbound_qty),
+                    channel_move=_coerce_float(entry.channel_move),
+                    safety_stock=_coerce_float(entry.safety_stock),
+                    inventory_days=float(entry.inventory_days)
+                    if entry.inventory_days is not None
+                    else None,
+                )
+            )
+
+    if not rows:
+        return PivotResult(rows=[], start_date=None, end_date=None)
+
+    rows.sort(key=lambda item: (item.date, item.warehouse_name, item.channel))
+    start = rows[0].date
+    cutoff = start + timedelta(days=target_days_ahead - 1)
+    filtered = [row for row in rows if row.date <= cutoff]
+    end = max(row.date for row in filtered) if filtered else None
+    return PivotResult(rows=filtered, start_date=start, end_date=end)

--- a/backend/app/services/psi_report/reporter.py
+++ b/backend/app/services/psi_report/reporter.py
@@ -1,0 +1,236 @@
+"""Markdown report builder for PSI insights."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Sequence
+
+from .analysis import StockoutRisk
+from .config import Settings
+from .data import PivotRow
+from .transfer import TransferSuggestion
+
+
+@dataclass(slots=True)
+class WarehouseCoverage:
+    warehouse_name: str
+    first_stockout: date | None
+    coverage_start: date | None
+    coverage_end: date | None
+    coverage_reason: str | None
+    transfer_summary: list[tuple[str, str, float]]
+
+
+def _format_date(value: date | None) -> str:
+    if value is None:
+        return "—"
+    return value.strftime("%Y-%m-%d")
+
+
+def _format_quantity(value: float) -> str:
+    return f"{value:,.0f}" if abs(value) >= 1 else f"{value:,.2f}"
+
+
+def _warehouse_transfer_summary(transfers: Sequence[TransferSuggestion], warehouse: str) -> list[tuple[str, str, float]]:
+    grouped: dict[tuple[str, str], float] = defaultdict(float)
+    for transfer in transfers:
+        if transfer.warehouse_name != warehouse:
+            continue
+        grouped[(transfer.from_channel, transfer.to_channel)] += transfer.quantity
+    summary: list[tuple[str, str, float]] = []
+    for (from_channel, to_channel), qty in sorted(grouped.items(), key=lambda item: (-item[1], item[0])):
+        summary.append((from_channel, to_channel, qty))
+    return summary
+
+
+def _coverage_reason(row: StockoutRisk) -> str:
+    if row.total_surplus <= row.total_deficit:
+        return "余剰不足（移動では不足量を満たせません）"
+    return "総在庫不足（全チャネル合計がマイナス）"
+
+
+def _compute_warehouse_coverage(
+    warehouse: str,
+    sku_code: str,
+    risks: Sequence[StockoutRisk],
+    transfers: Sequence[TransferSuggestion],
+) -> WarehouseCoverage:
+    relevant = sorted(
+        (row for row in risks if row.warehouse_name == warehouse and row.sku_code == sku_code),
+        key=lambda item: item.date,
+    )
+    first = next((row for row in relevant if row.has_deficit), None)
+    if first is None:
+        return WarehouseCoverage(
+            warehouse_name=warehouse,
+            first_stockout=None,
+            coverage_start=None,
+            coverage_end=None,
+            coverage_reason=None,
+            transfer_summary=_warehouse_transfer_summary(transfers, warehouse),
+        )
+
+    coverage_start = first.date if first.can_fully_cover else None
+    coverage_end = first.date if first.can_fully_cover else None
+    reason = None
+
+    if first.can_fully_cover:
+        last_covered = first.date
+        for row in relevant:
+            if row.date < first.date or not row.has_deficit:
+                continue
+            if not row.can_fully_cover:
+                reason = _coverage_reason(row)
+                break
+            gap = (row.date - last_covered).days
+            if gap > 1:
+                reason = "不足日が連続していないため逐次移動でのカバーが困難です"
+                break
+            coverage_end = row.date
+            last_covered = row.date
+        if reason is None and coverage_start is not None and coverage_end is not None:
+            max_deficit_date = max((row.date for row in relevant if row.has_deficit), default=coverage_end)
+            if coverage_end < max_deficit_date:
+                trailing = next(
+                    (row for row in relevant if row.date > coverage_end and row.has_deficit),
+                    None,
+                )
+                if trailing is not None:
+                    reason = _coverage_reason(trailing)
+    else:
+        reason = _coverage_reason(first)
+
+    return WarehouseCoverage(
+        warehouse_name=warehouse,
+        first_stockout=first.date,
+        coverage_start=coverage_start,
+        coverage_end=coverage_end,
+        coverage_reason=reason,
+        transfer_summary=_warehouse_transfer_summary(transfers, warehouse),
+    )
+
+
+def _risk_table_rows(risks: Sequence[StockoutRisk], limit: int) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for row in risks:
+        if not row.has_deficit:
+            continue
+        rows.append(
+            [
+                _format_date(row.date),
+                row.warehouse_name,
+                _format_quantity(row.total_stock),
+                _format_quantity(row.total_deficit),
+                _format_quantity(row.total_surplus),
+                "○" if row.can_fully_cover else "×",
+            ]
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _transfer_table_rows(transfers: Sequence[TransferSuggestion], limit: int) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for transfer in transfers[:limit]:
+        rows.append(
+            [
+                transfer.date.strftime("%Y-%m-%d"),
+                transfer.warehouse_name,
+                f"{transfer.from_channel} → {transfer.to_channel}",
+                _format_quantity(transfer.quantity),
+            ]
+        )
+    return rows
+
+
+def _render_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> list[str]:
+    if not rows:
+        return ["(該当なし)"]
+    header_line = " | ".join(headers)
+    separator = " | ".join(["---"] * len(headers))
+    lines = [f"| {header_line} |", f"| {separator} |"]
+    for row in rows:
+        lines.append(f"| {' | '.join(row)} |")
+    return lines
+
+
+def build_summary_md(
+    risks: Sequence[StockoutRisk],
+    transfers: Sequence[TransferSuggestion],
+    rows: Sequence[PivotRow],
+    cfg: Settings,
+    *,
+    generated_at: datetime,
+) -> str:
+    if not rows:
+        return "# 在庫移動レポート\n\n対象データが見つかりませんでした。"
+
+    sku_code = rows[0].sku_code
+    sku_name = rows[0].sku_name
+    start_date = min(row.date for row in rows)
+    end_date = max(row.date for row in rows)
+    warehouses = sorted({row.warehouse_name for row in rows})
+
+    lines: list[str] = []
+    lines.append(f"# 在庫移動レポート — SKU: {sku_code}")
+    if sku_name:
+        lines.append(f"**商品名**: {sku_name}")
+    lines.append(f"**対象期間**: {_format_date(start_date)} 〜 {_format_date(end_date)}")
+    lines.append(
+        "**生成日時**: " + generated_at.strftime("%Y-%m-%d %H:%M")
+    )
+    lines.append(
+        f"**設定**: LT={cfg.lead_time_days}日 / 安全在庫バッファ={cfg.safety_buffer_days}日 / 最小移動={cfg.min_move_qty} / 先読み={cfg.target_days_ahead}日"
+    )
+    if cfg.priority_channels:
+        lines.append("**優先チャネル**: " + ", ".join(cfg.priority_channels))
+    lines.append("")
+
+    lines.append("## 倉庫別ハイライト")
+    for warehouse in warehouses:
+        coverage = _compute_warehouse_coverage(warehouse, sku_code, risks, transfers)
+        lines.append(f"### {warehouse}")
+        lines.append(f"- 初回欠品日: {_format_date(coverage.first_stockout)}")
+        lines.append(
+            f"- 移動で賄える期間: {_format_date(coverage.coverage_start)} 〜 {_format_date(coverage.coverage_end)}"
+        )
+        if coverage.coverage_reason:
+            lines.append(f"- 賄えない理由: {coverage.coverage_reason}")
+        summary_lines = coverage.transfer_summary
+        if summary_lines:
+            lines.append("- 推奨移動合計:")
+            for from_channel, to_channel, qty in summary_lines:
+                lines.append(
+                    f"  - {from_channel} → {to_channel}: {_format_quantity(qty)}"
+                )
+        else:
+            lines.append("- 推奨移動合計: (提案なし)")
+        lines.append("")
+
+    lines.append("## 欠品リスク一覧 (上位10件)")
+    risk_rows = _risk_table_rows(risks, limit=10)
+    lines.extend(_render_table(["日付", "倉庫", "総在庫", "不足合計", "余剰合計", "移動で解消"], risk_rows))
+    lines.append("")
+
+    lines.append("## 移動提案一覧 (上位10件)")
+    transfer_rows = _transfer_table_rows(transfers, limit=10)
+    lines.extend(_render_table(["移動日", "倉庫", "移動方向", "数量"], transfer_rows))
+    lines.append("")
+
+    lines.append("## 担当者向けアクション")
+    actionable_transfers = len(transfers)
+    actionable_warehouses = sum(1 for warehouse in warehouses if any(t.warehouse_name == warehouse for t in transfers))
+    if actionable_transfers:
+        lines.append(f"- チャネル移動を {actionable_transfers} 件確認し、倉庫担当へ共有してください。")
+    else:
+        lines.append("- 現時点で移動提案はありません。欠品動向をモニタリングしてください。")
+    lines.append(
+        "- 在庫バランスを確認し、補充計画や入荷前倒しが可能か検討してください。"
+    )
+    if actionable_warehouses:
+        lines.append(f"- 特に {actionable_warehouses} 倉庫で不足が顕在化しています。現場と連携し対応状況を追跡してください。")
+
+    return "\n".join(lines)

--- a/backend/app/services/psi_report/transfer.py
+++ b/backend/app/services/psi_report/transfer.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+"""Greedy channel transfer suggestions for PSI reports."""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Iterable
+
+from .config import Settings
+from .data import PivotRow
+
+@dataclass(frozen=True, slots=True)
+class TransferSuggestion:
+    date: date
+    sku_code: str
+    sku_name: str | None
+    warehouse_name: str
+    from_channel: str
+    to_channel: str
+    quantity: float
+
+
+def _priority_key(channel: str, priority: list[str] | None) -> tuple[int, str]:
+    if priority is None:
+        return (0, channel)
+    lowered = channel.lower()
+    if lowered in priority:
+        return (priority.index(lowered), channel)
+    return (len(priority), channel)
+
+
+def _average_outbound(rows: Iterable[PivotRow]) -> float:
+    total = 0.0
+    count = 0
+    for row in rows:
+        if row.outbound_qty > 0:
+            total += row.outbound_qty
+            count += 1
+    if count == 0:
+        return 0.0
+    return total / count
+
+
+def suggest_channel_transfers(rows: Iterable[PivotRow], cfg: Settings) -> list[TransferSuggestion]:
+    grouped: dict[tuple[str, str], list[PivotRow]] = defaultdict(list)
+    for row in rows:
+        grouped[(row.sku_code, row.warehouse_name)].append(row)
+
+    suggestions: list[TransferSuggestion] = []
+
+    for (sku_code, warehouse_name), entries in grouped.items():
+        entries.sort(key=lambda item: (item.date, item.channel))
+        channels = sorted({row.channel for row in entries})
+        if len(channels) < 2:
+            continue
+
+        rows_by_channel_date: dict[tuple[str, date], PivotRow] = {
+            (row.channel, row.date): row for row in entries
+        }
+        dates = sorted({row.date for row in entries})
+        outbound_by_channel = {
+            channel: _average_outbound(row for row in entries if row.channel == channel)
+            for channel in channels
+        }
+
+        for current_date in dates:
+            stocks: dict[str, float] = {}
+            for channel in channels:
+                row = rows_by_channel_date.get((channel, current_date))
+                stocks[channel] = row.stock_closing if row else 0.0
+
+            deficits = [channel for channel in channels if stocks[channel] < 0]
+            if not deficits:
+                continue
+
+            surpluses = [channel for channel in channels if stocks[channel] > 0]
+            if not surpluses:
+                continue
+
+            deficits.sort(
+                key=lambda channel: (
+                    _priority_key(channel, cfg.priority_channels),
+                    stocks[channel],
+                )
+            )
+            surpluses.sort(key=lambda channel: stocks[channel], reverse=True)
+
+            buffer_by_channel = {
+                channel: outbound_by_channel[channel] * cfg.safety_buffer_days
+                for channel in channels
+            }
+
+            planned: dict[tuple[str, str], float] = defaultdict(float)
+
+            for deficit_channel in deficits:
+                need = abs(stocks[deficit_channel])
+                if need <= 0:
+                    continue
+                for surplus_channel in surpluses:
+                    if surplus_channel == deficit_channel:
+                        continue
+                    available = max(0.0, stocks[surplus_channel] - buffer_by_channel[surplus_channel])
+                    if available <= 0:
+                        continue
+                    move_qty = min(available, need)
+                    if move_qty < cfg.min_move_qty:
+                        continue
+                    stocks[surplus_channel] -= move_qty
+                    stocks[deficit_channel] += move_qty
+                    need -= move_qty
+                    planned[(surplus_channel, deficit_channel)] += move_qty
+                    if need <= 0:
+                        break
+
+            if not planned:
+                continue
+
+            effective_date = current_date
+            if cfg.lead_time_days > 0:
+                shifted = current_date - timedelta(days=cfg.lead_time_days)
+                earliest_date = dates[0]
+                if shifted >= earliest_date:
+                    effective_date = shifted
+
+            for (from_channel, to_channel), qty in planned.items():
+                suggestions.append(
+                    TransferSuggestion(
+                        date=effective_date,
+                        sku_code=sku_code,
+                        sku_name=entries[0].sku_name,
+                        warehouse_name=warehouse_name,
+                        from_channel=from_channel,
+                        to_channel=to_channel,
+                        quantity=qty,
+                    )
+                )
+
+    suggestions.sort(key=lambda item: (item.date, item.warehouse_name, item.from_channel, item.to_channel))
+    return suggestions

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2288,3 +2288,116 @@ button.danger:hover {
   gap: 12px;
   padding: 0 24px 24px;
 }
+
+.psi-report-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(17, 24, 39, 0.55);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 1rem;
+  z-index: 1100;
+}
+
+.psi-report-modal {
+  background-color: #ffffff;
+  color: #111827;
+  width: min(960px, 100%);
+  max-height: 100%;
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.psi-report-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem 1.75rem 1rem;
+  background: linear-gradient(135deg, #1e3a8a, #1d4ed8);
+  color: #f9fafb;
+}
+
+.psi-report-modal__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.psi-report-modal__subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(249, 250, 251, 0.85);
+}
+
+.psi-report-modal__header-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.psi-report-modal__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1rem 1.75rem;
+  background-color: #eef2ff;
+  border-bottom: 1px solid #c7d2fe;
+}
+
+.psi-report-modal__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 12rem;
+}
+
+.psi-report-modal__meta-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4f46e5;
+}
+
+.psi-report-modal__meta-value {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.psi-report-modal__body {
+  padding: 1.25rem 1.75rem 1.75rem;
+  overflow-y: auto;
+  background-color: #f9fafb;
+}
+
+.psi-report-modal__status {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 8px;
+  background-color: #e0f2fe;
+  color: #0c4a6e;
+  font-weight: 600;
+  text-align: center;
+}
+
+.psi-report-modal__status.error {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.psi-report-modal__content {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  background-color: #1f2937;
+  color: #f9fafb;
+  border-radius: 12px;
+  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}

--- a/frontend/src/components/PSIReportModal.tsx
+++ b/frontend/src/components/PSIReportModal.tsx
@@ -1,0 +1,156 @@
+import { MouseEvent, useEffect, useId, useRef } from "react";
+import { createPortal } from "react-dom";
+
+import { PSIReportSettings } from "../types";
+
+interface PSIReportModalProps {
+  isOpen: boolean;
+  skuCode: string | null;
+  skuName: string | null;
+  report: string | null;
+  generatedAt: string | null;
+  settings: PSIReportSettings | null;
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onRetry?: () => void;
+}
+
+const formatDateTime = (iso: string | null) => {
+  if (!iso) {
+    return "—";
+  }
+  try {
+    const date = new Date(iso);
+    return new Intl.DateTimeFormat("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  } catch (error) {
+    return iso;
+  }
+};
+
+const PSIReportModal = ({
+  isOpen,
+  skuCode,
+  skuName,
+  report,
+  generatedAt,
+  settings,
+  isLoading,
+  error,
+  onClose,
+  onRetry,
+}: PSIReportModalProps) => {
+  const headingId = useId();
+  const descriptionId = useId();
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    closeButtonRef.current?.focus();
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!report || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(report);
+    } catch (copyError) {
+      console.error("Failed to copy report", copyError);
+    }
+  };
+
+  return createPortal(
+    <div className="psi-report-modal-backdrop" role="presentation" onMouseDown={handleBackdropClick}>
+      <div className="psi-report-modal" role="dialog" aria-modal="true" aria-labelledby={headingId} aria-describedby={descriptionId}>
+        <header className="psi-report-modal__header">
+          <div>
+            <h2 id={headingId}>在庫移動レポート</h2>
+            <p id={descriptionId} className="psi-report-modal__subtitle">
+              SKU: {skuCode ?? "—"}
+              {skuName ? ` / ${skuName}` : ""}
+            </p>
+          </div>
+          <div className="psi-report-modal__header-actions">
+            <button type="button" className="psi-button secondary" onClick={handleCopy} disabled={!report}>
+              コピー
+            </button>
+            {onRetry && (
+              <button type="button" className="psi-button secondary" onClick={onRetry} disabled={isLoading}>
+                再生成
+              </button>
+            )}
+            <button type="button" className="psi-button" onClick={onClose} ref={closeButtonRef}>
+              閉じる
+            </button>
+          </div>
+        </header>
+        <div className="psi-report-modal__meta">
+          <div>
+            <span className="psi-report-modal__meta-label">生成日時</span>
+            <span className="psi-report-modal__meta-value">{formatDateTime(generatedAt)}</span>
+          </div>
+          {settings && (
+            <div>
+              <span className="psi-report-modal__meta-label">設定</span>
+              <span className="psi-report-modal__meta-value">
+                LT {settings.lead_time_days}日 / 安全在庫 {settings.safety_buffer_days}日 / 最小移動 {settings.min_move_qty} / 先読み {settings.target_days_ahead}日
+              </span>
+            </div>
+          )}
+          {settings?.priority_channels && settings.priority_channels.length > 0 && (
+            <div>
+              <span className="psi-report-modal__meta-label">優先チャネル</span>
+              <span className="psi-report-modal__meta-value">{settings.priority_channels.join(", ")}</span>
+            </div>
+          )}
+        </div>
+        <div className="psi-report-modal__body">
+          {isLoading && <p className="psi-report-modal__status">レポートを生成しています…</p>}
+          {error && !isLoading && <p className="psi-report-modal__status error">{error}</p>}
+          {!isLoading && !error && report && (
+            <pre className="psi-report-modal__content" aria-live="polite">
+              {report}
+            </pre>
+          )}
+          {!isLoading && !error && !report && <p className="psi-report-modal__status">表示するレポートがありません。</p>}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default PSIReportModal;

--- a/frontend/src/components/PSITableContent.tsx
+++ b/frontend/src/components/PSITableContent.tsx
@@ -31,6 +31,9 @@ interface PSITableContentProps {
   formatDisplayDate: (iso: string) => string;
   onDownload: () => void;
   canDownload: boolean;
+  onGenerateReport: () => void;
+  canGenerateReport: boolean;
+  isGeneratingReport: boolean;
   applyError: string | null;
   applySuccess: string | null;
   formatNumber: (value?: number | null) => string;
@@ -141,6 +144,9 @@ const PSITableContent = ({
   formatDisplayDate,
   onDownload,
   canDownload,
+  onGenerateReport,
+  canGenerateReport,
+  isGeneratingReport,
   applyError,
   applySuccess,
   formatNumber,
@@ -812,6 +818,15 @@ const PSITableContent = ({
                   aria-label="CSVをダウンロード"
                 >
                   <span>CSV</span>
+                </button>
+                <button
+                  type="button"
+                  className="psi-button secondary"
+                  onClick={onGenerateReport}
+                  disabled={!canGenerateReport || isGeneratingReport}
+                  aria-label="PSIレポートを表示"
+                >
+                  <span>{isGeneratingReport ? "生成中…" : "Report"}</span>
                 </button>
               </div>
               <div className="psi-table-toolbar-group psi-table-sku-navigator">

--- a/frontend/src/hooks/usePsiQueries.ts
+++ b/frontend/src/hooks/usePsiQueries.ts
@@ -7,6 +7,7 @@ import {
   ChannelTransferIdentifier,
   PSIChannel,
   PSISessionSummary,
+  PSIReportResponse,
   Session,
 } from "../types";
 
@@ -32,6 +33,19 @@ const fetchDailyPsi = async (
 
 const fetchSessionSummary = async (sessionId: string): Promise<PSISessionSummary> => {
   const { data } = await api.get<PSISessionSummary>(`/psi/${sessionId}/summary`);
+  return data;
+};
+
+const generatePsiReport = async ({
+  sessionId,
+  skuCode,
+}: {
+  sessionId: string;
+  skuCode: string;
+}): Promise<PSIReportResponse> => {
+  const { data } = await api.get<PSIReportResponse>(`/psi/${sessionId}/report`, {
+    params: { sku_code: skuCode },
+  });
   return data;
 };
 
@@ -108,4 +122,9 @@ export const useCreateChannelTransferMutation = () =>
 export const useDeleteChannelTransferMutation = () =>
   useMutation({
     mutationFn: deleteChannelTransfer,
+  });
+
+export const usePsiReportMutation = () =>
+  useMutation({
+    mutationFn: generatePsiReport,
   });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,6 +38,22 @@ export interface PSISessionSummary {
   end_date?: string | null;
 }
 
+export interface PSIReportSettings {
+  lead_time_days: number;
+  safety_buffer_days: number;
+  min_move_qty: number;
+  target_days_ahead: number;
+  priority_channels?: string[] | null;
+}
+
+export interface PSIReportResponse {
+  sku_code: string;
+  sku_name?: string | null;
+  generated_at: string;
+  report_markdown: string;
+  settings: PSIReportSettings;
+}
+
 export interface PSIEditApplyResult {
   applied: number;
   log_entries: number;


### PR DESCRIPTION
## Summary
- add a psi_report service that reshapes channel data, flags stockout risk, suggests intra-warehouse transfers, and builds a Markdown summary
- expose a GET /psi/{session_id}/report endpoint that returns the generated report together with configuration metadata
- surface the report in the PSI table via a Report button, React Query mutation, and a reusable modal with copy/retry controls and dedicated styling

## Testing
- pytest backend/tests/test_auth.py
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f80b75d8832e93f75fad21e32059