### PR TITLE
Fix PSI report crash when inventory days missing

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -59,6 +59,7 @@ class DailyPSI(BaseModel):
     stock_closing: float | None = None
     safety_stock: float | None = None
     movable_stock: float | None = None
+    inventory_days: float | None = None
 
 
 class ChannelDailyPSI(BaseModel):

--- a/backend/tests/test_psi_report.py
+++ b/backend/tests/test_psi_report.py
@@ -1,0 +1,35 @@
+import sys
+from datetime import date
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_build_pivot_rows_handles_missing_inventory_days():
+    from backend.app import schemas
+    from backend.app.services.psi_report import build_pivot_rows
+
+    channel = schemas.ChannelDailyPSI(
+        sku_code="SKU-1",
+        sku_name="Sample",
+        warehouse_name="WH-A",
+        channel="Online",
+        daily=[
+            schemas.DailyPSI(
+                date=date(2024, 1, 1),
+                stock_at_anchor=10,
+                inbound_qty=5,
+                outbound_qty=3,
+                net_flow=2,
+                stock_closing=12,
+                safety_stock=4,
+                movable_stock=8,
+            )
+        ],
+    )
+
+    result = build_pivot_rows([channel], target_days_ahead=14)
+
+    assert result.rows[0].inventory_days is None


### PR DESCRIPTION
## Summary
- add optional `inventory_days` field to the PSI daily schema so report generation can access it safely
- add a regression test covering report pivot row building when `inventory_days` data is absent

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d3fe2f3468832e9cc350467eec4dc1