### PR TITLE
Render Markdown content in PSI report modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.28.0",
-    "react-data-grid": "file:vendor/react-data-grid"
+    "react-data-grid": "file:vendor/react-data-grid",
+    "react-markdown": "9.0.3",
+    "remark-gfm": "4.0.1"
   },
   "devDependencies": {
     "@types/react": "18.3.7",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2400,4 +2400,53 @@ button.danger:hover {
   white-space: pre-wrap;
   word-break: break-word;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  overflow: auto;
+}
+
+.psi-report-modal__content :where(h1, h2, h3, h4, h5, h6) {
+  margin: 1.2rem 0 0.6rem;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.psi-report-modal__content :where(h1) {
+  font-size: 1.5rem;
+}
+
+.psi-report-modal__content :where(h2) {
+  font-size: 1.25rem;
+}
+
+.psi-report-modal__content :where(h3) {
+  font-size: 1.1rem;
+}
+
+.psi-report-modal__content :where(p) {
+  margin: 0.6rem 0;
+}
+
+.psi-report-modal__content :where(ul, ol) {
+  margin: 0.6rem 0 0.6rem 1.5rem;
+  padding: 0;
+}
+
+.psi-report-modal__content table {
+  width: 100%;
+  margin: 0.75rem 0;
+  border-collapse: collapse;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.psi-report-modal__content th,
+.psi-report-modal__content td {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}
+
+.psi-report-modal__content th {
+  background-color: rgba(148, 163, 184, 0.2);
+  font-weight: 600;
 }

--- a/frontend/src/components/PSIReportModal.tsx
+++ b/frontend/src/components/PSIReportModal.tsx
@@ -1,5 +1,7 @@
 import { MouseEvent, useEffect, useId, useRef } from "react";
 import { createPortal } from "react-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import { PSIReportSettings } from "../types";
 
@@ -141,9 +143,9 @@ const PSIReportModal = ({
           {isLoading && <p className="psi-report-modal__status">レポートを生成しています…</p>}
           {error && !isLoading && <p className="psi-report-modal__status error">{error}</p>}
           {!isLoading && !error && report && (
-            <pre className="psi-report-modal__content" aria-live="polite">
-              {report}
-            </pre>
+            <div className="psi-report-modal__content" aria-live="polite">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{report}</ReactMarkdown>
+            </div>
           )}
           {!isLoading && !error && !report && <p className="psi-report-modal__status">表示するレポートがありません。</p>}
         </div>


### PR DESCRIPTION
## Summary
- render PSI report content with ReactMarkdown so generated Markdown is formatted
- style Markdown elements in the modal including headings and tables for readability
- add remark-gfm support to handle GitHub-flavored Markdown in reports

## Testing
- npm install *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4005bea74832eab1e1d1f0551d92b