### PR TITLE
Fix PSI report generation when SKU codes contain whitespace

### DIFF
--- a/backend/app/routers/psi.py
+++ b/backend/app/routers/psi.py
@@ -598,7 +598,8 @@ def generate_psi_report(
 ) -> schemas.PSIReportResponse:
     """Generate a markdown summary highlighting stock risks and transfer suggestions."""
 
-    if not sku_code.strip():
+    sku_code = sku_code.strip()
+    if not sku_code:
         raise HTTPException(status_code=400, detail="sku_code is required")
 
     _get_session_or_404(db, session_id)


### PR DESCRIPTION
## Summary
- trim the incoming sku_code before validation in the PSI report endpoint
- ensure report generation works even when the frontend sends sku codes with surrounding whitespace

## Testing
- pytest backend/tests/test_psi_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d4048b2c34832e89b61801813738db