### PR TITLE
Fix PSI report generation when warehouse names are missing

### DIFF
--- a/backend/app/services/psi_report/analysis.py
+++ b/backend/app/services/psi_report/analysis.py
@@ -15,7 +15,7 @@ from .data import PivotRow
 class StockoutRisk:
     sku_code: str
     sku_name: str | None
-    warehouse_name: str
+    warehouse_name: str | None
     date: date
     channels_count: int
     total_stock: float
@@ -27,7 +27,7 @@ class StockoutRisk:
 
 def detect_stockout_risk(rows: Iterable[PivotRow], cfg: Settings) -> list[StockoutRisk]:
     _ = cfg  # placeholder for future tuning knobs
-    grouped: dict[tuple[str, str, date], list[PivotRow]] = defaultdict(list)
+    grouped: dict[tuple[str, str | None, date], list[PivotRow]] = defaultdict(list)
     for row in rows:
         grouped[(row.sku_code, row.warehouse_name, row.date)].append(row)
 
@@ -54,11 +54,13 @@ def detect_stockout_risk(rows: Iterable[PivotRow], cfg: Settings) -> list[Stocko
             )
         )
 
-    risks.sort(key=lambda item: (item.date, item.warehouse_name))
+    risks.sort(key=lambda item: (item.date, item.warehouse_name or ""))
     return risks
 
 
-def first_stockout_date(risk_rows: Iterable[StockoutRisk], sku_code: str, warehouse_name: str) -> date | None:
+def first_stockout_date(
+    risk_rows: Iterable[StockoutRisk], sku_code: str, warehouse_name: str | None
+) -> date | None:
     for row in risk_rows:
         if row.sku_code == sku_code and row.warehouse_name == warehouse_name and row.has_deficit:
             return row.date

--- a/backend/app/services/psi_report/data.py
+++ b/backend/app/services/psi_report/data.py
@@ -15,7 +15,7 @@ class PivotRow:
 
     sku_code: str
     sku_name: str | None
-    warehouse_name: str
+    warehouse_name: str | None
     channel: str
     date: date
     stock_closing: float
@@ -70,7 +70,7 @@ def build_pivot_rows(
     if not rows:
         return PivotResult(rows=[], start_date=None, end_date=None)
 
-    rows.sort(key=lambda item: (item.date, item.warehouse_name, item.channel))
+    rows.sort(key=lambda item: (item.date, item.warehouse_name or "", item.channel))
     start = rows[0].date
     cutoff = start + timedelta(days=target_days_ahead - 1)
     filtered = [row for row in rows if row.date <= cutoff]

--- a/backend/app/services/psi_report/transfer.py
+++ b/backend/app/services/psi_report/transfer.py
@@ -14,7 +14,7 @@ class TransferSuggestion:
     date: date
     sku_code: str
     sku_name: str | None
-    warehouse_name: str
+    warehouse_name: str | None
     from_channel: str
     to_channel: str
     quantity: float
@@ -42,7 +42,7 @@ def _average_outbound(rows: Iterable[PivotRow]) -> float:
 
 
 def suggest_channel_transfers(rows: Iterable[PivotRow], cfg: Settings) -> list[TransferSuggestion]:
-    grouped: dict[tuple[str, str], list[PivotRow]] = defaultdict(list)
+    grouped: dict[tuple[str, str | None], list[PivotRow]] = defaultdict(list)
     for row in rows:
         grouped[(row.sku_code, row.warehouse_name)].append(row)
 
@@ -135,5 +135,12 @@ def suggest_channel_transfers(rows: Iterable[PivotRow], cfg: Settings) -> list[T
                     )
                 )
 
-    suggestions.sort(key=lambda item: (item.date, item.warehouse_name, item.from_channel, item.to_channel))
+    suggestions.sort(
+        key=lambda item: (
+            item.date,
+            item.warehouse_name or "",
+            item.from_channel,
+            item.to_channel,
+        )
+    )
     return suggestions

--- a/backend/tests/test_psi_report_reporter.py
+++ b/backend/tests/test_psi_report_reporter.py
@@ -1,0 +1,54 @@
+from datetime import date, datetime, timezone
+
+from backend.app.services.psi_report import (
+    PivotRow,
+    Settings,
+    build_summary_md,
+    detect_stockout_risk,
+    suggest_channel_transfers,
+)
+
+
+def test_build_summary_md_handles_missing_warehouse_name() -> None:
+    cfg = Settings()
+    rows = [
+        PivotRow(
+            sku_code="SKU-001",
+            sku_name="Sample",
+            warehouse_name=None,
+            channel="EC",
+            date=date(2024, 1, 1),
+            stock_closing=-5.0,
+            inbound_qty=0.0,
+            outbound_qty=5.0,
+            channel_move=0.0,
+            safety_stock=0.0,
+            inventory_days=None,
+        ),
+        PivotRow(
+            sku_code="SKU-001",
+            sku_name="Sample",
+            warehouse_name=None,
+            channel="店舗",
+            date=date(2024, 1, 1),
+            stock_closing=10.0,
+            inbound_qty=0.0,
+            outbound_qty=0.0,
+            channel_move=0.0,
+            safety_stock=0.0,
+            inventory_days=None,
+        ),
+    ]
+
+    risks = detect_stockout_risk(rows, cfg)
+    transfers = suggest_channel_transfers(rows, cfg)
+    report = build_summary_md(
+        risks,
+        transfers,
+        rows,
+        cfg,
+        generated_at=datetime(2024, 1, 2, 9, 30, tzinfo=timezone.utc),
+    )
+
+    assert "### 未設定倉庫" in report
+    assert "| 2024-01-01 | 未設定倉庫 |" in report


### PR DESCRIPTION
## Summary
- normalise missing warehouse names in the PSI report markdown so tables and coverage sections render instead of raising errors
- allow the analysis, data, and transfer helpers to carry optional warehouse names safely when grouping and sorting
- add a regression test that exercises report generation with an unnamed warehouse

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d406f6bcb4832eadd2263a56206c83