### PR TITLE
Add feature guide for key PSI pages

### DIFF
--- a/docs/7_各ページ機能説明.md
+++ b/docs/7_各ページ機能説明.md
@@ -1,0 +1,45 @@
+# 各ページの役割と機能概要
+
+## Sessions ページ
+- セッションの新規作成フォームでは、タイトルと任意の説明を入力して登録できます。保存中はボタンが無効化され、完了するとステータスが表示されます。【F:frontend/src/pages/SessionsPage.tsx†L200-L225】【F:frontend/src/pages/SessionsPage.tsx†L257-L261】
+- 既存セッション一覧はタイトル・説明・作成者・更新者・リーダー情報を確認でき、検索フォームでタイトル／説明／ユーザー名を絞り込み可能です。【F:frontend/src/pages/SessionsPage.tsx†L227-L336】
+- 行のアクションからはリーダー切り替え、削除、CSV アップロード、PSI 表への遷移がワンクリックで行えます。アップロードは進行中表示と完了メッセージを備えています。【F:frontend/src/pages/SessionsPage.tsx†L281-L339】
+
+## PSI Table ページ
+### 画面全体の流れ
+- URL パラメータまたはリーダーセッションを初期選択し、選択変更時にはフィルタや編集状態をリセットします。【F:frontend/src/pages/PSITablePage.tsx†L327-L388】
+- PSI データの取得後は元データのクローンを保持し、再計算済みテーブルを表示・編集します。セッション説明の自動読込や編集ステータスも管理しています。【F:frontend/src/pages/PSITablePage.tsx†L351-L383】
+- SKU 選択やメトリクス表示項目は状態管理され、並び順変更や隣接 SKU への移動もできます。【F:frontend/src/pages/PSITablePage.tsx†L418-L520】
+
+### フィルタと概要パネル
+- 左ペインでセッション／SKU コード／倉庫／チャネルを入力すると PSI データ取得条件が絞り込まれます。セッション説明は開始日・終了日・作成日・更新日とともに編集保存でき、保存時はアイコン付きボタンと成功メッセージでフィードバックされます。【F:frontend/src/components/PSITableControls.tsx†L264-L372】
+- 右ペインの集計カードでは、SKU 集計一覧をフィルタメニューで条件切替し、ページャで 3 件ずつ閲覧・選択できます。SKU 選択は自動で最初の候補にフォーカスし、外したときは先頭に戻ります。【F:frontend/src/components/PSITableControls.tsx†L374-L487】
+- 下部ツールバーから PSI 編集の適用・再読込・リセットを実行可能です。適用時にはアイコン付きボタンと進捗表示があり、リセットはベースラインデータがある場合のみ有効になります。【F:frontend/src/components/PSITableControls.tsx†L445-L475】
+
+### テーブル操作
+- DataGrid は倉庫タブ／チャネル見出し／メトリクス行で構成され、メトリクスの表示切替メニューや全選択ボタンを備えています。【F:frontend/src/components/PSITableContent.tsx†L173-L725】
+- 日付列は在庫サマリ値を表示し、入荷量 (inbound_qty)・出荷量 (outbound_qty)・安全在庫 (safety_stock) は直接編集できます。数値エディタは Enter で確定、空文字で null に戻ります。【F:frontend/src/components/PSITableContent.tsx†L54-L122】【F:frontend/src/components/PSITableContent.tsx†L586-L616】
+- セル編集は onRowsChange で検知され、対象チャネル・日付・項目を特定して pending 編集に反映します。反映時には各行を再計算してネットフローや在庫日数を更新します。【F:frontend/src/components/PSITableContent.tsx†L727-L748】【F:frontend/src/pages/PSITablePage.tsx†L869-L897】
+- 変更は適用ボタンからサーバーに送信され、適用件数とログ件数のメッセージが返ります。成功するとベースラインを更新し、即座に再読込します。【F:frontend/src/pages/PSITablePage.tsx†L907-L931】
+- CSV ダウンロードや Markdown レポート生成はテーブルツールバーから操作し、SKU ナビゲータで前後 SKU を巡回できます。倉庫タブとメトリクスメッセージも同一ツールバーに表示されます。【F:frontend/src/components/PSITableContent.tsx†L810-L906】
+- 「t」キーで今日の日付列へスクロールするショートカットがあり、DataGrid 側のスクロールハンドラと連携します。【F:frontend/src/pages/PSITablePage.tsx†L722-L748】【F:frontend/src/components/PSITableContent.tsx†L770-L796】
+
+### チャネル移動 (channel_move)
+- channel_move 行のセルをクリックすると、対象チャネル・日付・SKU 情報を持つモーダルが開き、既存移動と新規草案を一括管理できます。【F:frontend/src/components/PSITableContent.tsx†L753-L906】【F:frontend/src/pages/PSITablePage.tsx†L520-L626】
+- モーダルでは既存移動の削除マーク、行追加、入出庫方向・相手チャネル・数量・メモ入力、フィールドバリデーション、在庫変化プレビューが利用できます。【F:frontend/src/components/ChannelMoveModal.tsx†L544-L656】
+- 保存処理では削除対象と追加対象を区別し、数量差分を集計してプレビューします。保存完了後は PSI テーブルと移動履歴を再読み込みします。【F:frontend/src/components/ChannelMoveModal.tsx†L200-L242】【F:frontend/src/pages/PSITablePage.tsx†L804-L845】
+- 指定日の移動計画 CSV をワンクリックでダウンロードできるため、事前調整やレビューに活用できます。【F:frontend/src/components/ChannelMoveModal.tsx†L292-L466】
+
+### レポート機能
+- Report ボタンで SKU 単位の Markdown レポートを生成し、モーダルに表示します。生成済みデータがあれば再利用し、必要に応じて再生成できます。【F:frontend/src/pages/PSITablePage.tsx†L439-L474】【F:frontend/src/pages/PSITablePage.tsx†L1063-L1073】
+- モーダル内の「コピー」ボタンでレポート全文をクリップボードにコピー可能です。テキストは Markdown 形式なので、Notion などのドキュメントツールへ貼り付けると見出しやリストがそのまま再現され、業務メモの共有効率が高まります。【F:frontend/src/components/PSIReportModal.tsx†L84-L148】
+
+## Transfer ページ
+- セッションごとにチャネル間移動履歴を一覧し、SKU／倉庫／更新日／ユーザーでフィルタできます。フィルタ適用・リセット・CSV ダウンロードがフォームから行えます。【F:frontend/src/pages/TransferPage.tsx†L411-L505】
+- 一覧では数量とメモをインライン編集でき、ペアになっている逆方向レコードの整合性チェックを行った上で同時更新します。適用・リセットボタンは保存中の行を無効化します。【F:frontend/src/pages/TransferPage.tsx†L232-L340】【F:frontend/src/pages/TransferPage.tsx†L520-L585】
+- 行リセット時はペアレコードも元の値に戻し、状態メッセージで結果を通知します。必要に応じて CSV エクスポートで共有できます。【F:frontend/src/pages/TransferPage.tsx†L344-L409】
+
+## Edits ページ
+- セッションの手動 PSI 変更履歴を監査するページで、SKU／倉庫／更新日／ユーザーを条件に検索できます。リーダーセッションが初期選択され、セッション変更時にフィルタが初期化されます。【F:frontend/src/pages/EditsPage.tsx†L80-L140】【F:frontend/src/pages/EditsPage.tsx†L173-L207】
+- 結果テーブルでは inbound/outbound/safety_stock の上書き値と作成・更新者情報を確認できます。該当データがない場合はメッセージで知らせます。【F:frontend/src/pages/EditsPage.tsx†L268-L314】
+- フィルタ適用・リセット・CSV ダウンロードボタンを備え、ダウンロード完了や失敗はステータスメッセージでフィードバックされます。【F:frontend/src/pages/EditsPage.tsx†L129-L171】【F:frontend/src/pages/EditsPage.tsx†L248-L263】


### PR DESCRIPTION
## Summary
- add documentation describing the purpose and main functions of the Sessions, PSI Table, Transfer, and Edits pages
- detail PSI Table operations including filters, inline edits, channel move workflow, and report usage tips

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4ad483c0c832e9cbeefcb16620c26