### PR TITLE
Add warehouse main channel metadata and API

### DIFF
--- a/backend/alembic/versions/0009_add_main_channel_to_warehouse_master.py
+++ b/backend/alembic/versions/0009_add_main_channel_to_warehouse_master.py
@@ -1,0 +1,85 @@
+"""add main_channel to warehouse master"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.config import settings
+
+revision: str = "0009"
+down_revision: Union[str, Sequence[str], None] = "0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = (settings.db_schema or "").strip() or None
+TABLE_NAME = "warehouse_master"
+COLUMN_NAME = "main_channel"
+FK_NAME = "fk_warehouse_master_main_channel"
+CHECK_NAME = "ck_warehouse_master_main_channel_not_blank"
+
+
+def _create_constraints(batch_op) -> None:
+    batch_op.create_check_constraint(
+        CHECK_NAME,
+        sa.text("main_channel IS NULL OR length(trim(main_channel)) > 0"),
+    )
+    batch_op.create_foreign_key(
+        FK_NAME,
+        "channel_master",
+        local_cols=[COLUMN_NAME],
+        remote_cols=["channel"],
+        referent_schema=SCHEMA,
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind else ""
+
+    if dialect == "sqlite":
+        with op.batch_alter_table(TABLE_NAME, schema=SCHEMA) as batch:
+            batch.add_column(sa.Column(COLUMN_NAME, sa.Text(), nullable=True))
+            _create_constraints(batch)
+        return
+
+    op.add_column(
+        TABLE_NAME,
+        sa.Column(COLUMN_NAME, sa.Text(), nullable=True),
+        schema=SCHEMA,
+    )
+
+    op.create_check_constraint(
+        CHECK_NAME,
+        TABLE_NAME,
+        sa.text("main_channel IS NULL OR length(trim(main_channel)) > 0"),
+        schema=SCHEMA,
+    )
+
+    op.create_foreign_key(
+        FK_NAME,
+        TABLE_NAME,
+        "channel_master",
+        local_cols=[COLUMN_NAME],
+        remote_cols=["channel"],
+        source_schema=SCHEMA,
+        referent_schema=SCHEMA,
+        ondelete=None,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind else ""
+
+    if dialect == "sqlite":
+        with op.batch_alter_table(TABLE_NAME, schema=SCHEMA) as batch:
+            batch.drop_constraint(FK_NAME, type_="foreignkey")
+            batch.drop_constraint(CHECK_NAME, type_="check")
+            batch.drop_column(COLUMN_NAME)
+        return
+
+    op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey", schema=SCHEMA)
+    op.drop_constraint(CHECK_NAME, TABLE_NAME, type_="check", schema=SCHEMA)
+    op.drop_column(TABLE_NAME, COLUMN_NAME, schema=SCHEMA)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from .routers import (
     psi_metrics,
     sessions,
     users,
+    warehouses,
 )
 
 app = FastAPI(title="GEN-like PSI API")
@@ -54,6 +55,7 @@ app.include_router(
     prefix="/channel-transfers",
     tags=["channel-transfers"],
 )
+app.include_router(warehouses.router, prefix="/warehouses", tags=["warehouses"])
 app.include_router(users.router, prefix="/users", tags=["users"])
 
 # /api 配下にもミラー（フロントが /api/* を叩いてもOKに）
@@ -70,6 +72,7 @@ app.include_router(
     prefix="/api/channel-transfers",
     tags=["channel-transfers"],
 )
+app.include_router(warehouses.router, prefix="/api/warehouses", tags=["warehouses"])
 app.include_router(users.router, prefix="/api/users", tags=["users"])
 
 @app.get("/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -172,6 +172,29 @@ class MasterRecord(Base, SchemaMixin, TimestampMixin):
     data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
 
 
+class ChannelMaster(Base, SchemaMixin):
+    """Sales channel master data shared across warehouses."""
+
+    __tablename__ = "channel_master"
+
+    channel: Mapped[str] = mapped_column(Text, primary_key=True, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class WarehouseMaster(Base, SchemaMixin):
+    """Warehouse definitions enriched with metadata such as main channel."""
+
+    __tablename__ = "warehouse_master"
+
+    warehouse_name: Mapped[str] = mapped_column(Text, primary_key=True, nullable=False)
+    region: Mapped[str | None] = mapped_column(Text, nullable=True)
+    main_channel: Mapped[str | None] = mapped_column(
+        Text,
+        ForeignKey(_qualified("channel_master", "channel")),
+        nullable=True,
+    )
+
+
 class PSIMetricDefinition(Base, SchemaMixin):
     """Definition of metrics displayed on the PSI table."""
 

--- a/backend/app/routers/warehouses.py
+++ b/backend/app/routers/warehouses.py
@@ -1,0 +1,32 @@
+"""Read-only endpoints for warehouse master records."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session as DBSession
+
+from .. import models, schemas
+from ..deps import get_db
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[schemas.WarehouseMasterRead])
+@router.get("/", response_model=list[schemas.WarehouseMasterRead])
+def list_warehouses(db: DBSession = Depends(get_db)) -> list[schemas.WarehouseMasterRead]:
+    """Return all warehouses ordered by name."""
+
+    query = select(models.WarehouseMaster).order_by(models.WarehouseMaster.warehouse_name.asc())
+    return db.scalars(query).all()
+
+
+@router.get("/{warehouse_name}", response_model=schemas.WarehouseMasterRead)
+def get_warehouse(
+    warehouse_name: str, db: DBSession = Depends(get_db)
+) -> schemas.WarehouseMasterRead:
+    """Return a single warehouse or raise 404 when missing."""
+
+    record = db.get(models.WarehouseMaster, warehouse_name)
+    if record is None:
+        raise HTTPException(status_code=404, detail="warehouse not found")
+    return record

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -187,6 +187,16 @@ class MasterRecordRead(MasterRecordBase):
     model_config = {"from_attributes": True}
 
 
+class WarehouseMasterRead(BaseModel):
+    """Warehouse metadata returned by the warehouse master endpoint."""
+
+    warehouse_name: str
+    region: str | None = None
+    main_channel: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
 class PSIMetricBase(BaseModel):
     """Shared attributes for PSI metric definitions."""
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -42,6 +42,7 @@ def test_upgrade_adds_audit_columns(tmp_path, monkeypatch):
         "psi_edits": {"created_by", "updated_by"},
         "channel_transfers": {"created_by", "updated_by"},
         "psi_edit_log": {"created_at", "updated_at", "created_by", "updated_by", "edited_by"},
+        "warehouse_master": {"main_channel"},
     }
 
     for table, columns in expected_columns.items():

--- a/backend/tests/test_warehouses_api.py
+++ b/backend/tests/test_warehouses_api.py
@@ -1,0 +1,154 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _perform_json_request(app, method: str, path: str):
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "scheme": "http",
+        "headers": [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+
+    messages: list[dict[str, object]] = []
+    received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    asyncio.run(app(scope, receive, send))
+
+    start = next(msg for msg in messages if msg["type"] == "http.response.start")
+    body = b"".join(
+        part.get("body", b"") for part in messages if part["type"] == "http.response.body"
+    )
+    payload = None
+    if body:
+        payload = json.loads(body.decode("utf-8"))
+    return start["status"], payload
+
+
+@pytest.fixture(scope="module")
+def app_env(tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
+    db_path = tmp_path_factory.mktemp("warehouses") / "warehouse_test.sqlite"
+    os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+    os.environ["DB_SCHEMA"] = ""
+    os.environ.setdefault("SESSION_SIGN_KEY", "sign")
+    os.environ.setdefault("SECRET_KEY", "secret")
+    os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:5173")
+    os.environ.setdefault("CSRF_ENABLED", "false")
+
+    for name in list(sys.modules):
+        if name.startswith("backend.app"):
+            del sys.modules[name]
+
+    from backend.app import models
+    from backend.app.deps import SessionLocal, engine
+    from backend.app.main import app
+
+    with engine.begin() as connection:
+        models.ChannelMaster.__table__.drop(bind=connection, checkfirst=True)
+        models.WarehouseMaster.__table__.drop(bind=connection, checkfirst=True)
+        models.ChannelMaster.__table__.create(bind=connection, checkfirst=True)
+        models.WarehouseMaster.__table__.create(bind=connection, checkfirst=True)
+
+    asyncio.run(app.router.startup())
+
+    return SimpleNamespace(
+        app=app,
+        models=models,
+        SessionLocal=SessionLocal,
+        engine=engine,
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_tables(app_env: SimpleNamespace) -> None:
+    with app_env.engine.begin() as connection:
+        connection.execute(app_env.models.WarehouseMaster.__table__.delete())
+        connection.execute(app_env.models.ChannelMaster.__table__.delete())
+    yield
+
+
+def test_list_warehouses_returns_sorted_records(app_env: SimpleNamespace) -> None:
+    with app_env.SessionLocal() as session:
+        session.add_all(
+            [
+                app_env.models.ChannelMaster(channel="Online", display_name="EC"),
+                app_env.models.ChannelMaster(channel="Retail", display_name="店舗"),
+            ]
+        )
+        session.add_all(
+            [
+                app_env.models.WarehouseMaster(
+                    warehouse_name="Osaka", region="Kansai", main_channel="Retail"
+                ),
+                app_env.models.WarehouseMaster(
+                    warehouse_name="Tokyo", region="Kanto", main_channel="Online"
+                ),
+            ]
+        )
+        session.commit()
+
+    status, payload = _perform_json_request(app_env.app, "GET", "/warehouses")
+    assert status == 200
+    assert payload == [
+        {
+            "warehouse_name": "Osaka",
+            "region": "Kansai",
+            "main_channel": "Retail",
+        },
+        {
+            "warehouse_name": "Tokyo",
+            "region": "Kanto",
+            "main_channel": "Online",
+        },
+    ]
+
+
+def test_get_warehouse_returns_record(app_env: SimpleNamespace) -> None:
+    with app_env.SessionLocal() as session:
+        session.add(app_env.models.ChannelMaster(channel="Online", display_name="EC"))
+        session.add(
+            app_env.models.WarehouseMaster(
+                warehouse_name="Central", region=None, main_channel="Online"
+            )
+        )
+        session.commit()
+
+    status, payload = _perform_json_request(app_env.app, "GET", "/warehouses/Central")
+    assert status == 200
+    assert payload == {
+        "warehouse_name": "Central",
+        "region": None,
+        "main_channel": "Online",
+    }
+
+
+def test_get_warehouse_missing_returns_404(app_env: SimpleNamespace) -> None:
+    status, payload = _perform_json_request(app_env.app, "GET", "/warehouses/Unknown")
+    assert status == 404
+    assert payload == {"detail": "warehouse not found"}

--- a/docs/1_システム概要.md
+++ b/docs/1_システム概要.md
@@ -31,6 +31,7 @@
   - `psi_edit_log`: 手修正履歴。
   - `channel_transfers`: チャネル間移動の管理 (複合 PK 的な一意制約)。
   - `master_records`: マスタデータ (Products / Customers / Suppliers) を JSON で保持。
+  - `warehouse_master`: 倉庫ごとの地域・メインチャネルなどの属性を保持。
 
 ## 主要機能
 ### セッション管理
@@ -57,6 +58,7 @@
 ### マスタ管理
 - モデル: `master_records` テーブル (type ごとに JSON 格納)。
 - エンドポイント: `/masters/{master_type}` 系 (一覧 / 作成 / 更新 / 削除)。
+- 参照 API: `GET /warehouses` / `GET /warehouses/{name}` で倉庫マスタを取得。`main_channel` 列はチャネルマスタ (`channel_master`) と参照整合性を保つ。
 - フロントエンド: `Masters` セクションに Product / Customer / Supplier のモック UI (JSON 形式をテーブル化) を実装。
 
 ### チャネル間移動管理

--- a/docs/2_データベース.md
+++ b/docs/2_データベース.md
@@ -182,7 +182,10 @@ CREATE TABLE IF NOT EXISTS psi.sku_master (
 
 CREATE TABLE IF NOT EXISTS psi.warehouse_master (
   warehouse_name text PRIMARY KEY,
-  region text
+  region text,
+  main_channel text REFERENCES psi.channel_master(channel),
+  CONSTRAINT ck_warehouse_master_main_channel_not_blank
+    CHECK (main_channel IS NULL OR length(trim(main_channel)) > 0)
 );
 
 CREATE TABLE IF NOT EXISTS psi.channel_master (
@@ -190,6 +193,8 @@ CREATE TABLE IF NOT EXISTS psi.channel_master (
   display_name text
 );
 ```
+
+`warehouse_master.main_channel` は倉庫の主要出荷チャネルを保持します。チャネル名は `channel_master.channel` に制約され、空文字列は登録できません。既存データは `UPDATE` / `INSERT ... ON CONFLICT DO UPDATE` で補完し、アプリケーションから参照できるようにします。
 
 ### 2.2 需要計画・日別キャッシュ
 

--- a/docs/5_作業手順.md
+++ b/docs/5_作業手順.md
@@ -24,3 +24,28 @@
 
    * 必要に応じて **Leader に設定**（Leader にすると PSITable のデフォルトになる）
 3. 作成したセッションに入り、**SKU を絞り込みながら作業を実施**
+
+---
+
+## 付録 : 倉庫メインチャネルの更新
+
+倉庫マスタへメインチャネルを反映する際は以下の手順を踏みます。
+
+1. `psi.channel_master` に対象チャネルが存在することを確認し、未登録なら先に `INSERT` します。
+2. 既存倉庫は `UPDATE` で、未登録倉庫は `INSERT ... ON CONFLICT` で `main_channel` を設定します。
+
+```sql
+-- 例: Tokyo 倉庫のメインチャネルを Online に更新
+UPDATE psi.warehouse_master
+   SET main_channel = 'Online'
+ WHERE warehouse_name = 'Tokyo';
+
+-- 例: 新倉庫 Osaka を Retail チャネル付きで登録
+INSERT INTO psi.warehouse_master (warehouse_name, region, main_channel)
+VALUES ('Osaka', 'Kansai', 'Retail')
+ON CONFLICT (warehouse_name)
+  DO UPDATE SET region = EXCLUDED.region,
+                main_channel = EXCLUDED.main_channel;
+```
+
+複数倉庫を更新する場合は同様のクエリを用意し、実行履歴を残して運用部門に共有してください。


### PR DESCRIPTION
## Summary
- add an Alembic migration to introduce the `main_channel` column on `warehouse_master` with appropriate constraints
- expose warehouse master metadata via new models, schemas, and read-only API routes for future UI consumption
- extend documentation and automated tests to cover the new column and warehouse endpoints

## Testing
- pytest backend/tests/test_warehouses_api.py backend/tests/test_migrations.py

------
https://chatgpt.com/codex/tasks/task_e_68dcdb990040832e9fb8e4442ba8aa9c