### PR TITLE
Add category rank parameter table and documentation

### DIFF
--- a/backend/alembic/versions/0009_create_category_rank_parameters_table.py
+++ b/backend/alembic/versions/0009_create_category_rank_parameters_table.py
@@ -1,0 +1,36 @@
+"""create category rank parameters table"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.config import settings
+
+revision: str = "0009"
+down_revision: Union[str, Sequence[str], None] = "0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = settings.db_schema or None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "category_rank_parameters",
+        sa.Column("rank_type", sa.Text(), nullable=False),
+        sa.Column("category_1", sa.Text(), nullable=False),
+        sa.Column("category_2", sa.Text(), nullable=False),
+        sa.Column("threshold", sa.Numeric(), nullable=False),
+        sa.CheckConstraint(
+            "rank_type IN ('FW', 'SS')",
+            name="ck_category_rank_parameters_rank_type",
+        ),
+        sa.PrimaryKeyConstraint("rank_type", "category_1", "category_2"),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("category_rank_parameters", schema=SCHEMA)

--- a/docs/2_データベース.md
+++ b/docs/2_データベース.md
@@ -249,6 +249,20 @@ CREATE TABLE IF NOT EXISTS psi.stock_transfers (
 );
 ```
 
+### 2.5 カテゴリ別ランク閾値: `psi.category_rank_parameters`
+
+カテゴリ別に計算へ渡す閾値（例: FW/SS のランク判定用）を保持するマスタです。`rank_type` は運用で利用する識別子に限定するため、チェック制約で `'FW'` と `'SS'` のみ許可しています。集計ロジックでは `category_1` / `category_2` の組み合わせごとに `threshold` を参照します。
+
+```sql
+CREATE TABLE IF NOT EXISTS psi.category_rank_parameters (
+  rank_type  text NOT NULL CHECK (rank_type IN ('FW', 'SS')),
+  category_1 text NOT NULL,
+  category_2 text NOT NULL,
+  threshold  numeric NOT NULL,
+  PRIMARY KEY (rank_type, category_1, category_2)
+);
+```
+
 ---
 
 ## 3) Alembic 管理テーブル

--- a/docs/8_カテゴリ別ランク設定.md
+++ b/docs/8_カテゴリ別ランク設定.md
@@ -1,0 +1,53 @@
+# 8.カテゴリ別ランク設定
+
+カテゴリ別にランク判定へ渡す数値パラメータを管理するためのガイドです。データベース上のマスタテーブルと、CSV を利用した運用フローについて記載します。
+
+## 1. マスタ概要
+
+- テーブル: `psi.category_rank_parameters`
+- 主キー: `(rank_type, category_1, category_2)`
+- カラム:
+  - `rank_type` — 閾値の利用シーン（`FW` / `SS` など）を表す識別子。チェック制約で `'FW'` と `'SS'` のみ許可。
+  - `category_1`, `category_2` — 分類コード。両方必須。
+  - `threshold` — ランク判定に用いる数値（decimal）。
+
+## 2. データ格納形式
+
+リポジトリ内の `docs/data/category_rank_parameters.csv` に、以下の列順で UTF-8 CSV として格納します。
+
+| 列名 | 必須 | 備考 |
+| --- | --- | --- |
+| `rank_type` | ✅ | `FW` または `SS` |
+| `category_1` | ✅ | 半角英数字推奨 |
+| `category_2` | ✅ | 半角英数字推奨 |
+| `threshold` | ✅ | `0.00` 形式の 10 進数 |
+
+> サンプル値は `docs/data/category_rank_parameters.csv` に格納しています。運用時は数値を上書きしてください。
+
+## 3. 更新フロー
+
+### 3.1 CSV インポート
+
+1. `docs/data/category_rank_parameters.csv` を編集し、レビューを経て main ブランチにマージします。
+2. 本番環境では、CSV をサーバーに配置した上で以下のコマンドで反映します。
+
+   ```bash
+   psql "$DATABASE_URL" <<'SQL'
+   TRUNCATE TABLE psi.category_rank_parameters;
+   \copy psi.category_rank_parameters FROM 'category_rank_parameters.csv' WITH (FORMAT csv, HEADER true);
+   SQL
+   ```
+
+   - `DATABASE_URL` は Alembic と同じ接続文字列を利用します。
+   - バックアップが必要な場合は `COPY psi.category_rank_parameters TO 'backup.csv' WITH (FORMAT csv, HEADER true);` を実行してください。
+
+3. 反映後、`SELECT * FROM psi.category_rank_parameters ORDER BY rank_type, category_1, category_2;` で内容を確認します。
+
+### 3.2 将来的な管理画面対応
+
+- 管理画面が実装された際は、同テーブルを直接編集する機能を追加します。
+- 画面側では `rank_type` をプルダウン（`FW` / `SS`）にし、CSV との整合性が取れるようバリデーションを実施してください。
+
+## 4. バックエンド連携
+
+後段で `backend/app/services/psi_report` などの集計ロジックからカテゴリ別閾値を参照する際は、本マスタをロードしてロジックに組み込みます。サービス層でのキャッシュ戦略や既存の PSI 指標との整合性は、具体的な要件が固まり次第検討します。

--- a/docs/data/category_rank_parameters.csv
+++ b/docs/data/category_rank_parameters.csv
@@ -1,0 +1,3 @@
+rank_type,category_1,category_2,threshold
+FW,FOOTWEAR,SNEAKERS,0.75
+SS,APPAREL,TOPS,0.60


### PR DESCRIPTION
## Summary
- add an Alembic migration that creates the psi.category_rank_parameters master table with rank type constraints
- document the CSV storage/update flow for category rank thresholds and provide a sample file

## Testing
- not run (documentation-only and schema change)


------
https://chatgpt.com/codex/tasks/task_e_68dcddcbdb5c832eb9bdc79858d594be