### PR TITLE
Add masters UI for warehouse and rank parameters

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from .config import settings
 from .middleware import CSRFMiddleware, SecurityHeadersMiddleware
 from .routers import (
     auth,
+    category_rank_parameters,
     channel_transfers,
     masters,
     psi,
@@ -48,6 +49,11 @@ app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(sessions.router, prefix="/sessions", tags=["sessions"])
 app.include_router(masters.router, prefix="/masters", tags=["masters"])
 app.include_router(psi_metrics.router, prefix="/psi-metrics", tags=["psi-metrics"])
+app.include_router(
+    category_rank_parameters.router,
+    prefix="/category-rank-parameters",
+    tags=["category-rank-parameters"],
+)
 app.include_router(psi.router, prefix="/psi", tags=["psi"])
 app.include_router(psi_edits.router, prefix="/psi-edits", tags=["psi-edits"])
 app.include_router(
@@ -64,6 +70,11 @@ app.include_router(sessions.router, prefix="/api/sessions", tags=["sessions"])
 app.include_router(masters.router, prefix="/api/masters", tags=["masters"])
 app.include_router(
     psi_metrics.router, prefix="/api/psi-metrics", tags=["psi-metrics"]
+)
+app.include_router(
+    category_rank_parameters.router,
+    prefix="/api/category-rank-parameters",
+    tags=["category-rank-parameters"],
 )
 app.include_router(psi.router, prefix="/api/psi", tags=["psi"])
 app.include_router(psi_edits.router, prefix="/api/psi-edits", tags=["psi-edits"])
@@ -110,6 +121,7 @@ API_PREFIXES = (
     "psi-metrics",
     "psi",
     "psi-edits",
+    "category-rank-parameters",
     "channel-transfers",
     "auth",
     "health",

--- a/backend/app/routers/category_rank_parameters.py
+++ b/backend/app/routers/category_rank_parameters.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session as DBSession
+
+from .. import models, schemas
+from ..deps import get_db
+
+router = APIRouter()
+
+
+def _normalize_required(value: str, field_name: str) -> str:
+    trimmed = value.strip()
+    if not trimmed:
+        raise HTTPException(status_code=422, detail=f"{field_name} cannot be blank")
+    return trimmed
+
+
+def _get_record_or_404(
+    db: DBSession, rank_type: str, category_1: str, category_2: str
+) -> models.CategoryRankParameter:
+    record = db.get(models.CategoryRankParameter, (rank_type, category_1, category_2))
+    if record is None:
+        raise HTTPException(status_code=404, detail="rank parameter not found")
+    return record
+
+
+@router.get("/", response_model=list[schemas.CategoryRankParameterRead])
+def list_rank_parameters(
+    db: DBSession = Depends(get_db),
+) -> list[schemas.CategoryRankParameterRead]:
+    query = select(models.CategoryRankParameter).order_by(
+        models.CategoryRankParameter.rank_type.asc(),
+        models.CategoryRankParameter.category_1.asc(),
+        models.CategoryRankParameter.category_2.asc(),
+    )
+    return list(db.scalars(query))
+
+
+@router.post(
+    "",
+    response_model=schemas.CategoryRankParameterRead,
+    status_code=status.HTTP_201_CREATED,
+)
+@router.post(
+    "/",
+    response_model=schemas.CategoryRankParameterRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_rank_parameter(
+    payload: schemas.CategoryRankParameterCreate, db: DBSession = Depends(get_db)
+) -> schemas.CategoryRankParameterRead:
+    rank_type = _normalize_required(payload.rank_type, "rank_type")
+    category_1 = _normalize_required(payload.category_1, "category_1")
+    category_2 = _normalize_required(payload.category_2, "category_2")
+
+    record = models.CategoryRankParameter(
+        rank_type=rank_type,
+        category_1=category_1,
+        category_2=category_2,
+        threshold=Decimal(payload.threshold),
+    )
+
+    db.add(record)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="rank parameter already exists") from exc
+
+    db.refresh(record)
+    return record
+
+
+@router.put(
+    "/{rank_type}/{category_1}/{category_2}",
+    response_model=schemas.CategoryRankParameterRead,
+)
+def update_rank_parameter(
+    rank_type: str,
+    category_1: str,
+    category_2: str,
+    payload: schemas.CategoryRankParameterUpdate,
+    db: DBSession = Depends(get_db),
+) -> schemas.CategoryRankParameterRead:
+    record = _get_record_or_404(db, rank_type, category_1, category_2)
+
+    update_values = payload.model_dump(exclude_unset=True)
+    if "rank_type" in update_values:
+        update_values["rank_type"] = _normalize_required(update_values["rank_type"], "rank_type")
+    if "category_1" in update_values:
+        update_values["category_1"] = _normalize_required(update_values["category_1"], "category_1")
+    if "category_2" in update_values:
+        update_values["category_2"] = _normalize_required(update_values["category_2"], "category_2")
+
+    new_rank_type = update_values.get("rank_type", record.rank_type)
+    new_category_1 = update_values.get("category_1", record.category_1)
+    new_category_2 = update_values.get("category_2", record.category_2)
+
+    if (new_rank_type, new_category_1, new_category_2) != (
+        record.rank_type,
+        record.category_1,
+        record.category_2,
+    ):
+        existing = db.get(
+            models.CategoryRankParameter,
+            (new_rank_type, new_category_1, new_category_2),
+        )
+        if existing is not None:
+            raise HTTPException(status_code=409, detail="rank parameter already exists")
+
+    for field, value in update_values.items():
+        if field == "threshold" and value is not None:
+            setattr(record, field, Decimal(value))
+        else:
+            setattr(record, field, value)
+
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.delete(
+    "/{rank_type}/{category_1}/{category_2}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_rank_parameter(
+    rank_type: str,
+    category_1: str,
+    category_2: str,
+    db: DBSession = Depends(get_db),
+) -> Response:
+    record = _get_record_or_404(db, rank_type, category_1, category_2)
+    db.delete(record)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/warehouses.py
+++ b/backend/app/routers/warehouses.py
@@ -1,14 +1,29 @@
-"""Read-only endpoints for warehouse master records."""
+"""CRUD endpoints for warehouse master records."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DBSession
 
 from .. import models, schemas
 from ..deps import get_db
 
 router = APIRouter()
+
+
+def _normalize_required(value: str, field_name: str) -> str:
+    trimmed = value.strip()
+    if not trimmed:
+        raise HTTPException(status_code=422, detail=f"{field_name} cannot be blank")
+    return trimmed
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
 
 
 @router.get("", response_model=list[schemas.WarehouseMasterRead])
@@ -30,3 +45,85 @@ def get_warehouse(
     if record is None:
         raise HTTPException(status_code=404, detail="warehouse not found")
     return record
+
+
+@router.post("", response_model=schemas.WarehouseMasterRead, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=schemas.WarehouseMasterRead, status_code=status.HTTP_201_CREATED)
+def create_warehouse(
+    payload: schemas.WarehouseMasterCreate, db: DBSession = Depends(get_db)
+) -> schemas.WarehouseMasterRead:
+    """Create a new warehouse master record."""
+
+    warehouse_name = _normalize_required(payload.warehouse_name, "warehouse_name")
+    region = _normalize_optional(payload.region)
+    main_channel = _normalize_optional(payload.main_channel)
+
+    record = models.WarehouseMaster(
+        warehouse_name=warehouse_name,
+        region=region,
+        main_channel=main_channel,
+    )
+
+    db.add(record)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="warehouse already exists") from exc
+
+    db.refresh(record)
+    return record
+
+
+@router.put("/{warehouse_name}", response_model=schemas.WarehouseMasterRead)
+def update_warehouse(
+    warehouse_name: str,
+    payload: schemas.WarehouseMasterUpdate,
+    db: DBSession = Depends(get_db),
+) -> schemas.WarehouseMasterRead:
+    """Update an existing warehouse master record."""
+
+    record = db.get(models.WarehouseMaster, warehouse_name)
+    if record is None:
+        raise HTTPException(status_code=404, detail="warehouse not found")
+
+    update_values = payload.model_dump(exclude_unset=True)
+
+    if "warehouse_name" in update_values:
+        update_values["warehouse_name"] = _normalize_required(
+            update_values["warehouse_name"], "warehouse_name"
+        )
+    if "region" in update_values:
+        update_values["region"] = _normalize_optional(update_values["region"])
+    if "main_channel" in update_values:
+        update_values["main_channel"] = _normalize_optional(update_values["main_channel"])
+
+    new_name = update_values.get("warehouse_name", record.warehouse_name)
+    if new_name != record.warehouse_name:
+        existing = db.get(models.WarehouseMaster, new_name)
+        if existing is not None:
+            raise HTTPException(status_code=409, detail="warehouse already exists")
+
+    for field, value in update_values.items():
+        setattr(record, field, value)
+
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.delete(
+    "/{warehouse_name}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_warehouse(warehouse_name: str, db: DBSession = Depends(get_db)) -> Response:
+    """Remove a warehouse master record."""
+
+    record = db.get(models.WarehouseMaster, warehouse_name)
+    if record is None:
+        raise HTTPException(status_code=404, detail="warehouse not found")
+
+    db.delete(record)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from decimal import Decimal
 from typing import Annotated, Any
 from uuid import UUID
 
@@ -192,12 +193,30 @@ class MasterRecordRead(MasterRecordBase):
     model_config = {"from_attributes": True}
 
 
-class WarehouseMasterRead(BaseModel):
-    """Warehouse metadata returned by the warehouse master endpoint."""
+class WarehouseMasterBase(BaseModel):
+    """Shared attributes for warehouse master payloads."""
 
-    warehouse_name: str
+    warehouse_name: Annotated[str, Field(min_length=1)]
+    region: Annotated[str | None, Field(default=None)] = None
+    main_channel: Annotated[str | None, Field(default=None)] = None
+
+
+class WarehouseMasterCreate(WarehouseMasterBase):
+    """Schema for creating a warehouse master record."""
+
+    pass
+
+
+class WarehouseMasterUpdate(BaseModel):
+    """Schema for updating mutable warehouse master fields."""
+
+    warehouse_name: Annotated[str, Field(min_length=1)] | None = None
     region: str | None = None
     main_channel: str | None = None
+
+
+class WarehouseMasterRead(WarehouseMasterBase):
+    """Warehouse metadata returned by the warehouse master endpoint."""
 
     model_config = {"from_attributes": True}
 
@@ -226,6 +245,36 @@ class PSIMetricUpdate(BaseModel):
 
 class PSIMetricRead(PSIMetricBase):
     """PSI metric definition returned by the API."""
+
+    model_config = {"from_attributes": True}
+
+
+class CategoryRankParameterBase(BaseModel):
+    """Shared attributes for category rank parameter payloads."""
+
+    rank_type: Annotated[str, Field(min_length=1)]
+    category_1: Annotated[str, Field(min_length=1)]
+    category_2: Annotated[str, Field(min_length=1)]
+    threshold: Annotated[Decimal, Field(max_digits=20, decimal_places=6)]
+
+
+class CategoryRankParameterCreate(CategoryRankParameterBase):
+    """Schema for creating a category rank parameter."""
+
+    pass
+
+
+class CategoryRankParameterUpdate(BaseModel):
+    """Schema for updating a category rank parameter."""
+
+    rank_type: Annotated[str, Field(min_length=1)] | None = None
+    category_1: Annotated[str, Field(min_length=1)] | None = None
+    category_2: Annotated[str, Field(min_length=1)] | None = None
+    threshold: Annotated[Decimal, Field(max_digits=20, decimal_places=6)] | None = None
+
+
+class CategoryRankParameterRead(CategoryRankParameterBase):
+    """Category rank parameter returned by the API."""
 
     model_config = {"from_attributes": True}
 

--- a/backend/tests/test_category_rank_parameters_api.py
+++ b/backend/tests/test_category_rank_parameters_api.py
@@ -1,0 +1,181 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _perform_json_request(app, method: str, path: str, payload: dict | None = None):
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "scheme": "http",
+        "headers": [(b"content-type", b"application/json")] if payload else [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+
+    messages: list[dict[str, object]] = []
+    received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        body = json.dumps(payload).encode("utf-8") if payload else b""
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    asyncio.run(app(scope, receive, send))
+
+    start = next(msg for msg in messages if msg["type"] == "http.response.start")
+    body = b"".join(
+        part.get("body", b"") for part in messages if part["type"] == "http.response.body"
+    )
+    payload = None
+    if body:
+        payload = json.loads(body.decode("utf-8"))
+    return start["status"], payload
+
+
+@pytest.fixture(scope="module")
+def app_env(tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
+    db_path = tmp_path_factory.mktemp("rank_params") / "rank_params.sqlite"
+    os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+    os.environ["DB_SCHEMA"] = ""
+    os.environ.setdefault("SESSION_SIGN_KEY", "sign")
+    os.environ.setdefault("SECRET_KEY", "secret")
+    os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:5173")
+    os.environ.setdefault("CSRF_ENABLED", "false")
+
+    for name in list(sys.modules):
+        if name.startswith("backend.app"):
+            del sys.modules[name]
+
+    from backend.app import models
+    from backend.app.deps import SessionLocal, engine
+    from backend.app.main import app
+
+    with engine.begin() as connection:
+        models.CategoryRankParameter.__table__.drop(bind=connection, checkfirst=True)
+        models.CategoryRankParameter.__table__.create(bind=connection, checkfirst=True)
+
+    asyncio.run(app.router.startup())
+
+    return SimpleNamespace(
+        app=app,
+        models=models,
+        SessionLocal=SessionLocal,
+        engine=engine,
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_table(app_env: SimpleNamespace) -> None:
+    with app_env.engine.begin() as connection:
+        connection.execute(app_env.models.CategoryRankParameter.__table__.delete())
+    yield
+
+
+def test_create_rank_parameter(app_env: SimpleNamespace) -> None:
+    status, payload = _perform_json_request(
+        app_env.app,
+        "POST",
+        "/category-rank-parameters",
+        {
+            "rank_type": "FW",
+            "category_1": "A",
+            "category_2": "01",
+            "threshold": "12.5",
+        },
+    )
+
+    assert status == 201
+    assert payload is not None
+    assert payload["rank_type"] == "FW"
+    assert payload["category_1"] == "A"
+    assert payload["category_2"] == "01"
+    assert float(payload["threshold"]) == 12.5
+
+    with app_env.SessionLocal() as session:
+        record = session.get(app_env.models.CategoryRankParameter, ("FW", "A", "01"))
+        assert record is not None
+        assert float(record.threshold) == 12.5
+
+
+def test_update_rank_parameter_changes_key(app_env: SimpleNamespace) -> None:
+    with app_env.SessionLocal() as session:
+        session.add(
+            app_env.models.CategoryRankParameter(
+                rank_type="FW",
+                category_1="A",
+                category_2="01",
+                threshold=12.5,
+            )
+        )
+        session.commit()
+
+    status, payload = _perform_json_request(
+        app_env.app,
+        "PUT",
+        "/category-rank-parameters/FW/A/01",
+        {
+            "rank_type": "SS",
+            "category_1": "A",
+            "category_2": "02",
+            "threshold": "20.000000",
+        },
+    )
+
+    assert status == 200
+    assert payload is not None
+    assert payload["rank_type"] == "SS"
+    assert payload["category_1"] == "A"
+    assert payload["category_2"] == "02"
+    assert float(payload["threshold"]) == 20
+
+    with app_env.SessionLocal() as session:
+        old_record = session.get(app_env.models.CategoryRankParameter, ("FW", "A", "01"))
+        assert old_record is None
+        new_record = session.get(app_env.models.CategoryRankParameter, ("SS", "A", "02"))
+        assert new_record is not None
+        assert float(new_record.threshold) == 20
+
+
+def test_delete_rank_parameter(app_env: SimpleNamespace) -> None:
+    with app_env.SessionLocal() as session:
+        session.add(
+            app_env.models.CategoryRankParameter(
+                rank_type="FW",
+                category_1="A",
+                category_2="01",
+                threshold=12.5,
+            )
+        )
+        session.commit()
+
+    status, payload = _perform_json_request(
+        app_env.app, "DELETE", "/category-rank-parameters/FW/A/01"
+    )
+
+    assert status == 204
+    assert payload is None
+
+    with app_env.SessionLocal() as session:
+        assert (
+            session.get(app_env.models.CategoryRankParameter, ("FW", "A", "01")) is None
+        )

--- a/docs/2_データベース.md
+++ b/docs/2_データベース.md
@@ -40,8 +40,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_sessions_leader_true
 ### 1.2 PSI 基礎データ: `psi.psi_base`
 
 ```sql
+CREATE SEQUENCE IF NOT EXISTS psi_base_id_seq;
+
 CREATE TABLE IF NOT EXISTS psi.psi_base (
-  id              bigserial PRIMARY KEY,
+  id              bigint NOT NULL DEFAULT nextval('psi_base_id_seq'::regclass) PRIMARY KEY,
   session_id      uuid NOT NULL REFERENCES psi.sessions(id) ON DELETE CASCADE,
   sku_code        text NOT NULL,
   sku_name        text,
@@ -53,15 +55,24 @@ CREATE TABLE IF NOT EXISTS psi.psi_base (
   warehouse_name  text NOT NULL,
   channel         text NOT NULL,
   date            date NOT NULL,
-  stock_at_anchor numeric,
-  inbound_qty     numeric,
-  outbound_qty    numeric,
-  net_flow        numeric,
-  stock_closing   numeric,
-  safety_stock    numeric,
-  movable_stock   numeric,
+  stock_at_anchor numeric(20, 6),
+  inbound_qty     numeric(20, 6),
+  outbound_qty    numeric(20, 6),
+  net_flow        numeric(20, 6),
+  stock_closing   numeric(20, 6),
+  safety_stock    numeric(20, 6),
+  movable_stock   numeric(20, 6),
   created_at      timestamptz NOT NULL DEFAULT now()
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_psibase_key
+  ON psi.psi_base (session_id, sku_code, warehouse_name, channel, date);
+
+CREATE INDEX IF NOT EXISTS idx_psibase_lookup
+  ON psi.psi_base (session_id, sku_code, warehouse_name, channel, date);
+
+CREATE INDEX IF NOT EXISTS idx_psi_base_fw_rank ON psi.psi_base (fw_rank);
+CREATE INDEX IF NOT EXISTS idx_psi_base_ss_rank ON psi.psi_base (ss_rank);
 ```
 
 ### 1.3 PSI 編集データ: `psi.psi_edits`
@@ -188,10 +199,12 @@ CREATE TABLE IF NOT EXISTS psi.sku_master (
 CREATE TABLE IF NOT EXISTS psi.warehouse_master (
   warehouse_name text PRIMARY KEY,
   region text,
-  main_channel text REFERENCES psi.channel_master(channel),
-  CONSTRAINT ck_warehouse_master_main_channel_not_blank
-    CHECK (main_channel IS NULL OR length(trim(main_channel)) > 0)
+  main_channel text REFERENCES psi.channel_master(channel)
+    ON DELETE SET NULL
+    ON UPDATE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_wh_main_channel ON psi.warehouse_master (main_channel);
 
 CREATE TABLE IF NOT EXISTS psi.channel_master (
   channel text PRIMARY KEY,
@@ -266,14 +279,14 @@ CREATE TABLE IF NOT EXISTS psi.stock_transfers (
 
 ### 2.5 カテゴリ別ランク閾値: `psi.category_rank_parameters`
 
-カテゴリ別に計算へ渡す閾値（例: FW/SS のランク判定用）を保持するマスタです。`rank_type` は運用で利用する識別子に限定するため、チェック制約で `'FW'` と `'SS'` のみ許可しています。集計ロジックでは `category_1` / `category_2` の組み合わせごとに `threshold` を参照します。
+カテゴリ別に計算へ渡す閾値（例: FW/SS のランク判定用）を保持するマスタです。`rank_type` は運用で利用する識別子を自由に設定できます。集計ロジックでは `category_1` / `category_2` の組み合わせごとに `threshold` を参照します。
 
 ```sql
 CREATE TABLE IF NOT EXISTS psi.category_rank_parameters (
-  rank_type  text NOT NULL CHECK (rank_type IN ('FW', 'SS')),
+  rank_type  text NOT NULL,
   category_1 text NOT NULL,
   category_2 text NOT NULL,
-  threshold  numeric NOT NULL,
+  threshold  numeric(20, 6) NOT NULL,
   PRIMARY KEY (rank_type, category_1, category_2)
 );
 ```

--- a/docs/8_カテゴリ別ランク設定.md
+++ b/docs/8_カテゴリ別ランク設定.md
@@ -7,9 +7,9 @@
 - テーブル: `psi.category_rank_parameters`
 - 主キー: `(rank_type, category_1, category_2)`
 - カラム:
-  - `rank_type` — 閾値の利用シーン（`FW` / `SS` など）を表す識別子。チェック制約で `'FW'` と `'SS'` のみ許可。
+  - `rank_type` — 閾値の利用シーン（`FW` / `SS` など）を表す識別子。必要に応じて運用で追加できます。
   - `category_1`, `category_2` — 分類コード。両方必須。
-  - `threshold` — ランク判定に用いる数値（decimal）。
+  - `threshold` — ランク判定に用いる数値（decimal(20, 6)）。
 
 ## 2. データ格納形式
 
@@ -17,7 +17,7 @@
 
 | 列名 | 必須 | 備考 |
 | --- | --- | --- |
-| `rank_type` | ✅ | `FW` または `SS` |
+| `rank_type` | ✅ | 運用で利用する任意の識別子 |
 | `category_1` | ✅ | 半角英数字推奨 |
 | `category_2` | ✅ | 半角英数字推奨 |
 | `threshold` | ✅ | `0.00` 形式の 10 進数 |
@@ -43,10 +43,11 @@
 
 3. 反映後、`SELECT * FROM psi.category_rank_parameters ORDER BY rank_type, category_1, category_2;` で内容を確認します。
 
-### 3.2 将来的な管理画面対応
+### 3.2 管理画面での編集
 
-- 管理画面が実装された際は、同テーブルを直接編集する機能を追加します。
-- 画面側では `rank_type` をプルダウン（`FW` / `SS`）にし、CSV との整合性が取れるようバリデーションを実施してください。
+- `Masters > Rank Parameters` からテーブル内容を直接編集できます。
+- 画面では `rank_type` / `category_1` / `category_2` の各値と閾値 (`threshold`) を追加・更新・削除できます。
+- CSV インポートと併用する場合は、最新状態を管理画面で確認してから投入してください。
 
 ## 4. バックエンド連携
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,9 @@ function ProtectedLayout() {
 
   const masters = useMemo(() => {
     const items = [
-      { path: "/masters/psi-metrics", label: "PSI Metrics Master", icon: "🧮" },
+      { path: "/masters/metrics", label: "Metrics", icon: "🧮" },
+      { path: "/masters/rank-parameters", label: "Rank Parameters", icon: "📈" },
+      { path: "/masters/warehouses", label: "Warehouse", icon: "🏭" },
     ];
 
     if (user?.is_admin) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -114,6 +114,19 @@ export interface PSIMetricDefinition {
   display_order: number;
 }
 
+export interface WarehouseMaster {
+  warehouse_name: string;
+  region?: string | null;
+  main_channel?: string | null;
+}
+
+export interface CategoryRankParameter {
+  rank_type: string;
+  category_1: string;
+  category_2: string;
+  threshold: string;
+}
+
 export interface MasterRecord {
   id: string;
   master_type: string;


### PR DESCRIPTION
## Summary
- update database documentation to match the latest PSI base and master table DDL
- add CRUD APIs and tests for warehouse and category rank parameters masters
- expand the Masters UI with warehouse and rank parameter management and refreshed navigation labels

## Testing
- pytest backend/tests/test_warehouses_api.py backend/tests/test_category_rank_parameters_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dce0131630832e9f4687195a225823