### PR TITLE
Handle FastAPI lifespan cancellation on shutdown

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,9 @@
 """FastAPI application entry-point."""
 from __future__ import annotations
 
+import asyncio
+import logging
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -26,7 +29,18 @@ from .routers import (
     warehouses,
 )
 
-app = FastAPI(title="GEN-like PSI API")
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    try:
+        yield
+    except asyncio.CancelledError:
+        logger.info("Application lifespan cancelled during shutdown.")
+
+
+app = FastAPI(title="GEN-like PSI API", lifespan=_lifespan)
 
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 app.add_middleware(SecurityHeadersMiddleware)


### PR DESCRIPTION
## Summary
- add a FastAPI lifespan context manager that gracefully handles asyncio.CancelledError during shutdown
- emit an informational log when the lifespan is cancelled so the shutdown remains transparent

## Testing
- pytest *(fails: alembic.util.exc.CommandError: Multiple head revisions are present for given argument 'head')*


------
https://chatgpt.com/codex/tasks/task_e_68dce4c574d8832e80a04ed7642ca581