### PR TITLE
Fix master data API proxy configuration

### DIFF
--- a/frontend/src/pages/MasterPage.tsx
+++ b/frontend/src/pages/MasterPage.tsx
@@ -68,6 +68,9 @@ const getErrorMessage = (error: unknown, fallback: string) => {
 
 const fetchMetrics = async (): Promise<PSIMetricDefinition[]> => {
   const { data } = await api.get<PSIMetricDefinition[]>("/psi-metrics/");
+  if (!Array.isArray(data)) {
+    throw new Error("Unexpected metrics response format.");
+  }
   return data;
 };
 
@@ -93,6 +96,9 @@ const deleteMetric = async (metricName: string): Promise<void> => {
 
 const fetchWarehouses = async (): Promise<WarehouseMaster[]> => {
   const { data } = await api.get<WarehouseMaster[]>("/warehouses/");
+  if (!Array.isArray(data)) {
+    throw new Error("Unexpected warehouses response format.");
+  }
   return data;
 };
 
@@ -118,6 +124,9 @@ const deleteWarehouse = async (warehouseName: string): Promise<void> => {
 
 const fetchRankParameters = async (): Promise<CategoryRankParameter[]> => {
   const { data } = await api.get<CategoryRankParameter[]>("/category-rank-parameters/");
+  if (!Array.isArray(data)) {
+    throw new Error("Unexpected rank parameters response format.");
+  }
   return data;
 };
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       // 認証
       "^/(auth)(/|$)": { target: "http://localhost:8000", changeOrigin: true },
       // PSI / セッション / マスター系など、使ってるAPIを全部ここに
-      "^/(psi|sessions|masters|api)(/|$)": {
+      "^/(psi|psi-metrics|sessions|masters|api|warehouses|category-rank-parameters|channel-transfers|psi-edits|users)(/|$)": {
         target: "http://localhost:8000",
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- extend the Vite dev-server proxy so master data endpoints are forwarded to the FastAPI backend
- guard master data fetchers against non-array responses to surface clear errors instead of crashing

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf603a3b0832eb00576251bcaff4e