### PR TITLE
Hide Rank Parameters master menu entry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,6 @@ function ProtectedLayout() {
   const masters = useMemo(() => {
     const items = [
       { path: "/masters/metrics", label: "Metrics", icon: "🧮" },
-      { path: "/masters/rank-parameters", label: "Rank Parameters", icon: "📈" },
       { path: "/masters/warehouses", label: "Warehouse", icon: "🏭" },
     ];
 


### PR DESCRIPTION
## Summary
- remove the Rank Parameters entry from the Masters sidebar menu so it no longer appears

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd149e43e8832e97902a506ab1254f