### PR TITLE
Add saved plan retrieval and SKU name support to reallocation

### DIFF
--- a/backend/app/routers/psi.py
+++ b/backend/app/routers/psi.py
@@ -815,6 +815,7 @@ def psi_matrix(
     return [
         schemas.MatrixRow(
             sku_code=row.sku_code,
+            sku_name=row.sku_name,
             warehouse_name=row.warehouse_name,
             channel=row.channel,
             stock_at_anchor=float(row.stock_at_anchor),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -329,6 +329,7 @@ class MatrixRow(BaseModel):
     """Aggregated PSI metrics decorated with plan movements."""
 
     sku_code: str
+    sku_name: str | None = None
     warehouse_name: str
     channel: str
     stock_at_anchor: float
@@ -352,6 +353,10 @@ class TransferPlanRead(BaseModel):
     start_date: date
     end_date: date
     status: TransferPlanStatus
+    created_at: datetime
+    updated_at: datetime
+    created_by: UUID | None = None
+    updated_by: UUID | None = None
 
     model_config = {"from_attributes": True}
 
@@ -396,11 +401,15 @@ class TransferPlanRecommendRequest(BaseModel):
     channels: list[str] | None = None
 
 
-class TransferPlanRecommendResponse(BaseModel):
-    """Transfer plan created by the recommendation engine."""
+class TransferPlanWithLines(BaseModel):
+    """Transfer plan along with the associated line items."""
 
     plan: TransferPlanRead
     lines: list[TransferPlanLineRead]
+
+
+class TransferPlanRecommendResponse(TransferPlanWithLines):
+    """Transfer plan created by the recommendation engine."""
 
 
 class TransferPlanLineUpsertRequest(BaseModel):

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -462,6 +462,10 @@ body {
   align-items: center;
 }
 
+.reallocation-page .filter-actions {
+  margin-top: 1rem;
+}
+
 .filter-actions button {
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
@@ -623,6 +627,46 @@ button.collapse-toggle:focus-visible {
   display: grid;
   gap: 0.25rem;
   font-weight: 600;
+}
+
+.existing-plans {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.existing-plans__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.existing-plans__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  min-width: 260px;
+}
+
+.existing-plans__select {
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-default);
+  background: var(--surface-panel);
+  color: inherit;
+}
+
+.existing-plans__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-subtle, #9ca3af);
+}
+
+.existing-plans__status--error {
+  color: var(--accent-red, #dc2626);
 }
 
 .psi-summary-card {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,25 +86,6 @@ function ProtectedLayout() {
             </NavLink>
           </li>
           <li>
-            <NavLink to="/psi" className={({ isActive }) => (isActive ? "active" : undefined)}>
-              <span className="menu-icon" aria-hidden="true">
-                📊
-              </span>
-              <span className="menu-label">PSI Table</span>
-            </NavLink>
-          </li>
-          <li>
-            <NavLink
-              to="/transfer"
-              className={({ isActive }) => (isActive ? "active" : undefined)}
-            >
-              <span className="menu-icon" aria-hidden="true">
-                🔄
-              </span>
-              <span className="menu-label">Transfer</span>
-            </NavLink>
-          </li>
-          <li>
             <NavLink
               to="/reallocation"
               className={({ isActive }) => (isActive ? "active" : undefined)}
@@ -113,14 +94,6 @@ function ProtectedLayout() {
                 ♻️
               </span>
               <span className="menu-label">Reallocation</span>
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/edits" className={({ isActive }) => (isActive ? "active" : undefined)}>
-              <span className="menu-icon" aria-hidden="true">
-                ✏️
-              </span>
-              <span className="menu-label">Edits</span>
             </NavLink>
           </li>
           <li>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,6 +112,7 @@ export interface ChannelTransfer extends ChannelTransferCreate {
 
 export interface MatrixRow {
   sku_code: string;
+  sku_name?: string | null;
   warehouse_name: string;
   channel: string;
   stock_at_anchor: number;
@@ -132,6 +133,10 @@ export interface TransferPlan {
   start_date: string;
   end_date: string;
   status: TransferPlanStatus;
+  created_at: string;
+  updated_at: string;
+  created_by?: string | null;
+  updated_by?: string | null;
 }
 
 export interface TransferPlanLine {
@@ -145,6 +150,11 @@ export interface TransferPlanLine {
   qty: number;
   is_manual: boolean;
   reason?: string | null;
+}
+
+export interface TransferPlanWithLines {
+  plan: TransferPlan;
+  lines: TransferPlanLine[];
 }
 
 export interface PSIMetricDefinition {


### PR DESCRIPTION
## Summary
- hide PSI Table, Transfer, and Edits from the sidebar while keeping their routes active
- add transfer plan listing and detail endpoints and include SKU names in PSI matrix data
- refresh the reallocation UI to load saved plans, remove SKU filters, and show SKU names with improved spacing

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd50fa5b50832ebfcaedf3888c9166