### PR TITLE
Add tabbed PSI matrix analytics views

### DIFF
--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from "react";
+
+import OriginView from "./views/OriginView";
+import CrossTableView from "./views/CrossTableView";
+import HeatmapView from "./views/HeatmapView";
+import BarsView from "./views/BarsView";
+import KpiView from "./views/KpiView";
+import type { PsiRow } from "./types";
+import { METRIC_DEFINITIONS, formatMetricValue, safeNumber } from "./utils";
+import "../../../styles/psi-matrix.css";
+
+const TAB_CONFIG = [
+  { value: "origin", label: "Origin" },
+  { value: "cross", label: "Cross Table" },
+  { value: "heatmap", label: "Heatmap" },
+  { value: "bars", label: "Bars" },
+  { value: "kpis", label: "KPIs" },
+] as const;
+
+type TabValue = (typeof TAB_CONFIG)[number]["value"];
+
+interface PSIMatrixTabsProps {
+  data: PsiRow[];
+  skuList: string[];
+  initialSkuIndex?: number;
+  onSkuChange?: (index: number) => void;
+}
+
+export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: PSIMatrixTabsProps) {
+  const normalizedSkuList = useMemo(() => {
+    if (skuList.length > 0) {
+      return skuList;
+    }
+    const set = new Set<string>();
+    const list: string[] = [];
+    data.forEach((row) => {
+      const sku = String(row.sku);
+      if (!set.has(sku)) {
+        set.add(sku);
+        list.push(sku);
+      }
+    });
+    return list;
+  }, [data, skuList]);
+
+  const [activeTab, setActiveTab] = useState<TabValue>("origin");
+  const [skuIndex, setSkuIndex] = useState(() => {
+    if (!normalizedSkuList.length) {
+      return 0;
+    }
+    const nextIndex = initialSkuIndex ?? 0;
+    return Math.min(Math.max(nextIndex, 0), normalizedSkuList.length - 1);
+  });
+  const [warehouseFilter, setWarehouseFilter] = useState("");
+  const [channelFilter, setChannelFilter] = useState("");
+
+  useEffect(() => {
+    if (typeof initialSkuIndex !== "number") {
+      return;
+    }
+    setSkuIndex((prev) => {
+      if (!normalizedSkuList.length) {
+        return 0;
+      }
+      const next = Math.min(Math.max(initialSkuIndex, 0), normalizedSkuList.length - 1);
+      return next === prev ? prev : next;
+    });
+  }, [initialSkuIndex, normalizedSkuList.length]);
+
+  useEffect(() => {
+    setSkuIndex((prev) => {
+      if (!normalizedSkuList.length) {
+        return 0;
+      }
+      const clamped = Math.min(Math.max(prev, 0), normalizedSkuList.length - 1);
+      return clamped === prev ? prev : clamped;
+    });
+  }, [normalizedSkuList]);
+
+  useEffect(() => {
+    if (onSkuChange) {
+      onSkuChange(skuIndex);
+    }
+  }, [skuIndex, onSkuChange]);
+
+  const currentSku = normalizedSkuList.length > 0 ? normalizedSkuList[Math.min(skuIndex, normalizedSkuList.length - 1)] : null;
+
+  const rowsForSku = useMemo(() => {
+    if (!currentSku) {
+      return [] as PsiRow[];
+    }
+    return data.filter((row) => String(row.sku) === currentSku);
+  }, [currentSku, data]);
+
+  const normalizedWarehouseFilter = warehouseFilter.trim().toLowerCase();
+  const normalizedChannelFilter = channelFilter.trim().toLowerCase();
+
+  const filteredRows = useMemo(() => {
+    if (!normalizedWarehouseFilter && !normalizedChannelFilter) {
+      return rowsForSku;
+    }
+    return rowsForSku.filter((row) => {
+      const warehouseMatch = normalizedWarehouseFilter
+        ? row.warehouse.toLowerCase().includes(normalizedWarehouseFilter)
+        : true;
+      const channelMatch = normalizedChannelFilter
+        ? row.channel.toLowerCase().includes(normalizedChannelFilter)
+        : true;
+      return warehouseMatch && channelMatch;
+    });
+  }, [rowsForSku, normalizedWarehouseFilter, normalizedChannelFilter]);
+
+  const skuName = rowsForSku[0]?.skuName ?? "";
+  const skuIndicator = currentSku
+    ? `${skuIndex + 1} / ${normalizedSkuList.length} : ${currentSku}${skuName ? ` – ${skuName}` : ""}`
+    : "-";
+
+  const hasFilteredRows = filteredRows.length > 0;
+  const emptyMessage = rowsForSku.length === 0 ? "No data for the selected SKU." : "No rows match the current filters.";
+
+  const handlePrevSku = () => {
+    setSkuIndex((prev) => Math.max(0, prev - 1));
+  };
+
+  const handleNextSku = () => {
+    setSkuIndex((prev) => {
+      if (!normalizedSkuList.length) {
+        return 0;
+      }
+      return Math.min(normalizedSkuList.length - 1, prev + 1);
+    });
+  };
+
+  let tabContent: JSX.Element;
+  if (!hasFilteredRows) {
+    tabContent = <p className="psi-matrix-empty">{emptyMessage}</p>;
+  } else {
+    switch (activeTab) {
+      case "origin":
+        tabContent = <OriginView rows={filteredRows} />;
+        break;
+      case "cross":
+        tabContent = <CrossTableView rows={filteredRows} metrics={METRIC_DEFINITIONS} />;
+        break;
+      case "heatmap":
+        tabContent = <HeatmapView rows={filteredRows} metrics={METRIC_DEFINITIONS} />;
+        break;
+      case "bars":
+        tabContent = <BarsView rows={filteredRows} />;
+        break;
+      case "kpis":
+        tabContent = <KpiView rows={filteredRows} />;
+        break;
+      default:
+        tabContent = <OriginView rows={filteredRows} />;
+    }
+  }
+
+  return (
+    <div className="psi-matrix-tabs">
+      <div className="psi-matrix-toolbar">
+        <div className="sku-navigation">
+          <button type="button" onClick={handlePrevSku} disabled={skuIndex <= 0}>
+            前のSKU
+          </button>
+          <span className="sku-indicator">{skuIndicator}</span>
+          <button
+            type="button"
+            onClick={handleNextSku}
+            disabled={normalizedSkuList.length === 0 || skuIndex >= normalizedSkuList.length - 1}
+          >
+            次のSKU
+          </button>
+        </div>
+        <div className="psi-matrix-filters">
+          <label>
+            Warehouse filter
+            <input
+              type="search"
+              value={warehouseFilter}
+              placeholder="Contains…"
+              onChange={(event) => setWarehouseFilter(event.target.value)}
+            />
+          </label>
+          <label>
+            Channel filter
+            <input
+              type="search"
+              value={channelFilter}
+              placeholder="Contains…"
+              onChange={(event) => setChannelFilter(event.target.value)}
+            />
+          </label>
+        </div>
+      </div>
+      <div className="psi-matrix-tablist" role="tablist" aria-label="PSI matrix views">
+        {TAB_CONFIG.map((tab) => (
+          <button
+            key={tab.value}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.value}
+            className={`psi-matrix-tab ${activeTab === tab.value ? "active" : ""}`}
+            onClick={() => setActiveTab(tab.value)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="psi-matrix-content" role="tabpanel">
+        {tabContent}
+      </div>
+      {hasFilteredRows && (
+        <footer className="psi-matrix-footer">
+          <span className="psi-matrix-count">
+            Showing {filteredRows.length} row{filteredRows.length === 1 ? "" : "s"}. Total:{" "}
+            {formatMetricValue(filteredRows.reduce((total, row) => total + safeNumber(row.stockFinal), 0))} Final
+          </span>
+        </footer>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/reallocation/psi/types.ts
+++ b/frontend/src/features/reallocation/psi/types.ts
@@ -1,0 +1,40 @@
+export interface PsiRowMetrics {
+  stockStart?: number;
+  inbound?: number;
+  outbound?: number;
+  stockClosing?: number;
+  stdStock?: number;
+  gap?: number;
+  move?: number;
+  stockFinal?: number;
+  gapAfter?: number;
+}
+
+export type MetricKey = keyof PsiRowMetrics;
+
+export interface PsiRowBase {
+  sku: string | number;
+  skuName?: string;
+  warehouse: string;
+  channel: string;
+}
+
+export type PsiRow = PsiRowBase & PsiRowMetrics;
+
+export interface MetricDefinition {
+  key: MetricKey;
+  label: string;
+  shortLabel?: string;
+  description?: string;
+}
+
+export interface ColumnGroup {
+  warehouse: string;
+  channels: string[];
+}
+
+export interface ColumnKey {
+  key: string;
+  warehouse: string;
+  channel: string;
+}

--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -1,0 +1,81 @@
+import type { ColumnGroup, ColumnKey, MetricDefinition, MetricKey, PsiRow } from "./types";
+
+export const METRIC_DEFINITIONS: MetricDefinition[] = [
+  { key: "stockStart", label: "Stock @ Start", shortLabel: "Start" },
+  { key: "inbound", label: "Inbound", shortLabel: "Inbound" },
+  { key: "outbound", label: "Outbound", shortLabel: "Outbound" },
+  { key: "stockClosing", label: "Stock Closing", shortLabel: "Closing" },
+  { key: "stdStock", label: "Std Stock", shortLabel: "Std" },
+  { key: "gap", label: "Gap", shortLabel: "Gap" },
+  { key: "move", label: "Move", shortLabel: "Move" },
+  { key: "stockFinal", label: "Stock Final", shortLabel: "Final" },
+  { key: "gapAfter", label: "Gap After", shortLabel: "Gap After" },
+];
+
+export const KPI_CARD_METRICS: Array<{ key: MetricKey; label: string; emphasize?: boolean }> = [
+  { key: "stockStart", label: "Start" },
+  { key: "inbound", label: "Inbound" },
+  { key: "outbound", label: "Outbound" },
+  { key: "stockFinal", label: "Final" },
+  { key: "gap", label: "Gap", emphasize: true },
+  { key: "gapAfter", label: "Gap After", emphasize: true },
+  { key: "stdStock", label: "Std Stock" },
+  { key: "move", label: "Move" },
+];
+
+export const DEFAULT_HEATMAP_METRICS: MetricKey[] = ["gap", "gapAfter"];
+
+export const makeColumnKey = (warehouse: string, channel: string) => `${warehouse}｜${channel}`;
+
+export const buildColumnGroups = (rows: PsiRow[]): ColumnGroup[] => {
+  const map = new Map<string, Set<string>>();
+  rows.forEach((row) => {
+    const warehouse = row.warehouse || "-";
+    const channel = row.channel || "-";
+    const set = map.get(warehouse) ?? new Set<string>();
+    set.add(channel);
+    map.set(warehouse, set);
+  });
+  return Array.from(map.entries())
+    .map(([warehouse, channelSet]) => ({
+      warehouse,
+      channels: Array.from(channelSet).sort((a, b) => a.localeCompare(b)),
+    }))
+    .sort((a, b) => a.warehouse.localeCompare(b.warehouse));
+};
+
+export const columnKeysFromGroups = (groups: ColumnGroup[]): ColumnKey[] =>
+  groups.flatMap((group) =>
+    group.channels.map((channel) => ({
+      key: makeColumnKey(group.warehouse, channel),
+      warehouse: group.warehouse,
+      channel,
+    })),
+  );
+
+export const safeNumber = (value: number | null | undefined): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+export const sumByMetric = (rows: PsiRow[], metric: MetricKey): number =>
+  rows.reduce((total, row) => total + safeNumber(row[metric]), 0);
+
+export const getMetricValue = (row: PsiRow | undefined, metric: MetricKey): number | null => {
+  if (!row) {
+    return null;
+  }
+  const value = row[metric];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+};
+
+export const formatMetricValue = (value: number | null | undefined): string => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "-";
+  }
+  const fixed = value.toFixed(2);
+  const [intPart, decimalPart = ""] = fixed.split(".");
+  const sign = value < 0 ? "-" : "";
+  const absInt = Math.abs(Number(intPart));
+  const intWithSeparators = absInt.toLocaleString();
+  const trimmedDecimal = decimalPart.replace(/0+$/, "");
+  return `${sign}${intWithSeparators}${trimmedDecimal ? `.${trimmedDecimal}` : ""}`;
+};

--- a/frontend/src/features/reallocation/psi/views/BarsView.tsx
+++ b/frontend/src/features/reallocation/psi/views/BarsView.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+
+import type { PsiRow } from "../types";
+import { formatMetricValue, makeColumnKey, safeNumber } from "../utils";
+
+interface BarsViewProps {
+  rows: PsiRow[];
+}
+
+const BAR_METRICS = [
+  { key: "stockStart", label: "Start", color: "#64748b" },
+  { key: "inbound", label: "Inbound", color: "#22c55e" },
+  { key: "outbound", label: "Outbound", color: "#f97316" },
+  { key: "stockFinal", label: "Final", color: "#3b82f6" },
+] as const;
+
+type BarMetricKey = (typeof BAR_METRICS)[number]["key"];
+
+type ChartDatum = {
+  key: string;
+  label: string;
+  values: Record<BarMetricKey, number>;
+};
+
+const buildTooltip = (values: Record<BarMetricKey, number>) =>
+  BAR_METRICS.map((metric) => `${metric.label}: ${formatMetricValue(values[metric.key])}`).join("\n");
+
+export default function BarsView({ rows }: BarsViewProps) {
+  const data = useMemo<ChartDatum[]>(() => {
+    const map = new Map<string, ChartDatum>();
+    rows.forEach((row) => {
+      const key = makeColumnKey(row.warehouse, row.channel);
+      const values = map.get(key)?.values ?? {
+        stockStart: 0,
+        inbound: 0,
+        outbound: 0,
+        stockFinal: 0,
+      };
+      values.stockStart += safeNumber(row.stockStart);
+      values.inbound += safeNumber(row.inbound);
+      values.outbound += safeNumber(row.outbound);
+      values.stockFinal += safeNumber(row.stockFinal);
+      map.set(key, {
+        key,
+        label: `${row.warehouse}｜${row.channel}`,
+        values,
+      });
+    });
+    return Array.from(map.values()).sort((a, b) => a.label.localeCompare(b.label));
+  }, [rows]);
+
+  if (data.length === 0) {
+    return <p className="psi-matrix-empty">No rows match the current filters.</p>;
+  }
+
+  return (
+    <div className="psi-bars-chart">
+      <div className="psi-bars-grid">
+        {data.map((item) => {
+          const total = BAR_METRICS.reduce(
+            (sum, metric) => sum + Math.abs(item.values[metric.key]),
+            0,
+          );
+          const tooltip = buildTooltip(item.values);
+          return (
+            <div key={item.key} className="psi-bar">
+              <div className="psi-bar-stack" title={tooltip} aria-label={`Stacked metrics for ${item.label}`}>
+                {BAR_METRICS.map((metric) => {
+                  const value = Math.abs(item.values[metric.key]);
+                  return (
+                    <div
+                      key={metric.key}
+                      className="psi-bar-segment"
+                      style={{
+                        backgroundColor: metric.color,
+                        flexGrow: value,
+                        minHeight: value > 0 ? 6 : 0,
+                      }}
+                    >
+                      {value > 0 && (
+                        <span className="psi-bar-segment-label">
+                          {formatMetricValue(item.values[metric.key])}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+                {total === 0 && <div className="psi-bar-empty">0</div>}
+              </div>
+              <div className="psi-bar-caption">
+                <span className="psi-bar-label" title={item.label}>
+                  {item.label}
+                </span>
+                <span className="psi-bar-final">{formatMetricValue(item.values.stockFinal)}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+
+import type { MetricDefinition, PsiRow } from "../types";
+import {
+  buildColumnGroups,
+  columnKeysFromGroups,
+  formatMetricValue,
+  getMetricValue,
+  makeColumnKey,
+} from "../utils";
+
+interface CrossTableViewProps {
+  rows: PsiRow[];
+  metrics: MetricDefinition[];
+}
+
+const getValueClassName = (value: number | null) => {
+  if (value === null || value === 0) {
+    return "value-neutral";
+  }
+  if (value > 0) {
+    return "value-positive";
+  }
+  return "value-negative";
+};
+
+export default function CrossTableView({ rows, metrics }: CrossTableViewProps) {
+  const columnGroups = useMemo(() => buildColumnGroups(rows), [rows]);
+  const columnKeys = useMemo(() => columnKeysFromGroups(columnGroups), [columnGroups]);
+  const rowMap = useMemo(() => {
+    const map = new Map<string, PsiRow>();
+    rows.forEach((row) => {
+      map.set(makeColumnKey(row.warehouse, row.channel), row);
+    });
+    return map;
+  }, [rows]);
+
+  if (columnKeys.length === 0) {
+    return <p className="psi-matrix-empty">No rows match the current filters.</p>;
+  }
+
+  return (
+    <div className="psi-matrix-scroll">
+      <table className="psi-matrix-table">
+        <thead>
+          <tr>
+            <th rowSpan={2} className="metric-column">
+              Metric
+            </th>
+            {columnGroups.map((group) => (
+              <th key={group.warehouse} colSpan={group.channels.length} className="warehouse-header">
+                {group.warehouse}
+              </th>
+            ))}
+          </tr>
+          <tr>
+            {columnGroups.flatMap((group) =>
+              group.channels.map((channel) => (
+                <th key={`${group.warehouse}|${channel}`} className="channel-header">
+                  {channel}
+                </th>
+              )),
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {metrics.map((metric) => (
+            <tr key={metric.key}>
+              <th scope="row" className="metric-label">
+                {metric.label}
+              </th>
+              {columnKeys.map((column) => {
+                const value = getMetricValue(rowMap.get(column.key), metric.key);
+                return (
+                  <td key={column.key} className={getValueClassName(value)}>
+                    {formatMetricValue(value)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
+++ b/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from "react";
+
+import type { MetricDefinition, MetricKey, PsiRow } from "../types";
+import {
+  DEFAULT_HEATMAP_METRICS,
+  buildColumnGroups,
+  columnKeysFromGroups,
+  formatMetricValue,
+  getMetricValue,
+  makeColumnKey,
+} from "../utils";
+
+interface HeatmapViewProps {
+  rows: PsiRow[];
+  metrics: MetricDefinition[];
+}
+
+const buildInitialSelection = (metrics: MetricDefinition[]) => {
+  const defaults = metrics.filter((metric) => DEFAULT_HEATMAP_METRICS.includes(metric.key));
+  if (defaults.length > 0) {
+    return defaults.map((metric) => metric.key);
+  }
+  return metrics.length > 0 ? [metrics[0].key] : [];
+};
+
+const createHeatmapStyle = (value: number | null, maxAbs: number) => {
+  if (value === null || maxAbs === 0) {
+    return {};
+  }
+  const intensity = Math.min(Math.abs(value) / maxAbs, 1);
+  const alpha = 0.2 + intensity * 0.5;
+  const backgroundColor = value >= 0 ? `rgba(34, 197, 94, ${alpha})` : `rgba(239, 68, 68, ${alpha})`;
+  const textColor = intensity > 0.6 ? "var(--surface-body)" : undefined;
+  return { backgroundColor, color: textColor };
+};
+
+export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
+  const [selectedMetrics, setSelectedMetrics] = useState(() => buildInitialSelection(metrics));
+  const columnGroups = useMemo(() => buildColumnGroups(rows), [rows]);
+  const columnKeys = useMemo(() => columnKeysFromGroups(columnGroups), [columnGroups]);
+  const rowMap = useMemo(() => {
+    const map = new Map<string, PsiRow>();
+    rows.forEach((row) => {
+      map.set(makeColumnKey(row.warehouse, row.channel), row);
+    });
+    return map;
+  }, [rows]);
+
+  const heatmapMax = useMemo(() => {
+    let max = 0;
+    selectedMetrics.forEach((metric) => {
+      columnKeys.forEach((column) => {
+        const value = getMetricValue(rowMap.get(column.key), metric);
+        if (value !== null) {
+          max = Math.max(max, Math.abs(value));
+        }
+      });
+    });
+    return max;
+  }, [selectedMetrics, columnKeys, rowMap]);
+
+  const handleToggleMetric = (metricKey: MetricKey) => {
+    setSelectedMetrics((prev) => {
+      if (prev.includes(metricKey)) {
+        return prev.filter((item) => item !== metricKey);
+      }
+      return [...prev, metricKey];
+    });
+  };
+
+  const handleSelectAll = () => {
+    setSelectedMetrics(metrics.map((metric) => metric.key));
+  };
+
+  const handleReset = () => {
+    setSelectedMetrics(buildInitialSelection(metrics));
+  };
+
+  if (columnKeys.length === 0) {
+    return <p className="psi-matrix-empty">No rows match the current filters.</p>;
+  }
+
+  return (
+    <div className="psi-heatmap">
+      <div className="psi-heatmap-controls">
+        <div className="psi-heatmap-buttons">
+          <button type="button" onClick={handleSelectAll} disabled={selectedMetrics.length === metrics.length}>
+            All
+          </button>
+          <button type="button" onClick={handleReset}>
+            Reset
+          </button>
+        </div>
+        <div className="psi-heatmap-checkboxes">
+          {metrics.map((metric) => (
+            <label key={metric.key} className="psi-heatmap-checkbox">
+              <input
+                type="checkbox"
+                checked={selectedMetrics.includes(metric.key)}
+                onChange={() => handleToggleMetric(metric.key)}
+              />
+              <span>{metric.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+      {selectedMetrics.length === 0 ? (
+        <p className="psi-matrix-empty">Select at least one metric to display the heatmap.</p>
+      ) : (
+        <div className="psi-matrix-scroll">
+          <table className="psi-matrix-table psi-heatmap-table">
+            <thead>
+              <tr>
+                <th rowSpan={2} className="metric-column">
+                  Metric
+                </th>
+                {columnGroups.map((group) => (
+                  <th key={group.warehouse} colSpan={group.channels.length} className="warehouse-header">
+                    {group.warehouse}
+                  </th>
+                ))}
+              </tr>
+              <tr>
+                {columnGroups.flatMap((group) =>
+                  group.channels.map((channel) => (
+                    <th key={`${group.warehouse}|${channel}`} className="channel-header">
+                      {channel}
+                    </th>
+                  )),
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {selectedMetrics.map((metricKey) => {
+                const metric = metrics.find((item) => item.key === metricKey);
+                if (!metric) {
+                  return null;
+                }
+                return (
+                  <tr key={metric.key}>
+                    <th scope="row" className="metric-label">
+                      {metric.label}
+                    </th>
+                    {columnKeys.map((column) => {
+                      const value = getMetricValue(rowMap.get(column.key), metric.key);
+                      return (
+                        <td key={column.key} style={createHeatmapStyle(value, heatmapMax)}>
+                          {formatMetricValue(value)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/reallocation/psi/views/KpiView.tsx
+++ b/frontend/src/features/reallocation/psi/views/KpiView.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+
+import type { PsiRow } from "../types";
+import {
+  KPI_CARD_METRICS,
+  buildColumnGroups,
+  columnKeysFromGroups,
+  formatMetricValue,
+  makeColumnKey,
+  safeNumber,
+  sumByMetric,
+} from "../utils";
+
+const MINI_TABLE_METRICS = ["stockFinal", "gap", "gapAfter"] as const;
+
+type MiniTableMetric = (typeof MINI_TABLE_METRICS)[number];
+
+export default function KpiView({ rows }: { rows: PsiRow[] }) {
+  const totals = useMemo(() => {
+    const record = new Map<string, number>();
+    KPI_CARD_METRICS.forEach((metric) => {
+      record.set(metric.key, sumByMetric(rows, metric.key));
+    });
+    return record;
+  }, [rows]);
+
+  const columnGroups = useMemo(() => buildColumnGroups(rows), [rows]);
+  const columnKeys = useMemo(() => columnKeysFromGroups(columnGroups), [columnGroups]);
+  const rowMap = useMemo(() => {
+    const map = new Map<string, PsiRow>();
+    rows.forEach((row) => {
+      map.set(makeColumnKey(row.warehouse, row.channel), row);
+    });
+    return map;
+  }, [rows]);
+
+  if (rows.length === 0) {
+    return <p className="psi-matrix-empty">No rows match the current filters.</p>;
+  }
+
+  return (
+    <div className="psi-kpi-view">
+      <div className="psi-kpi-grid">
+        {KPI_CARD_METRICS.map((metric) => {
+          const total = totals.get(metric.key) ?? 0;
+          return (
+            <div key={metric.key} className={`psi-kpi-card ${metric.emphasize ? "emphasize" : ""}`}>
+              <span className="psi-kpi-label">{metric.label}</span>
+              <span className="psi-kpi-value">{formatMetricValue(total)}</span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="psi-kpi-table-wrapper">
+        <table className="psi-kpi-mini-table">
+          <thead>
+            <tr>
+              <th>Warehouse</th>
+              <th>Channel</th>
+              <th>Final</th>
+              <th>Gap</th>
+              <th>Gap After</th>
+            </tr>
+          </thead>
+          <tbody>
+            {columnKeys.map((column) => {
+              const row = rowMap.get(column.key);
+              const values: Record<MiniTableMetric, number> = {
+                stockFinal: safeNumber(row?.stockFinal),
+                gap: safeNumber(row?.gap),
+                gapAfter:
+                  row?.gapAfter ?? safeNumber(row?.stockFinal) - safeNumber(row?.stdStock),
+              };
+              return (
+                <tr key={column.key}>
+                  <td>{column.warehouse}</td>
+                  <td>{column.channel}</td>
+                  {MINI_TABLE_METRICS.map((metric) => {
+                    const value = values[metric];
+                    const className = value > 0 ? "value-positive" : value < 0 ? "value-negative" : "value-neutral";
+                    return (
+                      <td key={metric} className={className}>
+                        {formatMetricValue(value)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/reallocation/psi/views/OriginView.tsx
+++ b/frontend/src/features/reallocation/psi/views/OriginView.tsx
@@ -1,0 +1,56 @@
+import type { PsiRow } from "../types";
+import { formatMetricValue, safeNumber } from "../utils";
+
+interface OriginViewProps {
+  rows: PsiRow[];
+}
+
+export default function OriginView({ rows }: OriginViewProps) {
+  return (
+    <div className="table-wrapper">
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>SKU</th>
+            <th>SKU Name</th>
+            <th>Warehouse</th>
+            <th>Channel</th>
+            <th>Stock @ Start</th>
+            <th>Inbound</th>
+            <th>Outbound</th>
+            <th>Stock Closing</th>
+            <th>Std Stock</th>
+            <th>Gap</th>
+            <th>Move</th>
+            <th>Stock Final</th>
+            <th>Gap After</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const gapAfter = row.gapAfter ?? safeNumber(row.stockFinal) - safeNumber(row.stdStock);
+            return (
+              <tr key={`${row.sku}|${row.warehouse}|${row.channel}`}>
+                <td>{row.sku}</td>
+                <td>{row.skuName ?? "-"}</td>
+                <td>{row.warehouse}</td>
+                <td>{row.channel}</td>
+                <td>{formatMetricValue(row.stockStart)}</td>
+                <td>{formatMetricValue(row.inbound)}</td>
+                <td>{formatMetricValue(row.outbound)}</td>
+                <td>{formatMetricValue(row.stockClosing)}</td>
+                <td>{formatMetricValue(row.stdStock)}</td>
+                <td>{formatMetricValue(row.gap)}</td>
+                <td>{formatMetricValue(row.move)}</td>
+                <td>{formatMetricValue(row.stockFinal)}</td>
+                <td style={{ color: gapAfter < 0 ? "#c0392b" : undefined }}>
+                  {formatMetricValue(gapAfter)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -1,0 +1,324 @@
+.psi-matrix-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--surface-panel);
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.psi-matrix-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.psi-matrix-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.psi-matrix-filters label {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.psi-matrix-filters input {
+  background: var(--surface-input);
+  border: 1px solid var(--border-input);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  color: var(--text-primary);
+}
+
+.psi-matrix-filters input:focus {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 1px;
+}
+
+.psi-matrix-tablist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.psi-matrix-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+.psi-matrix-tab:hover {
+  color: var(--text-primary);
+}
+
+.psi-matrix-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent-blue);
+  font-weight: 600;
+}
+
+.psi-matrix-content {
+  margin-top: 0.5rem;
+}
+
+.psi-matrix-scroll {
+  overflow-x: auto;
+}
+
+.psi-matrix-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface-table);
+  font-size: 0.9rem;
+}
+
+.psi-matrix-table th,
+.psi-matrix-table td {
+  border: 1px solid var(--border-default);
+  padding: 0.45rem 0.6rem;
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.psi-matrix-table thead th {
+  background: var(--surface-table-header);
+  text-align: center;
+  font-weight: 600;
+}
+
+.psi-matrix-table .metric-column,
+.psi-matrix-table .metric-label {
+  text-align: left;
+}
+
+.psi-matrix-table tbody tr:nth-child(even) {
+  background: var(--surface-table-zebra);
+}
+
+.value-positive {
+  color: var(--accent-green);
+}
+
+.value-negative {
+  color: var(--accent-red);
+}
+
+.value-neutral {
+  color: var(--text-secondary);
+}
+
+.psi-matrix-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--text-secondary);
+}
+
+.psi-heatmap {
+  display: grid;
+  gap: 1rem;
+}
+
+.psi-heatmap-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.psi-heatmap-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.psi-heatmap-buttons button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-default);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.psi-heatmap-buttons button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.psi-heatmap-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.psi-heatmap-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  background: var(--surface-panel-soft);
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-default);
+}
+
+.psi-heatmap-checkbox input {
+  accent-color: var(--accent-blue);
+}
+
+.psi-heatmap-table td {
+  text-align: center;
+  transition: background-color 0.2s ease;
+}
+
+.psi-bars-chart {
+  width: 100%;
+  background: var(--surface-panel-soft);
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.psi-bars-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.psi-bar {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.psi-bar-stack {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  height: 260px;
+  border-radius: 0.75rem;
+  background: rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+}
+
+.psi-bar-segment {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0.25rem;
+  color: var(--text-on-bright);
+  text-align: center;
+}
+
+.psi-bar-segment-label {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 999px;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.75rem;
+}
+
+.psi-bar-empty {
+  margin: auto;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.psi-bar-caption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.psi-bar-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.psi-bar-final {
+  font-weight: 600;
+}
+
+.psi-kpi-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.psi-kpi-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.psi-kpi-card {
+  background: var(--surface-panel-soft);
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.psi-kpi-card.emphasize {
+  border-color: var(--accent-amber);
+  box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.35);
+}
+
+.psi-kpi-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.psi-kpi-value {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.psi-kpi-table-wrapper {
+  overflow-x: auto;
+}
+
+.psi-kpi-mini-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.psi-kpi-mini-table th,
+.psi-kpi-mini-table td {
+  border: 1px solid var(--border-default);
+  padding: 0.45rem 0.6rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.psi-kpi-mini-table th {
+  background: var(--surface-table-header);
+  text-align: center;
+}
+
+.psi-matrix-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.psi-matrix-count {
+  display: inline-flex;
+  gap: 0.35rem;
+}


### PR DESCRIPTION
## Summary
- replace the PSI matrix table with a reusable tab strip that keeps the legacy grid and adds cross-table, heatmap, bar, and KPI views
- share PSI matrix helpers for metric definitions, formatting, and column grouping across the new visualisations
- style the tabs, heatmap controls, stacked bar display, and KPI cards while keeping SKU navigation and filters unified

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddce3fb290832ea95bf5e3b22d4ae1