### PR TITLE
Update PSI matrix views and enforce integer transfer quantities

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -369,7 +369,7 @@ class TransferPlanLineBase(BaseModel):
     from_channel: str
     to_warehouse: str
     to_channel: str
-    qty: Annotated[float, Field(gt=0)]
+    qty: Annotated[int, Field(gt=0)]
     is_manual: bool
     reason: str | None = None
 

--- a/backend/app/services/transfer_logic.py
+++ b/backend/app/services/transfer_logic.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Iterable
 
 ZERO = Decimal("0")
 QUANT = Decimal("0.000001")
+MOVE_UNIT = Decimal("1")
 
 
 @dataclass(slots=True)
@@ -124,7 +125,7 @@ def recommend_plan_lines(
                 qty = min(available, shortage_remaining)
                 if qty <= ZERO:
                     continue
-                qty = qty.quantize(QUANT)
+                qty = qty.quantize(MOVE_UNIT, rounding=ROUND_HALF_UP)
                 if qty <= ZERO:
                     continue
                 recommendations.append(
@@ -160,7 +161,7 @@ def recommend_plan_lines(
                 qty = min(available, shortage_remaining)
                 if qty <= ZERO:
                     continue
-                qty = qty.quantize(QUANT)
+                qty = qty.quantize(MOVE_UNIT, rounding=ROUND_HALF_UP)
                 if qty <= ZERO:
                     continue
                 recommendations.append(

--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -12,6 +12,7 @@ import "../../../styles/psi-matrix.css";
 const TAB_CONFIG = [
   { value: "origin", label: "Origin" },
   { value: "cross", label: "Cross Table" },
+  { value: "cross2", label: "Cross Table_2" },
   { value: "heatmap", label: "Heatmap" },
   { value: "bars", label: "Bars" },
   { value: "kpis", label: "KPIs" },
@@ -43,7 +44,7 @@ export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: P
     return list;
   }, [data, skuList]);
 
-  const [activeTab, setActiveTab] = useState<TabValue>("origin");
+  const [activeTab, setActiveTab] = useState<TabValue>("cross");
   const [skuIndex, setSkuIndex] = useState(() => {
     if (!normalizedSkuList.length) {
       return 0;
@@ -140,7 +141,14 @@ export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: P
         tabContent = <OriginView rows={filteredRows} />;
         break;
       case "cross":
-        tabContent = <CrossTableView rows={filteredRows} metrics={METRIC_DEFINITIONS} />;
+        tabContent = (
+          <CrossTableView rows={filteredRows} metrics={METRIC_DEFINITIONS} orientation="warehouse-first" />
+        );
+        break;
+      case "cross2":
+        tabContent = (
+          <CrossTableView rows={filteredRows} metrics={METRIC_DEFINITIONS} orientation="channel-first" />
+        );
         break;
       case "heatmap":
         tabContent = <HeatmapView rows={filteredRows} metrics={METRIC_DEFINITIONS} />;

--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -5,10 +5,10 @@ export const METRIC_DEFINITIONS: MetricDefinition[] = [
   { key: "inbound", label: "Inbound", shortLabel: "Inbound" },
   { key: "outbound", label: "Outbound", shortLabel: "Outbound" },
   { key: "stockClosing", label: "Stock Closing", shortLabel: "Closing" },
-  { key: "stdStock", label: "Std Stock", shortLabel: "Std" },
-  { key: "gap", label: "Gap", shortLabel: "Gap" },
   { key: "move", label: "Move", shortLabel: "Move" },
   { key: "stockFinal", label: "Stock Final", shortLabel: "Final" },
+  { key: "stdStock", label: "Std Stock", shortLabel: "Std" },
+  { key: "gap", label: "Gap", shortLabel: "Gap" },
   { key: "gapAfter", label: "Gap After", shortLabel: "Gap After" },
 ];
 
@@ -63,8 +63,23 @@ export const getMetricValue = (row: PsiRow | undefined, metric: MetricKey): numb
   if (!row) {
     return null;
   }
-  const value = row[metric];
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+  switch (metric) {
+    case "gap": {
+      const stdStock = safeNumber(row.stdStock);
+      const stockClosing = safeNumber(row.stockClosing);
+      return stdStock - stockClosing;
+    }
+    case "gapAfter": {
+      const stdStock = safeNumber(row.stdStock);
+      const stockClosing = safeNumber(row.stockClosing);
+      const move = safeNumber(row.move);
+      return stdStock - stockClosing + move;
+    }
+    default: {
+      const value = row[metric];
+      return typeof value === "number" && Number.isFinite(value) ? value : null;
+    }
+  }
 };
 
 export const formatMetricValue = (value: number | null | undefined): string => {

--- a/frontend/src/features/reallocation/psi/views/KpiView.tsx
+++ b/frontend/src/features/reallocation/psi/views/KpiView.tsx
@@ -65,11 +65,12 @@ export default function KpiView({ rows }: { rows: PsiRow[] }) {
           <tbody>
             {columnKeys.map((column) => {
               const row = rowMap.get(column.key);
+              const gapValue = safeNumber(row?.gap);
+              const moveValue = safeNumber(row?.move);
               const values: Record<MiniTableMetric, number> = {
                 stockFinal: safeNumber(row?.stockFinal),
-                gap: safeNumber(row?.gap),
-                gapAfter:
-                  row?.gapAfter ?? safeNumber(row?.stockFinal) - safeNumber(row?.stdStock),
+                gap: gapValue,
+                gapAfter: row?.gapAfter ?? gapValue + moveValue,
               };
               return (
                 <tr key={column.key}>


### PR DESCRIPTION
## Summary
- default the PSI matrix to the cross table view and add a channel-first "Cross Table_2" tab
- derive gap and gap after values from Std Stock, Stock Closing, and Move while reordering the metric list
- enforce integer transfer quantities across the UI and recommendation engine

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ddd69cd3c4832e9f4250d398fe2673