### PR TITLE
Allow fractional transfer plan quantities

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -369,7 +369,7 @@ class TransferPlanLineBase(BaseModel):
     from_channel: str
     to_warehouse: str
     to_channel: str
-    qty: Annotated[int, Field(gt=0)]
+    qty: Annotated[Decimal, Field(gt=0)]
     is_manual: bool
     reason: str | None = None
 
@@ -380,7 +380,10 @@ class TransferPlanLineRead(TransferPlanLineBase):
     line_id: UUID
     plan_id: UUID
 
-    model_config = {"from_attributes": True}
+    model_config = {
+        "from_attributes": True,
+        "json_encoders": {Decimal: lambda value: float(value)},
+    }
 
 
 class TransferPlanLineWrite(TransferPlanLineBase):

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -73,7 +73,7 @@ const draftToPayload = (draft: LineDraft): TransferPlanLineWrite => ({
   from_channel: draft.from_channel.trim(),
   to_warehouse: draft.to_warehouse.trim(),
   to_channel: draft.to_channel.trim(),
-  qty: Number.parseInt(draft.qty, 10),
+  qty: Number.parseFloat(draft.qty),
   is_manual: draft.is_manual,
   reason: draft.reason.trim() ? draft.reason.trim() : null,
 });
@@ -110,8 +110,7 @@ const buildMoveMap = (lines: LineDraft[]) => {
       !toWarehouse ||
       !toChannel ||
       !Number.isFinite(qtyValue) ||
-      qtyValue <= 0 ||
-      !Number.isInteger(qtyValue)
+      qtyValue <= 0
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary
- allow transfer plan line schemas to accept decimal quantities and serialize them as floats for the API
- update the reallocation page logic to preserve fractional quantities when saving and computing move totals

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddda5403b4832ebaf09e239d2915a6