### PR TITLE
Update PSI gap calculation to use starting stock

### DIFF
--- a/backend/app/routers/psi.py
+++ b/backend/app/routers/psi.py
@@ -637,8 +637,15 @@ def daily_psi(
         stdstock_value = base_row.stdstock
         gap_value = base_row.gap
         if stdstock_value is not None:
-            if recalc_closing or gap_value is None or channel_move_raw is not None:
-                gap_value = stdstock_value - stock_closing
+            stock_start_for_gap = stock_anchor_raw if stock_anchor_raw is not None else zero
+            if (
+                gap_value is None
+                or recalc_closing
+                or recalc_flow
+                or channel_move_raw is not None
+                or gap_value != stock_start_for_gap - stdstock_value
+            ):
+                gap_value = stock_start_for_gap - stdstock_value
 
         bucket["records"].append(
             schemas.DailyPSI(

--- a/backend/tests/test_psi_api.py
+++ b/backend/tests/test_psi_api.py
@@ -419,7 +419,9 @@ def test_upload_persists_stdstock_and_gap(
     assert first_row.gap == Decimal("5")
 
 
-def test_daily_psi_computes_gap_from_stdstock(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_daily_psi_computes_gap_from_stock_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from backend.app.routers import psi as psi_router
 
     base_row_first = SimpleNamespace(
@@ -497,7 +499,7 @@ def test_daily_psi_computes_gap_from_stdstock(monkeypatch: pytest.MonkeyPatch) -
     daily = response[0].daily
     assert len(daily) == 2
     assert daily[0].stdstock == pytest.approx(110.0)
-    # Channel move triggers gap recalculation: 110 - (105 + 2) == 3
-    assert daily[0].gap == pytest.approx(3.0)
+    # Gap is calculated from the starting stock regardless of channel moves: 100 - 110 == -10
+    assert daily[0].gap == pytest.approx(-10.0)
     assert daily[1].stdstock == pytest.approx(90.0)
-    assert daily[1].gap == pytest.approx(5.0)
+    assert daily[1].gap == pytest.approx(15.0)

--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -65,15 +65,15 @@ export const getMetricValue = (row: PsiRow | undefined, metric: MetricKey): numb
   }
   switch (metric) {
     case "gap": {
+      const stockStart = safeNumber(row.stockStart);
       const stdStock = safeNumber(row.stdStock);
-      const stockClosing = safeNumber(row.stockClosing);
-      return stdStock - stockClosing;
+      return stockStart - stdStock;
     }
     case "gapAfter": {
+      const stockStart = safeNumber(row.stockStart);
       const stdStock = safeNumber(row.stdStock);
-      const stockClosing = safeNumber(row.stockClosing);
       const move = safeNumber(row.move);
-      return stdStock - stockClosing + move;
+      return stockStart + move - stdStock;
     }
     default: {
       const value = row[metric];

--- a/frontend/src/features/reallocation/psi/views/KpiView.tsx
+++ b/frontend/src/features/reallocation/psi/views/KpiView.tsx
@@ -65,12 +65,16 @@ export default function KpiView({ rows }: { rows: PsiRow[] }) {
           <tbody>
             {columnKeys.map((column) => {
               const row = rowMap.get(column.key);
-              const gapValue = safeNumber(row?.gap);
+              const stockStartValue = safeNumber(row?.stockStart);
+              const stdStockValue = safeNumber(row?.stdStock);
               const moveValue = safeNumber(row?.move);
+              const gapValue = row?.gap ?? stockStartValue - stdStockValue;
+              const gapAfterValue =
+                row?.gapAfter ?? stockStartValue + moveValue - stdStockValue;
               const values: Record<MiniTableMetric, number> = {
                 stockFinal: safeNumber(row?.stockFinal),
                 gap: gapValue,
-                gapAfter: row?.gapAfter ?? gapValue + moveValue,
+                gapAfter: gapAfterValue,
               };
               return (
                 <tr key={column.key}>

--- a/frontend/src/features/reallocation/psi/views/OriginView.tsx
+++ b/frontend/src/features/reallocation/psi/views/OriginView.tsx
@@ -28,7 +28,10 @@ export default function OriginView({ rows }: OriginViewProps) {
         </thead>
         <tbody>
           {rows.map((row) => {
-            const gapAfter = row.gapAfter ?? safeNumber(row.stockFinal) - safeNumber(row.stdStock);
+            const stockStartValue = safeNumber(row.stockStart);
+            const moveValue = safeNumber(row.move);
+            const stdStockValue = safeNumber(row.stdStock);
+            const gapAfter = row.gapAfter ?? stockStartValue + moveValue - stdStockValue;
             return (
               <tr key={`${row.sku}|${row.warehouse}|${row.channel}`}>
                 <td>{row.sku}</td>

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -597,8 +597,11 @@ export default function ReallocationPage() {
   const psiRows = useMemo(
     () =>
       simulatedMatrixRows.map((row) => {
-        const gap = row.stdstock - row.stock_closing;
-        const gapAfter = gap + row.move;
+        const stockStart = row.stock_at_anchor ?? 0;
+        const stdStock = row.stdstock ?? 0;
+        const move = row.move ?? 0;
+        const gap = stockStart - stdStock;
+        const gapAfter = stockStart + move - stdStock;
         return {
           sku: row.sku_code,
           skuName: row.sku_name ?? undefined,


### PR DESCRIPTION
## Summary
- compute daily PSI gaps from starting stock when serving data
- align frontend PSI matrix gap and gap-after calculations with the new definition
- update the unit test covering the gap computation

## Testing
- pytest backend/tests/test_psi_api.py::test_daily_psi_computes_gap_from_stock_start

------
https://chatgpt.com/codex/tasks/task_e_68ddddd12f20832e99a4e7d7537bc6c7