### PR TITLE
docs: add reallocation logic overview

### DIFF
--- a/docs/9_在庫再配置ロジック.md
+++ b/docs/9_在庫再配置ロジック.md
@@ -1,0 +1,45 @@
+# 9.在庫再配置ロジック整理
+
+## 全体像
+- 「再配置（Reallocation）」ページでは、PSI 行列を期間・セッション単位で読み込み、倉庫間／チャネル間の在庫移動計画（Transfer Plan）を作成・編集します。【F:frontend/src/pages/ReallocationPage.tsx†L134-L349】
+- PSI 行列と移動計画は、選択中のセッション・日付範囲・計画IDをクエリキーに持つ React Query で取得し、フィルタ適用や行編集のたびに再計算されます。【F:frontend/src/hooks/useTransferPlans.ts†L25-L73】【F:frontend/src/pages/ReallocationPage.tsx†L191-L344】
+- 計画保存時は API が全行差し替えを行い、保存後は最新データを再取得して UI とサーバー状態の乖離を防ぎます。【F:backend/app/routers/transfer_plans.py†L200-L282】【F:frontend/src/pages/ReallocationPage.tsx†L320-L347】
+
+## PSI 行列データの取得と加工
+1. `/api/psi/matrix` は `MatrixQueryArgs`（セッションID・開始日・終了日・任意の計画ID/SKU配列）を URL パラメータ化して呼び出します。【F:frontend/src/hooks/useTransferPlans.ts†L17-L74】
+2. バックエンドでは指定期間の `psi_base` を SKU×倉庫×チャネルで集計し、移動計画IDが指定された場合は計画行の入出庫差分をマージした上で move 列を返します。【F:backend/app/services/transfer_plans.py†L22-L199】
+3. フロントエンドは取得した行を SKU で絞り込み、倉庫・チャネルフィルタを適用した上で表・ヒートマップなど複数ビューに渡します。【F:frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx†L20-L119】
+4. 計画行のドラフトがある場合は、ベース行＋保存済み移動＋ドラフト差分を合成して、シミュレート後の在庫 (`stock_fin`) を即時に可視化します。【F:frontend/src/pages/ReallocationPage.tsx†L462-L517】
+
+## 推奨計画（Recommendation）の生成
+1. ユーザーが「Create recommendation」を押すと、セッションIDと期間（+任意SKU）を `POST /api/transfer-plans/recommend` に送信します。【F:frontend/src/pages/ReallocationPage.tsx†L221-L245】【F:frontend/src/hooks/useTransferPlans.ts†L76-L103】
+2. API は対象セッションの PSI 行列を再集計し、該当倉庫のメインチャネル情報を取得します。【F:backend/app/routers/transfer_plans.py†L132-L159】【F:backend/app/services/transfer_plans.py†L202-L214】
+3. 推奨ロジックは SKU ごとにセル状態を構築し、
+   - メインチャネルの不足量を抽出
+   - 同一倉庫内の余剰から充当（intra）
+   - それでも不足が残れば他倉庫の余剰から充当（inter）
+   - 充当量は在庫残・余剰残を考慮し 1 個単位で四捨五入
+   という優先順位で移動候補を作成します。【F:backend/app/services/transfer_logic.py†L44-L181】
+4. 生成された行は `TransferPlan` として DB に保存され、レスポンスで計画ヘッダー＋行一覧が返却されます。【F:backend/app/routers/transfer_plans.py†L145-L197】
+5. フロントエンドはレスポンスをドラフト行に変換し、計画IDとフィルタを更新して一覧・マトリクスを再取得します。【F:frontend/src/pages/ReallocationPage.tsx†L233-L345】
+
+## 手動編集とバリデーション
+- 行の追加・編集は `LineDraft` を更新し、SKU/倉庫/チャネル/数量のいずれかが変わると即座にドラフト配列が再計算されます。【F:frontend/src/pages/ReallocationPage.tsx†L254-L336】
+- 保存前バリデーションでは以下を満たさない行があると即エラー表示し API 呼び出しを中止します。
+  - SKU・移動元/先の倉庫とチャネルがすべて入力済み
+  - 数量が正の整数
+  - `from` と `to` が同一組合せでない（API 側でも検証）【F:frontend/src/pages/ReallocationPage.tsx†L292-L347】【F:backend/app/routers/transfer_plans.py†L217-L255】
+- API はさらに、`line_id` 重複や `plan_id` 不一致、在庫起点数量を超える放出要求を検証します。不足があれば 422 エラーで詳細メッセージを返します。【F:backend/app/routers/transfer_plans.py†L214-L253】
+
+## 計画の読み込みと一覧管理
+- セッション・期間に紐づく計画は `/api/transfer-plans` で取得し、作成日時の降順で並べ替えてプルダウンに表示します。【F:frontend/src/pages/ReallocationPage.tsx†L403-L447】【F:backend/app/routers/transfer_plans.py†L30-L77】
+- 初期表示では最新計画を自動選択し、同時にサイレントロードを実行してドラフト状態を復元します。【F:frontend/src/pages/ReallocationPage.tsx†L419-L433】
+- 計画ID変更・削除などで選択肢から外れた場合は、自動で選択を解除し不整合を防ぎます。【F:frontend/src/pages/ReallocationPage.tsx†L453-L460】
+
+## PSI 行列ビュー（PSIMatrixTabs）
+- SKU ナビゲーションと倉庫・チャネルの部分一致フィルタを提供し、タブ切替で元データ表／クロステーブル／ヒートマップ／棒グラフ／KPI カードを表示します。【F:frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx†L20-L120】
+- 表示中の行数と `stockFinal` 合計をフッターで確認でき、ドラフト移動の影響を即座に把握できます。【F:frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx†L169-L207】
+
+## 今後の見直しポイント
+- 推奨アルゴリズムはメインチャネル不足を最優先で解消しますが、倉庫間コストやリードタイムは考慮していません。必要に応じて重み付け戦略を追加する余地があります。【F:backend/app/services/transfer_logic.py†L106-L179】
+- PSI 行列の集計は指定期間内すべての行を再集計するため、対象 SKU が多い場合はレスポンスが重くなる恐れがあります。SKU/倉庫/チャネルのフィルタリング強化やキャッシュ導入の検討価値があります。【F:backend/app/services/transfer_plans.py†L50-L199】


### PR DESCRIPTION
## Summary
- document the current PSI reallocation data flow and recommendation logic
- capture validation, API interaction, and UI behaviour for transfer plans

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dddf4697b8832ea216ac55f2452a88