### PR TITLE
Improve PSI matrix SKU navigation and add search

### DIFF
--- a/frontend/src/features/reallocation/psi/types.ts
+++ b/frontend/src/features/reallocation/psi/types.ts
@@ -17,6 +17,9 @@ export interface PsiRowBase {
   skuName?: string;
   warehouse: string;
   channel: string;
+  category_1?: string | null;
+  category_2?: string | null;
+  category_3?: string | null;
 }
 
 export type PsiRow = PsiRowBase & PsiRowMetrics;

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -500,11 +500,17 @@ export default function ReallocationPage() {
       const stdstock = baseRow?.stdstock ?? 0;
       const gap = stdstock - stock_closing;
       const sku_name = baseRow?.sku_name ?? skuNameMap.get(sku_code) ?? null;
+      const category_1 = baseRow?.category_1 ?? null;
+      const category_2 = baseRow?.category_2 ?? null;
+      const category_3 = baseRow?.category_3 ?? null;
       result.push({
         sku_code,
         sku_name,
         warehouse_name,
         channel,
+        category_1,
+        category_2,
+        category_3,
         stock_at_anchor,
         inbound_qty,
         outbound_qty,
@@ -607,6 +613,9 @@ export default function ReallocationPage() {
           skuName: row.sku_name ?? undefined,
           warehouse: row.warehouse_name,
           channel: row.channel,
+          category_1: row.category_1 ?? null,
+          category_2: row.category_2 ?? null,
+          category_3: row.category_3 ?? null,
           stockStart: row.stock_at_anchor,
           inbound: row.inbound_qty,
           outbound: row.outbound_qty,

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -10,10 +10,76 @@
 
 .psi-matrix-toolbar {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 1rem;
+}
+
+.sku-navigation {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.sku-navigation-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.sku-navigation-title {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+}
+
+.sku-navigation-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.sku-navigation-categories {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.sku-navigation-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.sku-navigation-actions button {
+  background: var(--surface-input);
+  border: 1px solid var(--border-input);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.sku-navigation-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sku-navigation-search {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.sku-navigation-search input {
+  background: var(--surface-input);
+  border: 1px solid var(--border-input);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  color: var(--text-primary);
+}
+
+.sku-navigation-search input:focus {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 1px;
 }
 
 .psi-matrix-filters {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,6 +115,9 @@ export interface MatrixRow {
   sku_name?: string | null;
   warehouse_name: string;
   channel: string;
+  category_1?: string | null;
+  category_2?: string | null;
+  category_3?: string | null;
   stock_at_anchor: number;
   inbound_qty: number;
   outbound_qty: number;


### PR DESCRIPTION
## Summary
- extend PSI matrix SKU navigation to show category hierarchy beneath the SKU name and keep navigation buttons in a fixed row
- replace the warehouse/channel filters with a SKU search box and enable fuzzy matching by code or name when browsing matrix data
- propagate SKU category data through the matrix rows and update styles to support the new layout

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dde5581714832e8a299a55aad24cfe