### PR TITLE
Update Test_Algo tooling for integer workflow

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2640,6 +2640,48 @@ button.danger:hover {
   align-items: center;
 }
 
+.test-algo-page .report-buttons {
+  gap: 1rem;
+}
+
+.test-algo-page .control-buttons button {
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.test-algo-page .btn-reset {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.test-algo-page .btn-reset:hover:not(:disabled) {
+  background: #fecaca;
+}
+
+.test-algo-page .btn-run {
+  background: #dbeafe;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+}
+
+.test-algo-page .btn-run:hover:not(:disabled) {
+  background: #bfdbfe;
+}
+
+.test-algo-page .btn-batch {
+  background: #dcfce7;
+  border-color: #bbf7d0;
+  color: #15803d;
+}
+
+.test-algo-page .btn-batch:hover:not(:disabled) {
+  background: #bbf7d0;
+}
+
 .test-algo-page .status-text {
   margin-top: 0.75rem;
   color: var(--text-secondary, var(--text-primary));
@@ -2673,13 +2715,13 @@ button.danger:hover {
   padding: 0.25rem 0.5rem;
 }
 
-.editable-cell.selected {
-  background: rgba(59, 130, 246, 0.15);
+.editable-cell input[type="number"]::-webkit-outer-spin-button,
+.editable-cell input[type="number"]::-webkit-inner-spin-button {
+  margin: 0;
 }
 
-.editable-cell .swap-button {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
+.editable-cell input[type="number"] {
+  -moz-appearance: textfield;
 }
 
 .report-section textarea {


### PR DESCRIPTION
## Summary
- regenerate Test_Algo seed data with configurable warehouse counts and integer-only metrics
- apply recommended transfer quantities back into the PSI matrix move column and streamline editing UI
- restyle action buttons, add a batch execution control, and update markdown/report outputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de69a70d78832e87c4f816ddc45ff1