### PR TITLE
Add totals to PSI tables and expand Test_Algo report

### DIFF
--- a/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
+++ b/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
@@ -8,6 +8,7 @@ import {
   formatMetricValue,
   getMetricValue,
   makeColumnKey,
+  safeNumber,
 } from "../utils";
 
 interface HeatmapViewProps {
@@ -119,6 +120,9 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
                     {group.warehouse}
                   </th>
                 ))}
+                <th rowSpan={2} className="total-column">
+                  Total
+                </th>
               </tr>
               <tr>
                 {columnGroups.flatMap((group) =>
@@ -149,6 +153,14 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
                         </td>
                       );
                     })}
+                    <td className="total-cell">
+                      {formatMetricValue(
+                        columnKeys.reduce((sum, column) => {
+                          const value = getMetricValue(rowMap.get(column.key), metric.key);
+                          return sum + safeNumber(value);
+                        }, 0),
+                      )}
+                    </td>
                   </tr>
                 );
               })}

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -207,6 +207,17 @@
   text-align: left;
 }
 
+.psi-matrix-table .total-column {
+  background: var(--surface-table-header-highlight, var(--surface-table-header));
+  font-weight: 700;
+  text-align: right;
+}
+
+.psi-matrix-table .total-cell {
+  font-weight: 600;
+  background: var(--surface-table-total, rgba(59, 130, 246, 0.08));
+}
+
 .psi-matrix-table tbody tr:nth-child(even) {
   background: var(--surface-table-zebra);
 }


### PR DESCRIPTION
## Summary
- add total columns to PSI cross tables and heatmap views
- surface total metrics on the Test_Algo PSI matrix and include a Crosstable section in the generated report
- style the new total columns for visual emphasis

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68de7014e1b4832e8b5df285b0b96b33