### PR TITLE
Add reallocation policy management

### DIFF
--- a/backend/alembic/versions/0012_create_reallocation_policy.py
+++ b/backend/alembic/versions/0012_create_reallocation_policy.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.config import settings
+
+revision: str = "0012"
+down_revision: Union[str, Sequence[str], None] = "0011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = (settings.db_schema or "").strip() or None
+TABLE_NAME = "reallocation_policy"
+ROUNDING_CHECK = "ck_reallocation_policy_rounding_mode"
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("take_from_other_main", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("rounding_mode", sa.Text(), nullable=False, server_default=sa.text("'floor'")),
+        sa.Column("allow_overfill", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+        schema=SCHEMA,
+    )
+    op.create_check_constraint(
+        ROUNDING_CHECK,
+        TABLE_NAME,
+        "rounding_mode IN ('floor','round','ceil')",
+        schema=SCHEMA,
+    )
+    insert = sa.text(
+        "INSERT INTO {table} (id) SELECT 1 WHERE NOT EXISTS ("
+        "SELECT 1 FROM {table} WHERE id = 1)".format(
+            table=f"{SCHEMA + '.' if SCHEMA else ''}{TABLE_NAME}"
+        )
+    )
+    op.execute(insert)
+
+
+def downgrade() -> None:
+    op.drop_constraint(ROUNDING_CHECK, TABLE_NAME, type_="check", schema=SCHEMA)
+    op.drop_table(TABLE_NAME, schema=SCHEMA)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from .routers import (
     psi,
     psi_edits,
     psi_metrics,
+    reallocation_policy,
     sessions,
     test_algo,
     transfer_plans,
@@ -82,6 +83,11 @@ app.include_router(
     prefix="/transfer-plans",
     tags=["transfer-plans"],
 )
+app.include_router(
+    reallocation_policy.router,
+    prefix="/reallocation-policy",
+    tags=["reallocation-policy"],
+)
 app.include_router(warehouses.router, prefix="/warehouses", tags=["warehouses"])
 app.include_router(users.router, prefix="/users", tags=["users"])
 app.include_router(test_algo.router, prefix="/test-algo", tags=["test-algo"])
@@ -109,6 +115,11 @@ app.include_router(
     transfer_plans.router,
     prefix="/api/transfer-plans",
     tags=["transfer-plans"],
+)
+app.include_router(
+    reallocation_policy.router,
+    prefix="/api/reallocation-policy",
+    tags=["reallocation-policy"],
 )
 app.include_router(warehouses.router, prefix="/api/warehouses", tags=["warehouses"])
 app.include_router(users.router, prefix="/api/users", tags=["users"])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -207,6 +207,27 @@ class WarehouseMaster(Base, SchemaMixin):
     )
 
 
+class ReallocationPolicy(Base, SchemaMixin):
+    """Global configuration controlling the reallocation algorithm."""
+
+    __tablename__ = "reallocation_policy"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    take_from_other_main: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    rounding_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'floor'")
+    )
+    allow_overfill: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    updated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 class CategoryRankParameter(Base, SchemaMixin):
     """Threshold configuration used to derive rank classifications per category."""
 

--- a/backend/app/routers/reallocation_policy.py
+++ b/backend/app/routers/reallocation_policy.py
@@ -1,0 +1,63 @@
+"""Endpoints exposing the global reallocation policy."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session as DBSession
+
+from .. import models, schemas
+from ..deps import get_admin_user, get_current_user, get_db
+from ..services.reallocation_policy import (
+    get_reallocation_policy,
+    update_reallocation_policy,
+)
+
+router = APIRouter()
+
+
+def _normalize_updated_by(value: str | None, fallback: str | None) -> str | None:
+    if value is None:
+        return fallback
+    trimmed = value.strip()
+    if not trimmed:
+        return fallback
+    return trimmed
+
+
+@router.get("", response_model=schemas.ReallocationPolicyRead)
+@router.get("/", response_model=schemas.ReallocationPolicyRead)
+def read_reallocation_policy(
+    db: DBSession = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+) -> schemas.ReallocationPolicyRead:
+    policy = get_reallocation_policy(db)
+    return schemas.ReallocationPolicyRead(
+        take_from_other_main=policy.take_from_other_main,
+        rounding_mode=policy.rounding_mode,
+        allow_overfill=policy.allow_overfill,
+        updated_at=policy.updated_at,
+        updated_by=policy.updated_by,
+    )
+
+
+@router.put("", response_model=schemas.ReallocationPolicyRead)
+@router.put("/", response_model=schemas.ReallocationPolicyRead)
+def update_policy(
+    payload: schemas.ReallocationPolicyWrite,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_admin_user),
+) -> schemas.ReallocationPolicyRead:
+    updated_by = _normalize_updated_by(payload.updated_by, current_user.username)
+    policy = update_reallocation_policy(
+        db,
+        take_from_other_main=payload.take_from_other_main,
+        rounding_mode=payload.rounding_mode,
+        allow_overfill=payload.allow_overfill,
+        updated_by=updated_by,
+    )
+    return schemas.ReallocationPolicyRead(
+        take_from_other_main=policy.take_from_other_main,
+        rounding_mode=policy.rounding_mode,
+        allow_overfill=policy.allow_overfill,
+        updated_at=policy.updated_at,
+        updated_by=policy.updated_by,
+    )

--- a/backend/app/routers/test_algo.py
+++ b/backend/app/routers/test_algo.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session as DBSession
 
 from .. import models
 from ..deps import get_db
+from ..services.reallocation_policy import get_reallocation_policy
 from ..services.transfer_logic import MatrixRowData, recommend_plan_lines
 from ..services.transfer_plans import fetch_main_channel_map
 
@@ -160,7 +161,12 @@ def run_test_algo(payload: TestAlgoRunRequest, db: DBSession = Depends(get_db)) 
 
     warehouse_names = {row.warehouse_name for row in prepared_rows}
     warehouse_main_channels = fetch_main_channel_map(db, warehouses=warehouse_names)
-    recommended = recommend_plan_lines(matrix_rows, warehouse_main_channels=warehouse_main_channels)
+    policy = get_reallocation_policy(db)
+    recommended = recommend_plan_lines(
+        matrix_rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=policy,
+    )
 
     return TestAlgoRunResponse(
         matrix_rows=[

--- a/backend/app/routers/transfer_plans.py
+++ b/backend/app/routers/transfer_plans.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session as DBSession
 
 from .. import models, schemas
 from ..deps import get_current_user, get_db
+from ..services.reallocation_policy import get_reallocation_policy
 from ..services.transfer_logic import QUANT, recommend_plan_lines
 from ..services.transfer_plans import fetch_main_channel_map, fetch_matrix_rows
 
@@ -141,6 +142,7 @@ def create_recommended_plan(
 
     warehouses: set[str] = {row.warehouse_name for row in matrix_rows}
     warehouse_main_channels = fetch_main_channel_map(db, warehouses=warehouses)
+    policy = get_reallocation_policy(db)
 
     plan = models.TransferPlan(
         session_id=session.id,
@@ -156,6 +158,7 @@ def create_recommended_plan(
     recommended_moves = recommend_plan_lines(
         matrix_rows,
         warehouse_main_channels=warehouse_main_channels,
+        policy=policy,
     )
 
     for move in recommended_moves:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -467,3 +467,24 @@ class UserCreateResult(BaseModel):
     is_active: bool
     is_admin: bool
     created_at: datetime
+
+
+class ReallocationPolicyBase(BaseModel):
+    """Shared fields for the reallocation policy."""
+
+    take_from_other_main: bool
+    rounding_mode: Literal["floor", "round", "ceil"]
+    allow_overfill: bool
+
+
+class ReallocationPolicyWrite(ReallocationPolicyBase):
+    """Payload used to update the reallocation policy."""
+
+    updated_by: str | None = None
+
+
+class ReallocationPolicyRead(ReallocationPolicyBase):
+    """Reallocation policy returned by the API."""
+
+    updated_at: datetime | None = None
+    updated_by: str | None = None

--- a/backend/app/services/reallocation_policy.py
+++ b/backend/app/services/reallocation_policy.py
@@ -1,0 +1,84 @@
+"""Helpers for fetching and updating the reallocation policy."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as DBSession
+
+from .. import models
+
+PolicyRoundingMode = Literal["floor", "round", "ceil"]
+
+
+@dataclass(slots=True)
+class ReallocationPolicyData:
+    """Representation of the persisted reallocation policy."""
+
+    take_from_other_main: bool
+    rounding_mode: PolicyRoundingMode
+    allow_overfill: bool
+    updated_at: datetime | None
+    updated_by: str | None
+
+
+def _record_to_data(record: models.ReallocationPolicy) -> ReallocationPolicyData:
+    return ReallocationPolicyData(
+        take_from_other_main=bool(record.take_from_other_main),
+        rounding_mode=cast(PolicyRoundingMode, record.rounding_mode),
+        allow_overfill=bool(record.allow_overfill),
+        updated_at=record.updated_at,
+        updated_by=record.updated_by,
+    )
+
+
+def _ensure_policy_record(db: DBSession) -> models.ReallocationPolicy:
+    policy = db.execute(
+        select(models.ReallocationPolicy).order_by(models.ReallocationPolicy.id).limit(1)
+    ).scalar_one_or_none()
+    if policy is not None:
+        return policy
+
+    policy = models.ReallocationPolicy(id=1)
+    db.add(policy)
+    db.commit()
+    db.refresh(policy)
+    return policy
+
+
+def get_reallocation_policy(db: DBSession) -> ReallocationPolicyData:
+    """Return the current reallocation policy creating it if missing."""
+
+    policy = _ensure_policy_record(db)
+    return _record_to_data(policy)
+
+
+def update_reallocation_policy(
+    db: DBSession,
+    *,
+    take_from_other_main: bool,
+    rounding_mode: PolicyRoundingMode,
+    allow_overfill: bool,
+    updated_by: str | None,
+) -> ReallocationPolicyData:
+    """Persist the reallocation policy and return the updated snapshot."""
+
+    policy = _ensure_policy_record(db)
+    policy.take_from_other_main = take_from_other_main
+    policy.rounding_mode = rounding_mode
+    policy.allow_overfill = allow_overfill
+    policy.updated_by = updated_by
+    db.add(policy)
+    db.commit()
+    db.refresh(policy)
+    return _record_to_data(policy)
+
+
+__all__ = [
+    "PolicyRoundingMode",
+    "ReallocationPolicyData",
+    "get_reallocation_policy",
+    "update_reallocation_policy",
+]

--- a/backend/app/services/transfer_logic.py
+++ b/backend/app/services/transfer_logic.py
@@ -1,13 +1,19 @@
 """Core algorithms supporting transfer plan recommendations."""
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_UP
 from typing import Iterable
+
+from .reallocation_policy import PolicyRoundingMode, ReallocationPolicyData
 
 ZERO = Decimal("0")
 QUANT = Decimal("0.000001")
 MOVE_UNIT = Decimal("1")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -46,17 +52,28 @@ class _CellState:
         "stock_at_anchor",
         "stdstock",
         "gap",
+        "stock_closing",
         "surplus_remaining",
         "allocated_out",
+        "allocated_in",
     )
 
-    def __init__(self, *, stock_at_anchor: Decimal, stdstock: Decimal, gap: Decimal) -> None:
+    def __init__(
+        self,
+        *,
+        stock_at_anchor: Decimal,
+        stdstock: Decimal,
+        gap: Decimal,
+        stock_closing: Decimal,
+    ) -> None:
         self.stock_at_anchor = stock_at_anchor
         self.stdstock = stdstock
         self.gap = gap
+        self.stock_closing = stock_closing
         surplus = gap if gap > ZERO else ZERO
         self.surplus_remaining = surplus
         self.allocated_out = ZERO
+        self.allocated_in = ZERO
 
     def available_surplus(self) -> Decimal:
         stock_remaining = self.stock_at_anchor - self.allocated_out
@@ -71,11 +88,36 @@ class _CellState:
         remaining = self.surplus_remaining - qty
         self.surplus_remaining = remaining if remaining > ZERO else ZERO
 
+    def receive(self, qty: Decimal) -> None:
+        self.allocated_in += qty
+
+    def remaining_capacity(self) -> Decimal:
+        capacity = self.stdstock - (self.stock_closing + self.allocated_in)
+        return capacity if capacity > ZERO else ZERO
+
+
+def _round_quantity(qty: Decimal, mode: PolicyRoundingMode) -> Decimal:
+    if qty <= ZERO:
+        return ZERO
+    if mode == "floor":
+        return qty.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+    if mode == "ceil":
+        return qty.quantize(MOVE_UNIT, rounding=ROUND_CEILING)
+    return qty.quantize(MOVE_UNIT, rounding=ROUND_HALF_UP)
+
+
+_BUCKET_REASON = {
+    "intra_nonmain": "fill main channel (intra)",
+    "inter_nonmain": "fill main channel (inter non-main)",
+    "inter_main": "fill main channel (inter main)",
+}
+
 
 def recommend_plan_lines(
     matrix_rows: Iterable[MatrixRowData],
     *,
     warehouse_main_channels: dict[str, str],
+    policy: ReallocationPolicyData,
 ) -> list[RecommendedMove]:
     """Create recommended transfer moves based on aggregated gaps."""
 
@@ -87,24 +129,31 @@ def recommend_plan_lines(
             stock_at_anchor=row.stock_at_anchor if row.stock_at_anchor > ZERO else ZERO,
             stdstock=row.stdstock if row.stdstock > ZERO else ZERO,
             gap=row.gap,
+            stock_closing=row.stock_closing if row.stock_closing > ZERO else ZERO,
         )
 
     recommendations: list[RecommendedMove] = []
 
     for sku_code, cells in rows_by_sku.items():
-        shortages: list[tuple[str, str, Decimal]] = []
+        shortages: list[tuple[str, str, Decimal, _CellState]] = []
         for warehouse, main_channel in warehouse_main_channels.items():
             cell = cells.get((warehouse, main_channel))
             if cell is None:
                 continue
             shortage = ZERO - cell.gap if cell.gap < ZERO else ZERO
             if shortage > ZERO:
-                shortages.append((warehouse, main_channel, shortage))
+                shortages.append((warehouse, main_channel, shortage, cell))
 
         shortages.sort(key=lambda item: item[2], reverse=True)
 
-        for warehouse, main_channel, shortage in shortages:
+        for warehouse, main_channel, shortage, receiver_state in shortages:
             shortage_remaining = shortage
+            bucket_attempts = {
+                "intra_nonmain": 0,
+                "inter_nonmain": 0,
+                "inter_main": 0,
+            }
+            blocked_reasons: set[str] = set()
 
             # Intra-warehouse fulfilment
             donors_intra: list[tuple[tuple[str, str], _CellState]] = [
@@ -116,35 +165,6 @@ def recommend_plan_lines(
             ]
             donors_intra.sort(key=lambda item: item[1].available_surplus(), reverse=True)
 
-            for (from_warehouse, from_channel), donor_state in donors_intra:
-                if shortage_remaining <= ZERO:
-                    break
-                available = donor_state.available_surplus()
-                if available <= ZERO:
-                    continue
-                qty = min(available, shortage_remaining)
-                if qty <= ZERO:
-                    continue
-                qty = qty.quantize(MOVE_UNIT, rounding=ROUND_HALF_UP)
-                if qty <= ZERO:
-                    continue
-                recommendations.append(
-                    RecommendedMove(
-                        sku_code=sku_code,
-                        from_warehouse=from_warehouse,
-                        from_channel=from_channel,
-                        to_warehouse=warehouse,
-                        to_channel=main_channel,
-                        qty=qty,
-                        reason="fill main channel (intra)",
-                    )
-                )
-                donor_state.allocate(qty)
-                shortage_remaining -= qty
-
-            if shortage_remaining <= ZERO:
-                continue
-
             donors_inter: list[tuple[tuple[str, str], _CellState]] = [
                 (key, state)
                 for key, state in cells.items()
@@ -152,31 +172,126 @@ def recommend_plan_lines(
             ]
             donors_inter.sort(key=lambda item: item[1].available_surplus(), reverse=True)
 
-            for (from_warehouse, from_channel), donor_state in donors_inter:
-                if shortage_remaining <= ZERO:
-                    break
-                available = donor_state.available_surplus()
-                if available <= ZERO:
-                    continue
-                qty = min(available, shortage_remaining)
-                if qty <= ZERO:
-                    continue
-                qty = qty.quantize(MOVE_UNIT, rounding=ROUND_HALF_UP)
-                if qty <= ZERO:
-                    continue
-                recommendations.append(
-                    RecommendedMove(
-                        sku_code=sku_code,
-                        from_warehouse=from_warehouse,
-                        from_channel=from_channel,
-                        to_warehouse=warehouse,
-                        to_channel=main_channel,
-                        qty=qty,
-                        reason="fill main channel (inter)",
+            donors_inter_nonmain: list[tuple[tuple[str, str], _CellState]] = []
+            donors_inter_main: list[tuple[tuple[str, str], _CellState]] = []
+            for donor in donors_inter:
+                donor_warehouse, donor_channel = donor[0]
+                if warehouse_main_channels.get(donor_warehouse) == donor_channel:
+                    donors_inter_main.append(donor)
+                else:
+                    donors_inter_nonmain.append(donor)
+
+            def allocate_from_bucket(
+                donors: list[tuple[tuple[str, str], _CellState]],
+                bucket: str,
+            ) -> bool:
+                nonlocal shortage_remaining
+                for (from_warehouse, from_channel), donor_state in donors:
+                    if shortage_remaining <= ZERO:
+                        break
+                    bucket_attempts[bucket] += 1
+                    available = donor_state.available_surplus()
+                    if available <= ZERO:
+                        continue
+                    receiver_room = None
+                    if not policy.allow_overfill:
+                        receiver_room = receiver_state.remaining_capacity()
+                        if receiver_room <= ZERO:
+                            blocked_reasons.add("overfill")
+                            return False
+                    raw_qty = min(available, shortage_remaining)
+                    if receiver_room is not None:
+                        raw_qty = min(raw_qty, receiver_room)
+                    if raw_qty <= ZERO:
+                        continue
+                    qty = _round_quantity(raw_qty, policy.rounding_mode)
+                    if qty <= ZERO:
+                        blocked_reasons.add("rounding_zero")
+                        continue
+                    max_allowed = raw_qty.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+                    if receiver_room is not None:
+                        max_allowed = min(
+                            max_allowed,
+                            receiver_room.quantize(MOVE_UNIT, rounding=ROUND_FLOOR),
+                        )
+                    max_allowed = min(
+                        max_allowed,
+                        available.quantize(MOVE_UNIT, rounding=ROUND_FLOOR),
+                        shortage_remaining.quantize(MOVE_UNIT, rounding=ROUND_FLOOR),
                     )
+                    if max_allowed <= ZERO:
+                        blocked_reasons.add("rounding_zero")
+                        continue
+                    if qty > max_allowed:
+                        qty = max_allowed
+                    if qty <= ZERO:
+                        blocked_reasons.add("rounding_zero")
+                        continue
+
+                    donor_state.allocate(qty)
+                    receiver_state.receive(qty)
+                    shortage_remaining -= qty
+                    move_reason = _BUCKET_REASON[bucket]
+                    recommendations.append(
+                        RecommendedMove(
+                            sku_code=sku_code,
+                            from_warehouse=from_warehouse,
+                            from_channel=from_channel,
+                            to_warehouse=warehouse,
+                            to_channel=main_channel,
+                            qty=qty,
+                            reason=move_reason,
+                        )
+                    )
+                    logger.info(
+                        "MOVE_DECISION %s",
+                        json.dumps(
+                            {
+                                "sku": sku_code,
+                                "from": {
+                                    "warehouse": from_warehouse,
+                                    "channel": from_channel,
+                                },
+                                "to": {"warehouse": warehouse, "channel": main_channel},
+                                "qty": str(qty),
+                                "reason": bucket,
+                            },
+                        ),
+                    )
+                return True
+
+            if not allocate_from_bucket(donors_intra, "intra_nonmain"):
+                continue
+
+            if shortage_remaining <= ZERO:
+                continue
+
+            if not allocate_from_bucket(donors_inter_nonmain, "inter_nonmain"):
+                continue
+
+            if shortage_remaining <= ZERO:
+                continue
+
+            if policy.take_from_other_main:
+                allocate_from_bucket(donors_inter_main, "inter_main")
+
+            if shortage_remaining > ZERO:
+                if sum(bucket_attempts.values()) == 0:
+                    blocked_reasons.add("no_donor")
+                deficit_after = shortage_remaining if shortage_remaining > ZERO else ZERO
+                logger.info(
+                    "WHY_NOT_FILLED %s",
+                    json.dumps(
+                        {
+                            "sku": sku_code,
+                            "target": {"warehouse": warehouse, "channel": main_channel},
+                            "deficit_before": str(shortage),
+                            "deficit_after": str(deficit_after),
+                            "tried": bucket_attempts,
+                            "blocked": sorted(blocked_reasons) if blocked_reasons else [],
+                        },
+                    ),
                 )
-                donor_state.allocate(qty)
-                shortage_remaining -= qty
 
     return recommendations
 

--- a/backend/tests/test_reallocation_policy_api.py
+++ b/backend/tests/test_reallocation_policy_api.py
@@ -1,0 +1,179 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _perform_json_request(app, method: str, path: str, payload: dict | None = None):
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "scheme": "http",
+        "headers": [(b"content-type", b"application/json")] if payload else [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+
+    messages: list[dict[str, object]] = []
+    received = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        body = json.dumps(payload).encode("utf-8") if payload else b""
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    asyncio.run(app(scope, receive, send))
+
+    start = next(msg for msg in messages if msg["type"] == "http.response.start")
+    body = b"".join(
+        part.get("body", b"") for part in messages if part["type"] == "http.response.body"
+    )
+    payload = None
+    if body:
+        payload = json.loads(body.decode("utf-8"))
+    return start["status"], payload
+
+
+def _create_user(env: SimpleNamespace, *, is_admin: bool, username: str) -> SimpleNamespace:
+    with env.SessionLocal() as session:
+        user = env.models.User(
+            username=username,
+            password_hash="x",
+            is_active=True,
+            is_admin=is_admin,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return SimpleNamespace(id=user.id, username=user.username, is_admin=user.is_admin)
+
+
+@pytest.fixture(scope="module")
+def app_env(tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
+    db_path = tmp_path_factory.mktemp("policy") / "policy.sqlite"
+    os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+    os.environ["DB_SCHEMA"] = ""
+    os.environ.setdefault("SESSION_SIGN_KEY", "sign")
+    os.environ.setdefault("SECRET_KEY", "secret")
+    os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:5173")
+    os.environ.setdefault("CSRF_ENABLED", "false")
+
+    for name in list(sys.modules):
+        if name.startswith("backend.app"):
+            del sys.modules[name]
+
+    from backend.app import models
+    from backend.app.deps import (
+        SessionLocal,
+        engine,
+        get_admin_user,
+        get_current_user,
+    )
+    from backend.app.main import app
+
+    with engine.begin() as connection:
+        models.ReallocationPolicy.__table__.drop(bind=connection, checkfirst=True)
+        models.User.__table__.drop(bind=connection, checkfirst=True)
+        models.User.__table__.create(bind=connection, checkfirst=True)
+        models.ReallocationPolicy.__table__.create(bind=connection, checkfirst=True)
+
+    asyncio.run(app.router.startup())
+
+    return SimpleNamespace(
+        app=app,
+        models=models,
+        SessionLocal=SessionLocal,
+        engine=engine,
+        get_current_user=get_current_user,
+        get_admin_user=get_admin_user,
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_tables(app_env: SimpleNamespace) -> None:
+    with app_env.engine.begin() as connection:
+        connection.execute(app_env.models.User.__table__.delete())
+        connection.execute(app_env.models.ReallocationPolicy.__table__.delete())
+    yield
+    app_env.app.dependency_overrides.clear()
+
+
+def test_get_reallocation_policy_returns_defaults(app_env: SimpleNamespace) -> None:
+    user = _create_user(app_env, is_admin=False, username="viewer")
+
+    def override_current_user():
+        return user
+
+    app_env.app.dependency_overrides[app_env.get_current_user] = override_current_user
+
+    status, payload = _perform_json_request(app_env.app, "GET", "/reallocation-policy")
+    assert status == 200
+    assert payload is not None
+    updated_at = payload["updated_at"]
+    assert updated_at is not None
+    assert payload == {
+        "take_from_other_main": False,
+        "rounding_mode": "floor",
+        "allow_overfill": False,
+        "updated_at": updated_at,
+        "updated_by": None,
+    }
+
+
+def test_put_reallocation_policy_updates_values(app_env: SimpleNamespace) -> None:
+    admin = _create_user(app_env, is_admin=True, username="admin")
+
+    def override_admin_user():
+        return admin
+
+    app_env.app.dependency_overrides[app_env.get_admin_user] = override_admin_user
+
+    status, payload = _perform_json_request(
+        app_env.app,
+        "PUT",
+        "/reallocation-policy",
+        {
+            "take_from_other_main": True,
+            "rounding_mode": "ceil",
+            "allow_overfill": True,
+            "updated_by": "  policy-bot  ",
+        },
+    )
+    assert status == 200
+    assert payload is not None
+    assert payload["take_from_other_main"] is True
+    assert payload["rounding_mode"] == "ceil"
+    assert payload["allow_overfill"] is True
+    assert payload["updated_by"] == "policy-bot"
+
+    viewer = _create_user(app_env, is_admin=False, username="viewer")
+
+    def override_current_user():
+        return viewer
+
+    app_env.app.dependency_overrides[app_env.get_current_user] = override_current_user
+
+    status, payload = _perform_json_request(app_env.app, "GET", "/reallocation-policy")
+    assert status == 200
+    assert payload["take_from_other_main"] is True
+    assert payload["rounding_mode"] == "ceil"
+    assert payload["allow_overfill"] is True
+    assert payload["updated_by"] == "policy-bot"

--- a/frontend/src/features/reallocation/master/MasterTab.tsx
+++ b/frontend/src/features/reallocation/master/MasterTab.tsx
@@ -1,0 +1,237 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import axios from "axios";
+
+import { useAuth } from "../../../hooks/useAuth";
+import {
+  useReallocationPolicyQuery,
+  useUpdateReallocationPolicyMutation,
+} from "../../../hooks/useReallocationPolicy";
+
+const ROUNDING_OPTIONS: Array<"floor" | "round" | "ceil"> = ["floor", "round", "ceil"];
+
+type StatusMessage = { type: "success" | "error"; text: string } | null;
+
+type FormState = {
+  take_from_other_main: boolean;
+  rounding_mode: "floor" | "round" | "ceil";
+  allow_overfill: boolean;
+  updated_by: string;
+};
+
+const DEFAULT_FORM: FormState = {
+  take_from_other_main: false,
+  rounding_mode: "floor",
+  allow_overfill: false,
+  updated_by: "",
+};
+
+const getErrorMessage = (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    const detail = (error.response?.data as { detail?: string } | undefined)?.detail;
+    if (detail) {
+      return detail;
+    }
+    if (error.message) {
+      return error.message;
+    }
+  } else if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "Failed to save policy";
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+export default function MasterTab() {
+  const { user } = useAuth();
+  const policyQuery = useReallocationPolicyQuery();
+  const updateMutation = useUpdateReallocationPolicyMutation();
+  const [formState, setFormState] = useState<FormState>(DEFAULT_FORM);
+  const [savedState, setSavedState] = useState<FormState | null>(null);
+  const [status, setStatus] = useState<StatusMessage>(null);
+
+  const isAdmin = Boolean(user?.is_admin);
+
+  useEffect(() => {
+    if (!policyQuery.data) {
+      return;
+    }
+    const nextState: FormState = {
+      take_from_other_main: policyQuery.data.take_from_other_main,
+      rounding_mode: policyQuery.data.rounding_mode,
+      allow_overfill: policyQuery.data.allow_overfill,
+      updated_by: policyQuery.data.updated_by ?? "",
+    };
+    setFormState(nextState);
+    setSavedState(nextState);
+  }, [policyQuery.data]);
+
+  const isDirty = useMemo(() => {
+    if (!savedState) {
+      return false;
+    }
+    return (
+      savedState.take_from_other_main !== formState.take_from_other_main ||
+      savedState.rounding_mode !== formState.rounding_mode ||
+      savedState.allow_overfill !== formState.allow_overfill ||
+      (savedState.updated_by ?? "").trim() !== formState.updated_by.trim()
+    );
+  }, [formState, savedState]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isAdmin) {
+      return;
+    }
+    setStatus(null);
+    try {
+      const payload = {
+        take_from_other_main: formState.take_from_other_main,
+        rounding_mode: formState.rounding_mode,
+        allow_overfill: formState.allow_overfill,
+        updated_by: formState.updated_by.trim() || undefined,
+      };
+      const data = await updateMutation.mutateAsync(payload);
+      const nextSaved: FormState = {
+        take_from_other_main: data.take_from_other_main,
+        rounding_mode: data.rounding_mode,
+        allow_overfill: data.allow_overfill,
+        updated_by: data.updated_by ?? "",
+      };
+      setSavedState(nextSaved);
+      setFormState((prev) => ({ ...prev, updated_by: nextSaved.updated_by }));
+      setStatus({ type: "success", text: "Policy saved successfully" });
+    } catch (error) {
+      setStatus({ type: "error", text: getErrorMessage(error) });
+    }
+  };
+
+  const loading = policyQuery.isLoading;
+  const loadError = policyQuery.isError;
+  const lastUpdatedAt = policyQuery.data?.updated_at ?? null;
+  const lastUpdatedBy = policyQuery.data?.updated_by ?? null;
+
+  return (
+    <section className="reallocation-master">
+      <h2>Reallocation Policy (Master)</h2>
+      {loading && <p>Loading policy…</p>}
+      {loadError && !loading && (
+        <p className="error-text">Failed to load policy. Please try again later.</p>
+      )}
+      {!loading && !loadError && (
+        <form className="master-policy-form" onSubmit={handleSubmit}>
+          <div className="form-field">
+            <label className="checkbox-field">
+              <input
+                type="checkbox"
+                checked={formState.take_from_other_main}
+                onChange={(event) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    take_from_other_main: event.target.checked,
+                  }))
+                }
+                disabled={!isAdmin || updateMutation.isPending}
+              />
+              <span>Allow taking stock from other warehouses&apos; main channels</span>
+            </label>
+            <p className="field-hint">
+              When enabled, other warehouses&apos; main channels may act as donors after non-main
+              sources are exhausted.
+            </p>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="rounding-mode">Rounding mode</label>
+            <select
+              id="rounding-mode"
+              value={formState.rounding_mode}
+              onChange={(event) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  rounding_mode: event.target.value as FormState["rounding_mode"],
+                }))
+              }
+              disabled={!isAdmin || updateMutation.isPending}
+            >
+              {ROUNDING_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+            <p className="field-hint">
+              Controls how fractional transfer quantities are converted to integers.
+            </p>
+          </div>
+
+          <div className="form-field">
+            <label className="checkbox-field">
+              <input
+                type="checkbox"
+                checked={formState.allow_overfill}
+                onChange={(event) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    allow_overfill: event.target.checked,
+                  }))
+                }
+                disabled={!isAdmin || updateMutation.isPending}
+              />
+              <span>Allow filling beyond STD stock</span>
+            </label>
+            <p className="field-hint">
+              Disable to cap moves when the receiving channel would exceed its STD stock.
+            </p>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="updated-by">Updated by (optional)</label>
+            <input
+              id="updated-by"
+              type="text"
+              value={formState.updated_by}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, updated_by: event.target.value }))
+              }
+              disabled={!isAdmin || updateMutation.isPending}
+            />
+          </div>
+
+          <div className="form-footer">
+            <div className="last-updated">
+              <span>
+                Last updated: <strong>{formatDate(lastUpdatedAt)}</strong>
+              </span>
+              <span>
+                Updated by: <strong>{lastUpdatedBy?.trim() || "—"}</strong>
+              </span>
+            </div>
+            <div className="form-actions">
+              {!isAdmin && (
+                <span className="field-hint">Only administrators can update the policy.</span>
+              )}
+              <button
+                type="submit"
+                disabled={!isAdmin || !isDirty || updateMutation.isPending}
+              >
+                {updateMutation.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+
+          {status && <p className={`status-message ${status.type}`}>{status.text}</p>}
+        </form>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useReallocationPolicy.ts
+++ b/frontend/src/hooks/useReallocationPolicy.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import api from "../lib/api";
+import type { ReallocationPolicy } from "../types";
+import { TEST_ALGO_METADATA_KEY } from "./useTestAlgo";
+
+export const REALLOCATION_POLICY_QUERY_KEY = ["reallocation-policy"] as const;
+
+type UpdatePayload = {
+  take_from_other_main: boolean;
+  rounding_mode: "floor" | "round" | "ceil";
+  allow_overfill: boolean;
+  updated_by?: string | null;
+};
+
+const fetchReallocationPolicy = async (): Promise<ReallocationPolicy> => {
+  const { data } = await api.get<ReallocationPolicy>("/api/reallocation-policy");
+  return data;
+};
+
+const updateReallocationPolicy = async (
+  payload: UpdatePayload,
+): Promise<ReallocationPolicy> => {
+  const { data } = await api.put<ReallocationPolicy>("/api/reallocation-policy", payload);
+  return data;
+};
+
+export const useReallocationPolicyQuery = () =>
+  useQuery({
+    queryKey: REALLOCATION_POLICY_QUERY_KEY,
+    queryFn: fetchReallocationPolicy,
+  });
+
+export const useUpdateReallocationPolicyMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateReallocationPolicy,
+    onSuccess: (data) => {
+      queryClient.setQueryData(REALLOCATION_POLICY_QUERY_KEY, data);
+      queryClient.invalidateQueries({ queryKey: ["psi-matrix"] });
+      queryClient.invalidateQueries({ queryKey: ["transfer-plans"] });
+      queryClient.invalidateQueries({ queryKey: TEST_ALGO_METADATA_KEY });
+    },
+  });
+};

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useSessionsQuery, useSessionSummaryQuery } from "../hooks/usePsiQueries";
 import type { MatrixRow, TransferPlan, TransferPlanLine } from "../types";
 import { PSIMatrixTabs } from "../features/reallocation/psi/PSIMatrixTabs";
+import MasterTab from "../features/reallocation/master/MasterTab";
 
 interface StatusMessage {
   type: "success" | "error";
@@ -787,6 +788,8 @@ export default function ReallocationPage() {
       </form>
 
       {status && <div className={`status-message ${status.type}`}>{status.text}</div>}
+
+      <MasterTab />
 
       <section className="matrix-section">
         <h2>PSI Matrix</h2>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -235,3 +235,11 @@ export interface UserAccount {
   is_admin: boolean;
   created_at: string;
 }
+
+export interface ReallocationPolicy {
+  take_from_other_main: boolean;
+  rounding_mode: "floor" | "round" | "ceil";
+  allow_overfill: boolean;
+  updated_at?: string | null;
+  updated_by?: string | null;
+}


### PR DESCRIPTION
## Summary
- add a persistent reallocation_policy table and service to expose GET/PUT APIs guarded by admin access
- update the transfer recommendation algorithm to honor policy flags for donor ordering, rounding, overfill clamping, and logging
- surface policy editing in the UI with a master tab form that refreshes PSI/Test_Algo data after saves and add regression tests for the API

## Testing
- pytest backend/tests/test_reallocation_policy_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e0754aea90832e9b72cf69cd2295b2