### PR TITLE
Add fair-share reallocation policy controls and algorithm updates

### DIFF
--- a/backend/alembic/versions/0012_create_reallocation_policy.py
+++ b/backend/alembic/versions/0012_create_reallocation_policy.py
@@ -26,12 +26,10 @@ def upgrade() -> None:
         sa.Column("allow_overfill", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.Column("updated_by", sa.Text(), nullable=True),
-        schema=SCHEMA,
-    )
-    op.create_check_constraint(
-        ROUNDING_CHECK,
-        TABLE_NAME,
-        "rounding_mode IN ('floor','round','ceil')",
+        sa.CheckConstraint(
+            "rounding_mode IN ('floor','round','ceil')",
+            name=ROUNDING_CHECK,
+        ),
         schema=SCHEMA,
     )
     insert = sa.text(
@@ -44,5 +42,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_constraint(ROUNDING_CHECK, TABLE_NAME, type_="check", schema=SCHEMA)
     op.drop_table(TABLE_NAME, schema=SCHEMA)

--- a/backend/alembic/versions/0013_add_fair_share_mode_to_policy.py
+++ b/backend/alembic/versions/0013_add_fair_share_mode_to_policy.py
@@ -1,0 +1,41 @@
+"""Add fair_share_mode column to the reallocation policy."""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.config import settings
+
+revision: str = "0013"
+down_revision: Union[str, Sequence[str], None] = "0012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = (settings.db_schema or "").strip() or None
+TABLE_NAME = "reallocation_policy"
+COLUMN_NAME = "fair_share_mode"
+CONSTRAINT_NAME = "ck_fair_share_mode"
+
+
+def upgrade() -> None:
+    with op.batch_alter_table(TABLE_NAME, schema=SCHEMA) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                COLUMN_NAME,
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("'off'"),
+            )
+        )
+        batch_op.create_check_constraint(
+            CONSTRAINT_NAME,
+            "fair_share_mode IN ('off','equalize_ratio_closing','equalize_ratio_start')",
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint(CONSTRAINT_NAME, TABLE_NAME, type_="check", schema=SCHEMA)
+    with op.batch_alter_table(TABLE_NAME, schema=SCHEMA) as batch_op:
+        batch_op.drop_column(COLUMN_NAME)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -222,6 +222,9 @@ class ReallocationPolicy(Base, SchemaMixin):
     allow_overfill: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
+    fair_share_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'off'"), default="off"
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )

--- a/backend/app/routers/reallocation_policy.py
+++ b/backend/app/routers/reallocation_policy.py
@@ -34,6 +34,7 @@ def read_reallocation_policy(
         take_from_other_main=policy.take_from_other_main,
         rounding_mode=policy.rounding_mode,
         allow_overfill=policy.allow_overfill,
+        fair_share_mode=policy.fair_share_mode,
         updated_at=policy.updated_at,
         updated_by=policy.updated_by,
     )
@@ -52,12 +53,14 @@ def update_policy(
         take_from_other_main=payload.take_from_other_main,
         rounding_mode=payload.rounding_mode,
         allow_overfill=payload.allow_overfill,
+        fair_share_mode=payload.fair_share_mode,
         updated_by=updated_by,
     )
     return schemas.ReallocationPolicyRead(
         take_from_other_main=policy.take_from_other_main,
         rounding_mode=policy.rounding_mode,
         allow_overfill=policy.allow_overfill,
+        fair_share_mode=policy.fair_share_mode,
         updated_at=policy.updated_at,
         updated_by=policy.updated_by,
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -475,6 +475,7 @@ class ReallocationPolicyBase(BaseModel):
     take_from_other_main: bool
     rounding_mode: Literal["floor", "round", "ceil"]
     allow_overfill: bool
+    fair_share_mode: Literal["off", "equalize_ratio_closing", "equalize_ratio_start"]
 
 
 class ReallocationPolicyWrite(ReallocationPolicyBase):

--- a/backend/app/services/reallocation_policy.py
+++ b/backend/app/services/reallocation_policy.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session as DBSession
 from .. import models
 
 PolicyRoundingMode = Literal["floor", "round", "ceil"]
+PolicyFairShareMode = Literal["off", "equalize_ratio_closing", "equalize_ratio_start"]
 
 
 @dataclass(slots=True)
@@ -20,6 +21,7 @@ class ReallocationPolicyData:
     take_from_other_main: bool
     rounding_mode: PolicyRoundingMode
     allow_overfill: bool
+    fair_share_mode: PolicyFairShareMode
     updated_at: datetime | None
     updated_by: str | None
 
@@ -29,6 +31,7 @@ def _record_to_data(record: models.ReallocationPolicy) -> ReallocationPolicyData
         take_from_other_main=bool(record.take_from_other_main),
         rounding_mode=cast(PolicyRoundingMode, record.rounding_mode),
         allow_overfill=bool(record.allow_overfill),
+        fair_share_mode=cast(PolicyFairShareMode, record.fair_share_mode),
         updated_at=record.updated_at,
         updated_by=record.updated_by,
     )
@@ -38,6 +41,7 @@ _DEFAULT_POLICY = ReallocationPolicyData(
     take_from_other_main=False,
     rounding_mode="floor",
     allow_overfill=False,
+    fair_share_mode="off",
     updated_at=None,
     updated_by=None,
 )
@@ -85,6 +89,7 @@ def update_reallocation_policy(
     take_from_other_main: bool,
     rounding_mode: PolicyRoundingMode,
     allow_overfill: bool,
+    fair_share_mode: PolicyFairShareMode,
     updated_by: str | None,
 ) -> ReallocationPolicyData:
     """Persist the reallocation policy and return the updated snapshot."""
@@ -95,6 +100,7 @@ def update_reallocation_policy(
     policy.take_from_other_main = take_from_other_main
     policy.rounding_mode = rounding_mode
     policy.allow_overfill = allow_overfill
+    policy.fair_share_mode = fair_share_mode
     policy.updated_by = updated_by
     db.add(policy)
     db.commit()
@@ -104,6 +110,7 @@ def update_reallocation_policy(
 
 __all__ = [
     "PolicyRoundingMode",
+    "PolicyFairShareMode",
     "ReallocationPolicyData",
     "get_reallocation_policy",
     "update_reallocation_policy",

--- a/backend/app/services/transfer_logic.py
+++ b/backend/app/services/transfer_logic.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_UP
 from typing import Iterable
 
-from .reallocation_policy import PolicyRoundingMode, ReallocationPolicyData
+from .reallocation_policy import (
+    PolicyFairShareMode,
+    PolicyRoundingMode,
+    ReallocationPolicyData,
+)
 
 ZERO = Decimal("0")
 QUANT = Decimal("0.000001")
@@ -96,6 +100,20 @@ class _CellState:
         return capacity if capacity > ZERO else ZERO
 
 
+@dataclass(slots=True)
+class _FairShareReceiver:
+    warehouse: str
+    channel: str
+    state: _CellState
+    base: Decimal
+    std: Decimal
+    shortage: Decimal
+    max_receivable: Decimal | None
+
+    def key(self) -> tuple[str, str]:
+        return (self.warehouse, self.channel)
+
+
 def _round_quantity(qty: Decimal, mode: PolicyRoundingMode) -> Decimal:
     if qty <= ZERO:
         return ZERO
@@ -135,6 +153,16 @@ def recommend_plan_lines(
     recommendations: list[RecommendedMove] = []
 
     for sku_code, cells in rows_by_sku.items():
+        if policy.fair_share_mode != "off":
+            _recommend_fair_share(
+                sku_code,
+                cells,
+                warehouse_main_channels,
+                policy,
+                recommendations,
+            )
+            continue
+
         shortages: list[tuple[str, str, Decimal, _CellState]] = []
         for warehouse, main_channel in warehouse_main_channels.items():
             cell = cells.get((warehouse, main_channel))
@@ -303,3 +331,448 @@ __all__ = [
     "QUANT",
     "ZERO",
 ]
+
+
+def _recommend_fair_share(
+    sku_code: str,
+    cells: dict[tuple[str, str], _CellState],
+    warehouse_main_channels: dict[str, str],
+    policy: ReallocationPolicyData,
+    recommendations: list[RecommendedMove],
+) -> None:
+    receivers: list[_FairShareReceiver] = []
+    for warehouse, main_channel in warehouse_main_channels.items():
+        state = cells.get((warehouse, main_channel))
+        if state is None:
+            continue
+        shortage = ZERO - state.gap if state.gap < ZERO else ZERO
+        if shortage <= ZERO:
+            continue
+        std_value = state.stdstock if state.stdstock > ZERO else ZERO
+        if std_value <= ZERO:
+            continue
+        if policy.fair_share_mode == "equalize_ratio_start":
+            base_value = state.stock_at_anchor
+        else:
+            base_value = state.stock_closing
+        if base_value < ZERO:
+            base_value = ZERO
+        max_receivable: Decimal | None = None
+        if not policy.allow_overfill:
+            capacity = state.remaining_capacity()
+            if capacity <= ZERO:
+                continue
+            max_receivable = capacity
+        receivers.append(
+            _FairShareReceiver(
+                warehouse=warehouse,
+                channel=main_channel,
+                state=state,
+                base=base_value,
+                std=std_value,
+                shortage=shortage,
+                max_receivable=max_receivable,
+            )
+        )
+
+    if not receivers:
+        return
+
+    donors_nonmain: list[tuple[tuple[str, str], _CellState]] = []
+    donors_inter_main: list[tuple[tuple[str, str], _CellState]] = []
+    total_available = ZERO
+
+    for key, state in cells.items():
+        available = state.available_surplus()
+        if available <= ZERO:
+            continue
+        warehouse, channel = key
+        main_channel = warehouse_main_channels.get(warehouse)
+        if main_channel == channel:
+            if policy.take_from_other_main:
+                donors_inter_main.append((key, state))
+                total_available += available
+        else:
+            donors_nonmain.append((key, state))
+            total_available += available
+
+    donors_nonmain.sort(key=lambda item: item[1].available_surplus(), reverse=True)
+    donors_inter_main.sort(key=lambda item: item[1].available_surplus(), reverse=True)
+
+    donors_intra_by_warehouse: dict[str, list[tuple[tuple[str, str], _CellState]]] = {}
+    for donor in donors_nonmain:
+        donors_intra_by_warehouse.setdefault(donor[0][0], []).append(donor)
+
+    for donors in donors_intra_by_warehouse.values():
+        donors.sort(key=lambda item: item[1].available_surplus(), reverse=True)
+
+    if total_available <= ZERO:
+        _log_fair_share_outcome(
+            sku_code,
+            policy.fair_share_mode,
+            Decimal("0"),
+            receivers,
+            {receiver.key(): ZERO for receiver in receivers},
+            {receiver.key(): ZERO for receiver in receivers},
+            {bucket: ZERO for bucket in _BUCKET_REASON},
+            {receiver.key(): {bucket: 0 for bucket in _BUCKET_REASON} for receiver in receivers},
+        )
+        for receiver in receivers:
+            logger.info(
+                "WHY_NOT_FILLED %s",
+                json.dumps(
+                    {
+                        "sku": sku_code,
+                        "mode": "fair_share",
+                        "target": {
+                            "warehouse": receiver.warehouse,
+                            "channel": receiver.channel,
+                        },
+                        "deficit_before": str(receiver.shortage),
+                        "deficit_after": str(receiver.shortage),
+                        "tried": {bucket: 0 for bucket in _BUCKET_REASON},
+                        "blocked": ["no_donor"],
+                    }
+                ),
+            )
+        return
+
+    if not policy.allow_overfill:
+        capacity_total = sum(
+            receiver.max_receivable or ZERO for receiver in receivers
+        )
+        if capacity_total <= ZERO:
+            return
+        effective_total = min(total_available, capacity_total)
+    else:
+        effective_total = total_available
+
+    donor_units = sum(
+        donor_state.available_surplus().quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+        for _, donor_state in donors_nonmain
+    )
+    if policy.take_from_other_main:
+        donor_units += sum(
+            donor_state.available_surplus().quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+            for _, donor_state in donors_inter_main
+        )
+
+    if not policy.allow_overfill:
+        capacity_units = sum(
+            (receiver.max_receivable or ZERO).quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+            for receiver in receivers
+        )
+        donor_units = min(donor_units, capacity_units)
+
+    available_units = min(
+        effective_total.quantize(MOVE_UNIT, rounding=ROUND_FLOOR),
+        donor_units,
+    )
+
+    ratio_values = [
+        (receiver.base / receiver.std) if receiver.std > ZERO else ZERO
+        for receiver in receivers
+    ]
+    min_ratio = min(ratio_values) if ratio_values else ZERO
+    if min_ratio < ZERO:
+        min_ratio = ZERO
+
+    def needs_for_lambda(lambda_value: Decimal) -> tuple[Decimal, list[Decimal]]:
+        needs: list[Decimal] = []
+        total = ZERO
+        for receiver in receivers:
+            std_value = receiver.std
+            if std_value <= ZERO:
+                needs.append(ZERO)
+                continue
+            target = std_value * lambda_value
+            if not policy.allow_overfill:
+                target = min(target, std_value)
+            need = target - receiver.base
+            if need <= ZERO:
+                needs.append(ZERO)
+                continue
+            if receiver.max_receivable is not None and need > receiver.max_receivable:
+                need = receiver.max_receivable
+            need = need if need > ZERO else ZERO
+            needs.append(need)
+            total += need
+        return total, needs
+
+    if effective_total <= ZERO:
+        lambda_value = Decimal(min_ratio)
+        needs = [ZERO for _ in receivers]
+    else:
+        high = max(Decimal(min_ratio), Decimal("1"))
+        if high <= Decimal(min_ratio):
+            high = Decimal(min_ratio) + QUANT
+        total_high, _ = needs_for_lambda(high)
+        iterations = 0
+        while total_high + QUANT < effective_total and iterations < 32:
+            high *= Decimal("2")
+            total_high, _ = needs_for_lambda(high)
+            iterations += 1
+            if high > Decimal("1000"):
+                break
+
+        low = Decimal(min_ratio)
+        for _ in range(60):
+            mid = (low + high) / Decimal("2")
+            total_mid, _ = needs_for_lambda(mid)
+            if total_mid + QUANT < effective_total:
+                low = mid
+            else:
+                high = mid
+
+        lambda_value = high
+        _, needs = needs_for_lambda(lambda_value)
+
+    plans = []
+    for receiver, need in zip(receivers, needs):
+        if need <= ZERO:
+            plans.append(ZERO)
+            continue
+        if receiver.max_receivable is not None and need > receiver.max_receivable:
+            need = receiver.max_receivable
+        plans.append(need)
+
+    rounded_plans: list[Decimal] = []
+    for receiver, need in zip(receivers, plans):
+        qty = _round_quantity(need, policy.rounding_mode)
+        if receiver.max_receivable is not None:
+            cap = receiver.max_receivable.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+            if qty > cap:
+                qty = cap
+        rounded_plans.append(qty)
+
+    plan_total = sum(rounded_plans)
+    diff = available_units - plan_total
+    indices_sorted = sorted(
+        range(len(receivers)), key=lambda idx: plans[idx], reverse=True
+    )
+
+    def apply_adjustment(delta: Decimal) -> None:
+        remaining = delta
+        for idx in indices_sorted:
+            if remaining == ZERO:
+                break
+            receiver = receivers[idx]
+            cap = (
+                receiver.max_receivable.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+                if receiver.max_receivable is not None
+                else None
+            )
+            if delta > ZERO:
+                while remaining > ZERO:
+                    if cap is not None and rounded_plans[idx] >= cap:
+                        break
+                    rounded_plans[idx] += MOVE_UNIT
+                    remaining -= MOVE_UNIT
+                    if remaining <= ZERO:
+                        break
+            else:
+                while remaining < ZERO and rounded_plans[idx] > ZERO:
+                    rounded_plans[idx] -= MOVE_UNIT
+                    remaining += MOVE_UNIT
+                    if remaining >= ZERO:
+                        break
+
+    if diff > ZERO:
+        apply_adjustment(diff)
+    elif diff < ZERO:
+        apply_adjustment(diff)
+
+    remaining_plan: dict[tuple[str, str], Decimal] = {}
+    allocated: dict[tuple[str, str], Decimal] = {}
+    for receiver, qty in zip(receivers, rounded_plans):
+        key = receiver.key()
+        remaining_plan[key] = qty if qty > ZERO else ZERO
+        allocated[key] = ZERO
+
+    bucket_usage_qty = {bucket: ZERO for bucket in _BUCKET_REASON}
+    bucket_attempts: dict[tuple[str, str], dict[str, int]] = {
+        receiver.key(): {bucket: 0 for bucket in _BUCKET_REASON}
+        for receiver in receivers
+    }
+
+    receiver_order = sorted(
+        receivers,
+        key=lambda receiver: (receiver.base / receiver.std) if receiver.std > ZERO else ZERO,
+    )
+
+    remaining_total = sum(remaining_plan.values())
+
+    def next_receiver_with_need() -> _FairShareReceiver | None:
+        for receiver in receiver_order:
+            if remaining_plan[receiver.key()] > ZERO:
+                return receiver
+        return None
+
+    def commit_move(
+        donor_key: tuple[str, str],
+        donor_state: _CellState,
+        receiver: _FairShareReceiver,
+        qty: Decimal,
+        bucket: str,
+    ) -> None:
+        nonlocal remaining_total
+        donor_state.allocate(qty)
+        receiver.state.receive(qty)
+        key = receiver.key()
+        remaining_plan[key] -= qty
+        if remaining_plan[key] < ZERO:
+            remaining_plan[key] = ZERO
+        allocated[key] += qty
+        remaining_total -= qty
+        if remaining_total < ZERO:
+            remaining_total = ZERO
+        bucket_usage_qty[bucket] += qty
+        recommendations.append(
+            RecommendedMove(
+                sku_code=sku_code,
+                from_warehouse=donor_key[0],
+                from_channel=donor_key[1],
+                to_warehouse=receiver.warehouse,
+                to_channel=receiver.channel,
+                qty=qty,
+                reason=_BUCKET_REASON[bucket],
+            )
+        )
+        logger.info(
+            "MOVE_DECISION %s",
+            json.dumps(
+                {
+                    "sku": sku_code,
+                    "mode": "fair_share",
+                    "from": {"warehouse": donor_key[0], "channel": donor_key[1]},
+                    "to": {
+                        "warehouse": receiver.warehouse,
+                        "channel": receiver.channel,
+                    },
+                    "qty": str(qty),
+                    "reason": bucket,
+                }
+            ),
+        )
+
+    # Intra-warehouse allocation
+    for receiver in receiver_order:
+        key = receiver.key()
+        donors = donors_intra_by_warehouse.get(receiver.warehouse, [])
+        for donor_key, donor_state in donors:
+            if remaining_plan[key] <= ZERO or remaining_total <= ZERO:
+                break
+            available = donor_state.available_surplus()
+            if available <= ZERO:
+                continue
+            bucket_attempts[key]["intra_nonmain"] += 1
+            qty = min(available, remaining_plan[key])
+            if not policy.allow_overfill:
+                receiver_room = receiver.state.remaining_capacity()
+                qty = min(qty, receiver_room)
+            qty = qty.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+            if qty <= ZERO:
+                continue
+            commit_move(donor_key, donor_state, receiver, qty, "intra_nonmain")
+
+    if remaining_total > ZERO:
+        for donor_key, donor_state in donors_nonmain:
+            while donor_state.available_surplus() > ZERO and remaining_total > ZERO:
+                receiver = next_receiver_with_need()
+                if receiver is None:
+                    break
+                key = receiver.key()
+                bucket_attempts[key]["inter_nonmain"] += 1
+                qty = min(donor_state.available_surplus(), remaining_plan[key])
+                if not policy.allow_overfill:
+                    receiver_room = receiver.state.remaining_capacity()
+                    qty = min(qty, receiver_room)
+                qty = qty.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+                if qty <= ZERO:
+                    break
+                commit_move(donor_key, donor_state, receiver, qty, "inter_nonmain")
+
+    if remaining_total > ZERO and policy.take_from_other_main:
+        for donor_key, donor_state in donors_inter_main:
+            while donor_state.available_surplus() > ZERO and remaining_total > ZERO:
+                receiver = next_receiver_with_need()
+                if receiver is None:
+                    break
+                key = receiver.key()
+                bucket_attempts[key]["inter_main"] += 1
+                qty = min(donor_state.available_surplus(), remaining_plan[key])
+                if not policy.allow_overfill:
+                    receiver_room = receiver.state.remaining_capacity()
+                    qty = min(qty, receiver_room)
+                qty = qty.quantize(MOVE_UNIT, rounding=ROUND_FLOOR)
+                if qty <= ZERO:
+                    break
+                commit_move(donor_key, donor_state, receiver, qty, "inter_main")
+
+    for receiver in receivers:
+        key = receiver.key()
+        remaining = remaining_plan[key]
+        if remaining > ZERO:
+            blocked: list[str] = []
+            if not policy.allow_overfill and receiver.state.remaining_capacity() <= ZERO:
+                blocked.append("overfill")
+            blocked.append("no_donor")
+            logger.info(
+                "WHY_NOT_FILLED %s",
+                json.dumps(
+                    {
+                        "sku": sku_code,
+                        "mode": "fair_share",
+                        "target": {
+                            "warehouse": receiver.warehouse,
+                            "channel": receiver.channel,
+                        },
+                        "deficit_before": str(receiver.shortage),
+                        "deficit_after": str(remaining),
+                        "tried": bucket_attempts[key],
+                        "blocked": sorted(set(blocked)),
+                    }
+                ),
+            )
+
+    _log_fair_share_outcome(
+        sku_code,
+        policy.fair_share_mode,
+        lambda_value,
+        receivers,
+        remaining_plan,
+        allocated,
+        bucket_usage_qty,
+        bucket_attempts,
+    )
+
+
+def _log_fair_share_outcome(
+    sku_code: str,
+    mode: PolicyFairShareMode,
+    lambda_value: Decimal,
+    receivers: list[_FairShareReceiver],
+    remaining_plan: dict[tuple[str, str], Decimal],
+    allocated: dict[tuple[str, str], Decimal],
+    bucket_usage_qty: dict[str, Decimal],
+    bucket_attempts: dict[tuple[str, str], dict[str, int]],
+) -> None:
+    debug_payload = {
+        "mode": mode,
+        "lambda": str(lambda_value),
+        "per_main_alloc": {
+            f"{receiver.warehouse}:{receiver.channel}": {
+                "planned": str((allocated[receiver.key()] + remaining_plan[receiver.key()])),
+                "allocated": str(allocated[receiver.key()]),
+                "remaining": str(remaining_plan[receiver.key()]),
+                "attempts": bucket_attempts[receiver.key()],
+            }
+            for receiver in receivers
+        },
+        "donor_usage_breakdown": {bucket: str(qty) for bucket, qty in bucket_usage_qty.items()},
+        "leftover_demand": str(sum(remaining_plan.values())),
+    }
+    logger.info(
+        "FAIR_SHARE %s",
+        json.dumps({"sku": sku_code, "fair_share_debug": debug_payload}),
+    )

--- a/backend/tests/test_reallocation_policy_service.py
+++ b/backend/tests/test_reallocation_policy_service.py
@@ -58,6 +58,7 @@ def test_get_reallocation_policy_returns_defaults_when_table_missing(isolated_ap
         take_from_other_main=False,
         rounding_mode="floor",
         allow_overfill=False,
+        fair_share_mode="off",
         updated_at=None,
         updated_by=None,
     )

--- a/backend/tests/test_transfer_logic.py
+++ b/backend/tests/test_transfer_logic.py
@@ -1,0 +1,165 @@
+"""Tests covering the fair-share transfer allocation logic."""
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+
+import pytest
+
+from backend.app.services.reallocation_policy import ReallocationPolicyData
+from backend.app.services.transfer_logic import MatrixRowData, recommend_plan_lines
+
+
+def _dec(value: str | int | float) -> Decimal:
+    return Decimal(str(value))
+
+
+def _make_row(
+    warehouse: str,
+    channel: str,
+    *,
+    closing: str | int | float,
+    std: str | int | float,
+    gap: str | int | float,
+    stock_at_anchor: str | int | float | None = None,
+) -> MatrixRowData:
+    anchor = stock_at_anchor if stock_at_anchor is not None else closing
+    return MatrixRowData(
+        sku_code="SKU-1",
+        sku_name=None,
+        warehouse_name=warehouse,
+        channel=channel,
+        stock_at_anchor=_dec(anchor),
+        inbound_qty=_dec(0),
+        outbound_qty=_dec(0),
+        stock_closing=_dec(closing),
+        stdstock=_dec(std),
+        gap=_dec(gap),
+        move=_dec(0),
+        stock_fin=_dec(0),
+    )
+
+
+def _policy(
+    *,
+    fair_share_mode: str,
+    rounding_mode: str = "floor",
+    take_from_other_main: bool = False,
+    allow_overfill: bool = False,
+) -> ReallocationPolicyData:
+    return ReallocationPolicyData(
+        take_from_other_main=take_from_other_main,
+        rounding_mode=rounding_mode,  # type: ignore[arg-type]
+        allow_overfill=allow_overfill,
+        fair_share_mode=fair_share_mode,  # type: ignore[arg-type]
+        updated_at=None,
+        updated_by=None,
+    )
+
+
+def _collect_allocations(moves):
+    totals: dict[tuple[str, str], Decimal] = defaultdict(lambda: _dec(0))
+    for move in moves:
+        totals[(move.to_warehouse, move.to_channel)] += move.qty
+    return totals
+
+
+def test_equalize_ratio_closing_balances_closing_levels() -> None:
+    rows = [
+        _make_row("W1", "main", closing="100", std="300", gap="-200"),
+        _make_row("W2", "main", closing="200", std="300", gap="-100"),
+        _make_row("W2", "secondary", closing="200", std="0", gap="100", stock_at_anchor="200"),
+    ]
+    warehouse_main_channels = {"W1": "main", "W2": "main"}
+    moves = recommend_plan_lines(
+        rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=_policy(fair_share_mode="equalize_ratio_closing"),
+    )
+
+    allocations = _collect_allocations(moves)
+    assert allocations[("W1", "main")] == _dec(100)
+    closing_after = {"W1": _dec(100) + allocations[("W1", "main")], "W2": _dec(200)}
+    assert abs(closing_after["W1"] - closing_after["W2"]) <= _dec(1)
+
+
+def test_allow_overfill_false_caps_at_std() -> None:
+    rows = [
+        _make_row("W1", "main", closing="200", std="300", gap="-100"),
+        _make_row("W2", "main", closing="200", std="300", gap="-100"),
+        _make_row("W1", "secondary", closing="250", std="0", gap="200", stock_at_anchor="250"),
+        _make_row("W2", "secondary", closing="250", std="0", gap="200", stock_at_anchor="250"),
+    ]
+    warehouse_main_channels = {"W1": "main", "W2": "main"}
+    moves = recommend_plan_lines(
+        rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=_policy(fair_share_mode="equalize_ratio_closing"),
+    )
+
+    allocations = _collect_allocations(moves)
+    final_closing = {
+        "W1": _dec(200) + allocations[("W1", "main")],
+        "W2": _dec(200) + allocations[("W2", "main")],
+    }
+    assert final_closing["W1"] <= _dec(300)
+    assert final_closing["W2"] <= _dec(300)
+
+
+def test_equalize_ratio_start_prefers_lower_start_ratio() -> None:
+    rows = [
+        _make_row("W1", "main", closing="120", std="300", gap="-180", stock_at_anchor="280"),
+        _make_row("W2", "main", closing="120", std="300", gap="-180", stock_at_anchor="60"),
+        _make_row("W1", "secondary", closing="200", std="0", gap="50", stock_at_anchor="200"),
+        _make_row("W2", "secondary", closing="200", std="0", gap="50", stock_at_anchor="200"),
+    ]
+    warehouse_main_channels = {"W1": "main", "W2": "main"}
+    moves = recommend_plan_lines(
+        rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=_policy(fair_share_mode="equalize_ratio_start"),
+    )
+
+    allocations = _collect_allocations(moves)
+    assert allocations[("W2", "main")] >= allocations[("W1", "main")]
+
+
+def test_main_donors_ignored_when_policy_disallows() -> None:
+    rows = [
+        _make_row("W1", "main", closing="100", std="300", gap="-200"),
+        _make_row("W2", "main", closing="400", std="300", gap="100"),
+    ]
+    warehouse_main_channels = {"W1": "main", "W2": "main"}
+    moves = recommend_plan_lines(
+        rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=_policy(fair_share_mode="equalize_ratio_closing", take_from_other_main=False),
+    )
+
+    assert moves == []
+
+
+def test_rounding_mode_affects_integer_allocation() -> None:
+    rows = [
+        _make_row("W1", "main", closing="90", std="100", gap="-10"),
+        _make_row("W2", "main", closing="90", std="100", gap="-10"),
+        _make_row("W3", "secondary", closing="50", std="0", gap="1", stock_at_anchor="50"),
+    ]
+    warehouse_main_channels = {"W1": "main", "W2": "main"}
+    floor_moves = recommend_plan_lines(
+        rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=_policy(fair_share_mode="equalize_ratio_closing", rounding_mode="floor"),
+    )
+    ceil_moves = recommend_plan_lines(
+        rows,
+        warehouse_main_channels=warehouse_main_channels,
+        policy=_policy(fair_share_mode="equalize_ratio_closing", rounding_mode="ceil"),
+    )
+
+    floor_allocations = _collect_allocations(floor_moves)
+    ceil_allocations = _collect_allocations(ceil_moves)
+    assert floor_allocations[("W1", "main")] == _dec(1)
+    assert floor_allocations[("W2", "main")] == _dec(0)
+    assert ceil_allocations[("W1", "main")] == _dec(0)
+    assert ceil_allocations[("W2", "main")] == _dec(1)

--- a/frontend/src/features/reallocation/master/MasterTab.tsx
+++ b/frontend/src/features/reallocation/master/MasterTab.tsx
@@ -8,6 +8,9 @@ import {
 } from "../../../hooks/useReallocationPolicy";
 
 const ROUNDING_OPTIONS: Array<"floor" | "round" | "ceil"> = ["floor", "round", "ceil"];
+const FAIR_SHARE_OPTIONS: Array<
+  "off" | "equalize_ratio_closing" | "equalize_ratio_start"
+> = ["off", "equalize_ratio_closing", "equalize_ratio_start"];
 
 type StatusMessage = { type: "success" | "error"; text: string } | null;
 
@@ -15,6 +18,7 @@ type FormState = {
   take_from_other_main: boolean;
   rounding_mode: "floor" | "round" | "ceil";
   allow_overfill: boolean;
+  fair_share_mode: "off" | "equalize_ratio_closing" | "equalize_ratio_start";
   updated_by: string;
 };
 
@@ -22,6 +26,7 @@ const DEFAULT_FORM: FormState = {
   take_from_other_main: false,
   rounding_mode: "floor",
   allow_overfill: false,
+  fair_share_mode: "off",
   updated_by: "",
 };
 
@@ -69,6 +74,7 @@ export default function MasterTab() {
       take_from_other_main: policyQuery.data.take_from_other_main,
       rounding_mode: policyQuery.data.rounding_mode,
       allow_overfill: policyQuery.data.allow_overfill,
+      fair_share_mode: policyQuery.data.fair_share_mode,
       updated_by: policyQuery.data.updated_by ?? "",
     };
     setFormState(nextState);
@@ -83,6 +89,7 @@ export default function MasterTab() {
       savedState.take_from_other_main !== formState.take_from_other_main ||
       savedState.rounding_mode !== formState.rounding_mode ||
       savedState.allow_overfill !== formState.allow_overfill ||
+      savedState.fair_share_mode !== formState.fair_share_mode ||
       (savedState.updated_by ?? "").trim() !== formState.updated_by.trim()
     );
   }, [formState, savedState]);
@@ -98,6 +105,7 @@ export default function MasterTab() {
         take_from_other_main: formState.take_from_other_main,
         rounding_mode: formState.rounding_mode,
         allow_overfill: formState.allow_overfill,
+        fair_share_mode: formState.fair_share_mode,
         updated_by: formState.updated_by.trim() || undefined,
       };
       const data = await updateMutation.mutateAsync(payload);
@@ -105,6 +113,7 @@ export default function MasterTab() {
         take_from_other_main: data.take_from_other_main,
         rounding_mode: data.rounding_mode,
         allow_overfill: data.allow_overfill,
+        fair_share_mode: data.fair_share_mode,
         updated_by: data.updated_by ?? "",
       };
       setSavedState(nextSaved);
@@ -171,6 +180,31 @@ export default function MasterTab() {
             </select>
             <p className="field-hint">
               Controls how fractional transfer quantities are converted to integers.
+            </p>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="fair-share-mode">Fair-share mode</label>
+            <select
+              id="fair-share-mode"
+              value={formState.fair_share_mode}
+              onChange={(event) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  fair_share_mode: event.target.value as FormState["fair_share_mode"],
+                }))
+              }
+              disabled={!isAdmin || updateMutation.isPending}
+            >
+              {FAIR_SHARE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+            <p className="field-hint">
+              Distributes donors to equalize main channels’ stock-to-STD ratio (closing or
+              start based).
             </p>
           </div>
 

--- a/frontend/src/hooks/useReallocationPolicy.ts
+++ b/frontend/src/hooks/useReallocationPolicy.ts
@@ -10,6 +10,7 @@ type UpdatePayload = {
   take_from_other_main: boolean;
   rounding_mode: "floor" | "round" | "ceil";
   allow_overfill: boolean;
+  fair_share_mode: "off" | "equalize_ratio_closing" | "equalize_ratio_start";
   updated_by?: string | null;
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -240,6 +240,7 @@ export interface ReallocationPolicy {
   take_from_other_main: boolean;
   rounding_mode: "floor" | "round" | "ceil";
   allow_overfill: boolean;
+  fair_share_mode: "off" | "equalize_ratio_closing" | "equalize_ratio_start";
   updated_at?: string | null;
   updated_by?: string | null;
 }


### PR DESCRIPTION
## Summary
- add a new `fair_share_mode` configuration stored in the reallocation policy schema and database
- expose and persist the shared policy (including the new mode) through the API and Master parameters UI
- implement water-filling based fair-share allocation logic with accompanying backend tests

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e0807a0194832e87522a5e9b787573