### PR TITLE
Add master policy tab layout and auto-create policy record

### DIFF
--- a/backend/tests/test_reallocation_policy_service.py
+++ b/backend/tests/test_reallocation_policy_service.py
@@ -54,11 +54,9 @@ def test_get_reallocation_policy_returns_defaults_when_table_missing(isolated_ap
     with SessionLocal() as session:
         policy = get_reallocation_policy(session)
 
-    assert policy == ReallocationPolicyData(
-        take_from_other_main=False,
-        rounding_mode="floor",
-        allow_overfill=False,
-        fair_share_mode="off",
-        updated_at=None,
-        updated_by=None,
-    )
+    assert policy.take_from_other_main is False
+    assert policy.rounding_mode == "floor"
+    assert policy.allow_overfill is False
+    assert policy.fair_share_mode == "off"
+    assert policy.updated_by is None
+    assert policy.updated_at is not None

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -397,6 +397,189 @@ body {
   color: var(--accent-red, #dc2626);
 }
 
+.reallocation-page .reallocation-master {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border-subtle, #d1d5db);
+  border-radius: 0.75rem;
+  background: var(--surface-panel, #f9fafb);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.reallocation-page .reallocation-master h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.reallocation-page .master-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.reallocation-page .master-tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border-subtle, #d1d5db);
+  padding-bottom: 0.5rem;
+}
+
+.reallocation-page .master-tab-trigger {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 0.85rem;
+  font-weight: 600;
+  color: var(--text-subtle, #6b7280);
+  border-bottom: 3px solid transparent;
+  border-radius: 0.5rem 0.5rem 0 0;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.reallocation-page .master-tab-trigger:hover {
+  color: var(--text-primary);
+  background-color: rgba(59, 130, 246, 0.08);
+}
+
+.reallocation-page .master-tab-trigger.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--button-primary-bg);
+  background-color: rgba(59, 130, 246, 0.12);
+}
+
+.reallocation-page .master-tab-trigger:focus-visible {
+  outline: 2px solid var(--button-primary-bg);
+  outline-offset: 2px;
+}
+
+.reallocation-page .master-tab-panel {
+  display: block;
+}
+
+.reallocation-page .master-policy-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.reallocation-page .master-policy-guidance {
+  flex: 1 1 320px;
+  background: var(--surface-panel-soft, #eef2ff);
+  border: 1px solid var(--border-subtle, #d1d5db);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  line-height: 1.6;
+}
+
+.reallocation-page .master-policy-guidance h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.15rem;
+}
+
+.reallocation-page .master-policy-guidance ul {
+  margin: 0.75rem 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.reallocation-page .master-policy-guidance li strong {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.reallocation-page .master-policy-guidance .guidance-note {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: var(--text-subtle, #6b7280);
+}
+
+.reallocation-page .master-policy-form {
+  flex: 1 1 340px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--surface-panel-soft, #eef2ff);
+  border: 1px solid var(--border-subtle, #d1d5db);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+}
+
+.reallocation-page .master-policy-form .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reallocation-page .master-policy-form label {
+  font-weight: 600;
+}
+
+.reallocation-page .master-policy-form .checkbox-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.reallocation-page .master-policy-form .checkbox-field input {
+  margin-top: 0.25rem;
+}
+
+.reallocation-page .master-policy-form input[type="text"],
+.reallocation-page .master-policy-form select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-subtle, #d1d5db);
+  background: var(--surface-body, #ffffff);
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.reallocation-page .master-policy-form input[type="text"]:disabled,
+.reallocation-page .master-policy-form select:disabled {
+  background: rgba(148, 163, 184, 0.15);
+  cursor: not-allowed;
+}
+
+.reallocation-page .master-policy-form .field-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-subtle, #6b7280);
+}
+
+.reallocation-page .master-policy-form .form-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reallocation-page .master-policy-form .last-updated {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: var(--text-subtle, #6b7280);
+}
+
+.reallocation-page .master-policy-form .form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.reallocation-page .master-policy-form button {
+  align-self: flex-start;
+}
+
 .reallocation-page .plan-lines-section input:not([type="checkbox"]),
 .reallocation-page .plan-lines-section select {
   width: 100%;


### PR DESCRIPTION
## Summary
- introduce a dedicated "Reallocation Policy" tab inside the master section with Japanese guidance and form controls
- style the new master policy tab layout for clarity
- ensure the backend auto-creates the policy table/record and update the corresponding service test

## Testing
- npm run build
- pytest tests/test_reallocation_policy_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e085df9fa4832e9d52b8b44408bff1