### PR TITLE
Add inventory transfer documentation for developers and operations

### DIFF
--- a/docs/inventory-transfer-dev.md
+++ b/docs/inventory-transfer-dev.md
@@ -1,0 +1,47 @@
+# 在庫移動機能（開発者向け）
+
+## 1. 概要
+- 「在庫再配置」画面はセッションと期間をもとに PSI 行列を取得し、倉庫・チャネル間の在庫移動計画（Transfer Plan）の作成・編集を行います。【F:frontend/src/pages/ReallocationPage.tsx†L620-L706】
+- PSI 行列は `/api/psi/matrix` 経由で集計済みの `MatrixRowData` を取得し、保存済みの移動量とドラフト差分を合成して表示・計算します。【F:backend/app/services/transfer_plans.py†L21-L120】【F:frontend/src/pages/ReallocationPage.tsx†L488-L568】
+- 移動計画は API 側でヘッダー・行を管理し、ドラフト生成・保存・再読込がフロントエンドの React Query フローと同期する設計です。【F:backend/app/routers/transfer_plans.py†L136-L238】【F:frontend/src/pages/ReallocationPage.tsx†L329-L455】
+
+## 2. PSI 行列取得と加工
+1. `fetch_matrix_rows` は指定セッション・期間の `psi_base` を SKU×倉庫×チャネルで集計し、開始日基準の在庫（stock_at_anchor）と標準在庫（stdstock）、期間内入出庫などをまとめます。【F:backend/app/services/transfer_plans.py†L21-L120】
+2. 計画 ID が与えられた場合、`transfer_plan_lines` を出庫（負）/入庫（正）に分けて結合し、ベース集計に移動量をマージします。【F:backend/app/services/transfer_plans.py†L53-L110】
+3. フロントエンドは取得した行に保存済み移動量・ドラフト差分を重ね合わせ、`stock_fin` や Gap などの指標をリアルタイムで再計算します。【F:frontend/src/pages/ReallocationPage.tsx†L488-L568】
+4. PSI 行列 UI（`PSIMatrixTabs`）は SKU ナビゲーション、複数タブ（クロステーブル・ヒートマップ・KPI など）を通じて分析視点を切り替えられるよう構成されています。【F:frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx†L20-L234】
+
+## 3. 推奨計画生成ロジック
+- `/api/transfer-plans/recommend` は指定条件の PSI 行列を再集計し、倉庫ごとのメインチャネルと再配置ポリシーを取得した上でアルゴリズムを実行します。【F:backend/app/routers/transfer_plans.py†L136-L199】
+- `recommend_plan_lines` は SKU 単位で不足セル（メインチャネル Gap<0）を抽出し、次の順序で移動候補を作成します。【F:backend/app/services/transfer_logic.py†L130-L239】
+  1. 同一倉庫内の非メインチャネル余剰から補填（intra）。
+  2. 他倉庫の非メインチャネル余剰から補填（inter_nonmain）。
+  3. ポリシーが許可する場合、他倉庫メインチャネルからも補填（inter_main）。
+- 補填量は `rounding_mode` 設定に従って 1 個単位へ丸められ、`allow_overfill` が false の場合は受け側の標準在庫超過をブロックします。【F:backend/app/services/transfer_logic.py†L210-L266】
+- 公平分配モード（`fair_share_mode` ≠ `off`）では、SKU ごとに不足セルへ余剰を比率配分する専用ルーチン `_recommend_fair_share` が呼び出されます。【F:backend/app/services/transfer_logic.py†L276-L360】
+
+## 4. API エンドポイント
+- `GET /api/transfer-plans`：条件に合致する計画一覧を返却。クエリはセッションや期間でフィルタできます。【F:backend/app/routers/transfer_plans.py†L30-L118】
+- `POST /api/transfer-plans/recommend`：指定セッション・期間（＋任意 SKU/倉庫/チャネル）から推奨ドラフトを生成し、計画ヘッダーと行を新規保存します。【F:backend/app/routers/transfer_plans.py†L136-L199】
+- `GET /api/transfer-plans/{plan_id}`：計画詳細を取得し、フロント側でドラフト行へ変換します。【F:backend/app/routers/transfer_plans.py†L200-L238】【F:frontend/src/pages/ReallocationPage.tsx†L372-L455】
+- `PUT /api/transfer-plans/{plan_id}/lines`：計画行を全件置換。出庫数量が在庫起点を超えると 422 エラーを返します。【F:backend/app/routers/transfer_plans.py†L200-L282】
+
+## 5. フロントエンド連携
+- フィルタフォームではセッション・期間を指定し、「Create recommendation」「Load plan」「Refresh list」などの操作でドラフト生成・既存計画読込を行います。【F:frontend/src/pages/ReallocationPage.tsx†L706-L792】
+- 計画行テーブルでは SKU・倉庫・チャネル・数量・理由を編集でき、保存時に未入力や数量不正をバリデーションします。【F:frontend/src/pages/ReallocationPage.tsx†L260-L360】【F:frontend/src/pages/ReallocationPage.tsx†L792-L936】
+- 行一覧は CSV 形式でダウンロードでき、出力には計画 ID や手動編集フラグが含まれます。【F:frontend/src/pages/ReallocationPage.tsx†L540-L620】【F:frontend/src/pages/ReallocationPage.tsx†L792-L906】
+
+## 6. マスタとグローバルパラメータ
+- 倉庫マスタ `warehouse_master` の `main_channel` 列はメインチャネル優先順位を決める根拠となり、推奨生成時に `fetch_main_channel_map` で参照されます。【F:backend/app/models.py†L170-L207】【F:backend/app/services/transfer_plans.py†L200-L214】
+- チャネル一覧は `channel_master` に保持され、倉庫マスタの外部参照先になります。【F:backend/app/models.py†L162-L175】
+- 再配置ポリシー `reallocation_policy` は以下の 4 つの制御フラグを持ち、推奨アルゴリズム全体の振る舞いを切り替えます。【F:backend/app/models.py†L208-L236】【F:backend/app/services/reallocation_policy.py†L12-L64】
+  - `take_from_other_main`：他倉庫メインチャネルからの移動を許可。
+  - `rounding_mode`：数量丸め方法（floor/round/ceil）。
+  - `allow_overfill`：標準在庫超過を許容。
+  - `fair_share_mode`：公平分配モード（off/equalize_ratio_closing/equalize_ratio_start）。
+- ポリシー API は `GET /api/reallocation-policy` で取得、`PUT /api/reallocation-policy` で更新します。更新時は管理者認証が必須です。【F:backend/app/routers/reallocation_policy.py†L20-L55】
+
+## 7. バリデーションと制約
+- 保存 API は `from` = `to`、`line_id` 重複、`plan_id` 不一致を拒否し、出庫合計が `stock_at_anchor` を超える場合は 422 エラーになります。【F:backend/app/routers/transfer_plans.py†L214-L282】
+- 推奨生成時は期間の前後関係やセッション存在確認を行い、不正なリクエストを 400/404 エラーで防ぎます。【F:backend/app/routers/transfer_plans.py†L136-L170】
+- アルゴリズム内では不足が解消できなかった理由（donor 不足、丸め、オーバーフィル禁止など）をログ出力し、調査時に根拠を追跡できるようにしています。【F:backend/app/services/transfer_logic.py†L200-L273】

--- a/docs/inventory-transfer-ops.md
+++ b/docs/inventory-transfer-ops.md
@@ -1,0 +1,29 @@
+# 在庫移動機能（業務担当者向け）
+
+## 1. 機能概要
+- 在庫再配置画面では、選択したセッションと期間に対する PSI 行列を表示し、倉庫・チャネル間の在庫移動計画（Transfer Plan）を作成・編集できます。【F:frontend/src/pages/ReallocationPage.tsx†L620-L706】
+- PSI 行列タブでは SKU ごとの在庫指標をクロステーブル／ヒートマップ／KPI などの視点で確認でき、ドラフト移動の影響が即時に反映されます。【F:frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx†L20-L234】
+
+## 2. 前提マスタ設定
+- **倉庫マスタ**：各倉庫の「メインチャネル」を設定すると、推奨計画作成時に不足を優先的に解消する対象として扱われます。未設定の倉庫は推奨ロジックの対象外になるため、倉庫追加時は必ずメインチャネルを登録してください。【F:backend/app/models.py†L170-L207】【F:backend/app/services/transfer_plans.py†L200-L214】
+- **再配置ポリシー**：管理者は `/api/reallocation-policy` を通じて以下の制御値を調整できます。【F:backend/app/routers/reallocation_policy.py†L20-L55】
+  - `take_from_other_main`：他倉庫メインチャネルからも在庫を融通するか。
+  - `rounding_mode`：推奨数量の丸め方（切り捨て／四捨五入／切り上げ）。
+  - `allow_overfill`：標準在庫を超える入庫を許容するか。
+  - `fair_share_mode`：不足倉庫への配分ルール（オフ／期末在庫比率／期首在庫比率）。
+- ポリシー変更は即時に推奨アルゴリズムへ反映されるため、運用フロー変更時は事前に影響範囲を確認した上で更新してください。【F:backend/app/services/transfer_logic.py†L130-L266】
+
+## 3. 操作フロー
+1. 画面上部のフォームでセッションと期間（Start/End date）を選択し、「Apply filters」を押して PSI 行列を読み込みます。【F:frontend/src/pages/ReallocationPage.tsx†L706-L764】
+2. 「Create recommendation」を押すと、指定期間の不足を補う推奨計画が自動生成され、計画 ID と行が読み込まれます。処理完了後はステータスメッセージで結果が表示されます。【F:frontend/src/pages/ReallocationPage.tsx†L706-L792】
+3. 既存計画を再編集したい場合は「作成済みプラン」ドロップダウンから選択し、「Load plan」で内容を読み込みます。リストは最新順で自動補完され、必要に応じて「Refresh list」で再取得できます。【F:frontend/src/pages/ReallocationPage.tsx†L736-L792】
+4. PSI 行列セクションでは SKU タブを切り替え、在庫指標の変化を確認します。検索窓やナビゲーションボタンで SKU を移動しながら内容を確認できます。【F:frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx†L32-L228】
+
+## 4. 計画行の編集と保存
+- 計画行テーブルでは、SKU・倉庫・チャネル・数量・理由を直接編集できます。メニューから「Add manual line」で手動行を追加し、不要な行は「Remove」で削除します。【F:frontend/src/pages/ReallocationPage.tsx†L792-L936】
+- 保存前に必須項目（SKU／移動元・先の倉庫とチャネル／数量）を入力し、数量は正の整数になるよう調整してください。条件を満たさない場合はエラーが表示され保存できません。【F:frontend/src/pages/ReallocationPage.tsx†L260-L360】【F:frontend/src/pages/ReallocationPage.tsx†L792-L876】
+- 「Save lines」を押すとサーバーへ一括保存され、成功時には PSI 行列と計画一覧が最新状態に更新されます。【F:frontend/src/pages/ReallocationPage.tsx†L820-L876】
+
+## 5. データ活用
+- 「CSVダウンロード」を押すと、現在の計画行をヘッダー付き CSV で出力できます。ファイル名には計画 ID とタイムスタンプが付与され、手動行フラグや理由列も含まれます。【F:frontend/src/pages/ReallocationPage.tsx†L540-L620】【F:frontend/src/pages/ReallocationPage.tsx†L792-L876】
+- 推奨計画で不足が解消されない場合は、倉庫のメインチャネル設定や再配置ポリシー値を見直し、必要に応じて手動行を追加して調整してください。【F:backend/app/services/transfer_logic.py†L200-L273】


### PR DESCRIPTION
## Summary
- document the inventory transfer feature for developers, covering data flow, APIs, and master parameters
- add an operations-facing guide describing prerequisites, workflow, and CSV export usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a9c895d8832eb7f290f399097003