### PR TITLE
Handle summary uploads without channel transfers table

### DIFF
--- a/backend/alembic/versions/0015_create_psi_summary_base_table.py
+++ b/backend/alembic/versions/0015_create_psi_summary_base_table.py
@@ -1,0 +1,68 @@
+"""create psi summary base table"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.config import settings
+
+revision: str = "0015"
+down_revision: Union[str, Sequence[str], None] = "0014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = settings.db_schema or None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table("psi_summary_base", schema=SCHEMA):
+        return
+
+    session_target = f"{SCHEMA}.sessions.id" if SCHEMA else "sessions.id"
+
+    op.create_table(
+        "psi_summary_base",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sku_code", sa.Text(), nullable=False),
+        sa.Column("sku_name", sa.Text(), nullable=True),
+        sa.Column("warehouse_name", sa.Text(), nullable=False),
+        sa.Column("channel", sa.Text(), nullable=False),
+        sa.Column("inbound_qty", sa.Numeric(), nullable=True),
+        sa.Column("outbound_qty", sa.Numeric(), nullable=True),
+        sa.Column("std_stock", sa.Numeric(), nullable=True),
+        sa.Column("stock", sa.Numeric(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["session_id"], [session_target], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "session_id",
+            "sku_code",
+            "warehouse_name",
+            "channel",
+            name="uq_psi_summary_base_key",
+        ),
+        schema=SCHEMA,
+    )
+
+    op.create_index(
+        "idx_psi_summary_base_lookup",
+        "psi_summary_base",
+        ["session_id", "sku_code", "warehouse_name", "channel"],
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_psi_summary_base_lookup", table_name="psi_summary_base", schema=SCHEMA)
+    op.drop_table("psi_summary_base", schema=SCHEMA)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,12 +1,20 @@
 """Pydantic schemas for API payloads."""
 from __future__ import annotations
 
+from enum import Enum
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+
+class SessionDataType(str, Enum):
+    """Type of PSI data attached to a planning session."""
+
+    BASE = "base"
+    SUMMARY = "summary"
 
 
 class SessionBase(BaseModel):
@@ -36,6 +44,7 @@ class SessionRead(SessionBase):
     #id: str
     id: UUID
     is_leader: bool
+    data_type: SessionDataType
     created_by: UUID | None = None
     updated_by: UUID | None = None
     created_at: datetime
@@ -142,6 +151,7 @@ class PSISessionSummary(BaseModel):
     """High-level information about the available PSI data for a session."""
 
     session_id: UUID
+    data_type: SessionDataType
     start_date: date | None = None
     end_date: date | None = None
 


### PR DESCRIPTION
## Summary
- add a helper to detect whether the channel transfers table exists before purging data during summary uploads
- guard the summary ingestion flow so SQLite runs skip deleting from channel transfers when the table is absent
- order summary daily PSI rows by insertion id to preserve CSV ordering
- add an Alembic migration (and runtime helpers) to create the PSI summary table when it is missing
- expose the session data type enum in API schemas so endpoints can differentiate summary sessions

## Testing
- pytest backend/tests/test_psi_api.py backend/tests/test_sessions_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e13b8d1e90832e9da4d8aa45be7caa