### PR TITLE
Support sessions data_mode column

### DIFF
--- a/backend/alembic/versions/0016_use_data_mode_for_sessions.py
+++ b/backend/alembic/versions/0016_use_data_mode_for_sessions.py
@@ -1,0 +1,133 @@
+"""Ensure planning sessions use the ``data_mode`` column."""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.config import settings
+
+revision: str = "0016"
+down_revision: Union[str, Sequence[str], None] = "0015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = settings.db_schema or None
+
+
+def _qualified(table: str) -> str:
+    return f"{SCHEMA}.{table}" if SCHEMA else table
+
+
+def _session_table_columns(inspector: sa.Inspector) -> set[str]:
+    return {column["name"] for column in inspector.get_columns("sessions", schema=SCHEMA)}
+
+
+def _session_check_constraints(inspector: sa.Inspector) -> set[str]:
+    return {
+        constraint["name"]
+        for constraint in inspector.get_check_constraints("sessions", schema=SCHEMA)
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = _session_table_columns(inspector)
+
+    if "data_mode" not in columns and "data_type" in columns:
+        op.alter_column(
+            "sessions",
+            "data_type",
+            new_column_name="data_mode",
+            schema=SCHEMA,
+            existing_type=sa.String(length=16),
+        )
+        columns = _session_table_columns(sa.inspect(op.get_bind()))
+
+    if "data_mode" not in columns:
+        op.add_column(
+            "sessions",
+            sa.Column(
+                "data_mode",
+                sa.String(length=16),
+                nullable=False,
+                server_default=sa.text("'base'"),
+            ),
+            schema=SCHEMA,
+        )
+        columns.add("data_mode")
+
+    if "data_type" in columns and "data_mode" in columns:
+        session_table = _qualified("sessions")
+        op.execute(
+            sa.text(
+                f"UPDATE {session_table} "
+                "SET data_mode = COALESCE(data_mode, data_type, 'base')"
+            )
+        )
+        if bind.dialect.name != "sqlite":
+            op.drop_column("sessions", "data_type", schema=SCHEMA)
+
+    if bind.dialect.name != "sqlite":
+        op.alter_column(
+            "sessions",
+            "data_mode",
+            nullable=False,
+            server_default=sa.text("'base'"),
+            existing_type=sa.String(length=16),
+            schema=SCHEMA,
+        )
+
+    constraints = _session_check_constraints(sa.inspect(op.get_bind()))
+    if bind.dialect.name != "sqlite" and "ck_sessions_data_mode" not in constraints:
+        op.create_check_constraint(
+            "ck_sessions_data_mode",
+            "sessions",
+            "data_mode IN ('base','summary')",
+            schema=SCHEMA,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    constraints = _session_check_constraints(inspector)
+    if bind.dialect.name != "sqlite" and "ck_sessions_data_mode" in constraints:
+        op.drop_constraint("ck_sessions_data_mode", "sessions", schema=SCHEMA)
+
+    columns = _session_table_columns(inspector)
+    if "data_type" not in columns:
+        op.add_column(
+            "sessions",
+            sa.Column(
+                "data_type",
+                sa.String(length=16),
+                nullable=False,
+                server_default=sa.text("'base'"),
+            ),
+            schema=SCHEMA,
+        )
+
+    session_table = _qualified("sessions")
+    op.execute(
+        sa.text(
+            f"UPDATE {session_table} SET data_type = COALESCE(data_mode, 'base')"
+        )
+    )
+
+    if bind.dialect.name != "sqlite":
+        op.alter_column(
+            "sessions",
+            "data_type",
+            nullable=False,
+            server_default=sa.text("'base'"),
+            existing_type=sa.String(length=16),
+            schema=SCHEMA,
+        )
+
+    if bind.dialect.name != "sqlite":
+        op.drop_column("sessions", "data_mode", schema=SCHEMA)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -26,7 +26,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine import Connection, Engine
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, synonym
 
 from .config import settings
 
@@ -134,7 +134,13 @@ class Session(Base, SchemaMixin, TimestampMixin, UserTrackingMixin):
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_leader: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    data_type: Mapped[str] = mapped_column(String(length=16), default="base", nullable=False)
+    _data_mode: Mapped[str] = mapped_column(
+        "data_mode",
+        String(length=16),
+        default="base",
+        nullable=False,
+        server_default=text("'base'"),
+    )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         PGUUID(as_uuid=True), ForeignKey(_qualified("users")), nullable=True
     )
@@ -157,6 +163,8 @@ class Session(Base, SchemaMixin, TimestampMixin, UserTrackingMixin):
     transfer_plans: Mapped[list["TransferPlan"]] = relationship(
         back_populates="session", cascade="all, delete-orphan"
     )
+    data_mode = synonym("_data_mode")
+    data_type = synonym("_data_mode")
     created_by_user: Mapped[User | None] = relationship(
         "User",
         foreign_keys="Session.created_by",

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -38,7 +38,7 @@ def test_upgrade_adds_audit_columns(tmp_path, monkeypatch):
     inspector = sa.inspect(engine)
 
     expected_columns = {
-        "sessions": {"created_by", "updated_by"},
+        "sessions": {"created_by", "updated_by", "data_mode"},
         "psi_edits": {"created_by", "updated_by"},
         "channel_transfers": {"created_by", "updated_by"},
         "psi_edit_log": {"created_at", "updated_at", "created_by", "updated_by", "edited_by"},


### PR DESCRIPTION
## Summary
- map the new sessions.data_mode column in the SQLAlchemy model while keeping data_type compatibility
- add an Alembic migration to rename/add the column and enforce defaults/check constraints when available
- adjust migration tests to expect the new column

## Testing
- pytest backend/tests/test_sessions_api.py backend/tests/test_psi_api.py backend/tests/test_migrations.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e145287740832e9005476fb757555d