### PR TITLE
Add session data mode support and summary upload handling

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -27,7 +27,7 @@ class SessionBase(BaseModel):
 class SessionCreate(SessionBase):
     """Schema for creating a session."""
 
-    pass
+    data_mode: SessionDataType = SessionDataType.BASE
 
 
 class SessionUpdate(BaseModel):
@@ -36,15 +36,17 @@ class SessionUpdate(BaseModel):
     title: Annotated[str, Field(min_length=1, max_length=255)] | None = None
     description: str | None = None
     is_leader: bool | None = None
+    data_mode: SessionDataType | None = None
 
 
 class SessionRead(SessionBase):
     """Session data returned by the API."""
 
-    #id: str
     id: UUID
     is_leader: bool
-    data_type: SessionDataType
+    data_mode: SessionDataType
+    # Backwards compatibility: expose legacy name while callers migrate
+    data_type: SessionDataType | None = None
     created_by: UUID | None = None
     updated_by: UUID | None = None
     created_at: datetime
@@ -92,9 +94,15 @@ class ChannelDailyPSI(BaseModel):
 class PSIUploadResult(BaseModel):
     """Upload summary returned after processing a PSI CSV file."""
 
+    ok: bool
+    mode: SessionDataType
+    rows: int
     rows_imported: int
     session_id: UUID
     dates: list[date]
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}
 
 
 class PSIEditEntry(BaseModel):

--- a/docs/data/psi_base_sample.csv
+++ b/docs/data/psi_base_sample.csv
@@ -1,0 +1,4 @@
+sku_code,sku_name,warehouse_name,channel,date,category_1,category_2,category_3,fw_rank,ss_rank,stock_at_anchor,inbound_qty,outbound_qty,net_flow,stock_closing,safety_stock,movable_stock,stdstock,gap
+SKU-001,Sample Item A,Tokyo,直営店,2024-04-01,Men,Outer,Coat,A,B,120,30,10,20,140,90,50,95,45
+SKU-001,Sample Item A,Tokyo,直営店,2024-04-02,Men,Outer,Coat,A,B,140,20,25,-5,135,90,45,95,40
+SKU-010,Sample Item B,Osaka,online,2024-04-01,Women,Tops,Blouse,B,C,80,15,12,3,83,55,28,60,23

--- a/docs/data/psi_summary_sample.csv
+++ b/docs/data/psi_summary_sample.csv
@@ -1,0 +1,4 @@
+sku_code,sku_name,warehouse_name,channel,inbound_qty,outbound_qty,std_stock,stock
+SKU-001,Sample Item A,Tokyo,直営店,50,20,35,80
+SKU-002,Sample Item B,Osaka,online,10,5,12,20
+SKU-003,Sample Item C,Nagoya,法人,0,0,8,9

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1372,6 +1372,290 @@ button.icon-button:focus-visible {
   border-bottom: none;
 }
 
+.data-mode-fieldset {
+  margin: 0;
+  padding: 1rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.data-mode-fieldset legend {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.data-mode-fieldset label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.data-mode-fieldset input[type="radio"] {
+  accent-color: var(--accent-blue);
+}
+
+.sessions-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.mode-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mode-filter button {
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.mode-filter button.active {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.45);
+  color: var(--accent-blue-strong);
+}
+
+.mode-filter button:hover:not(.active),
+.mode-filter button:focus-visible:not(.active) {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.35);
+  outline: none;
+}
+
+.mode-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.mode-badge--base {
+  background-color: rgba(59, 130, 246, 0.18);
+  color: var(--badge-info-text);
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.mode-badge--summary {
+  background-color: rgba(245, 158, 11, 0.18);
+  color: #fbbf24;
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.upload-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 70;
+}
+
+.upload-dialog {
+  width: min(640px, 95vw);
+  max-height: 90vh;
+  background: var(--surface-panel);
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-default);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  color: var(--text-primary);
+}
+
+.upload-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem 1.5rem 0.75rem;
+}
+
+.upload-dialog__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.upload-dialog__header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.upload-dialog__form {
+  padding: 0 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+}
+
+.upload-dialog__help {
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--surface-table);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.upload-dialog__help h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.upload-dialog__aliases p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.upload-dialog__aliases ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
+}
+
+.upload-dialog__sample {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--accent-blue);
+  text-decoration: none;
+}
+
+.upload-dialog__sample:hover,
+.upload-dialog__sample:focus-visible {
+  text-decoration: underline;
+}
+
+.upload-dialog__file {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.upload-dialog__file-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.upload-dialog__file-name {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.upload-dialog__file-placeholder {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.upload-dialog__status {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.upload-dialog__status--error {
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: var(--text-warning);
+}
+
+.upload-dialog__result {
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--surface-table);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.upload-dialog__warnings ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1rem;
+}
+
+.upload-dialog__no-warnings {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.upload-dialog__duplicates {
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.upload-dialog__duplicates table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.upload-dialog__duplicates th,
+.upload-dialog__duplicates td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+}
+
+.upload-dialog__duplicates th {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.upload-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.upload-dialog__columns {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.upload-dialog__columns code {
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 0.35rem;
+  padding: 0.15rem 0.35rem;
+  display: inline-block;
+}
+
 .psi-table-scroll-area {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,21 +1,91 @@
-import { ChangeEvent, FormEvent, useRef, useState } from "react";
+import { ChangeEvent, FormEvent, MouseEvent, useMemo, useState } from "react";
 import axios from "axios";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import api from "../lib/api";
-import { Session } from "../types";
+import { Session, UploadResponse } from "../types";
+
+type DataMode = "base" | "summary";
+type ModeFilter = "all" | DataMode;
 
 interface SessionFormState {
   title: string;
   description?: string;
+  data_mode: DataMode;
 }
 
 interface UploadVariables {
   file: File;
   sessionId: string;
   sessionTitle: string;
+  dataMode: DataMode;
 }
+
+interface DuplicateKey {
+  sku_code: string;
+  warehouse_name: string;
+  channel: string;
+}
+
+const REQUIRED_COLUMNS: Record<DataMode, string[]> = {
+  base: [
+    "category_1",
+    "category_2",
+    "category_3",
+    "channel",
+    "date",
+    "fw_rank",
+    "gap",
+    "inbound_qty",
+    "movable_stock",
+    "net_flow",
+    "outbound_qty",
+    "safety_stock",
+    "sku_code",
+    "ss_rank",
+    "stdstock",
+    "stock_at_anchor",
+    "stock_closing",
+    "warehouse_name",
+  ],
+  summary: [
+    "sku_code",
+    "warehouse_name",
+    "channel",
+    "inbound_qty",
+    "outbound_qty",
+    "std_stock",
+    "stock",
+  ],
+};
+
+const SUMMARY_ALIAS_NOTES = [
+  "SKU名 → sku_name",
+  "inbound → inbound_qty",
+  "outbound → outbound_qty",
+];
+
+const MODE_LABELS: Record<DataMode, string> = {
+  base: "BASE",
+  summary: "SUMMARY",
+};
+
+const SAMPLE_LINKS: Record<DataMode, string> = {
+  base: "/docs/data/psi_base_sample.csv",
+  summary: "/docs/data/psi_summary_sample.csv",
+};
+
+const MODE_DESCRIPTIONS: Record<DataMode, string> = {
+  base: "Upload day-level PSI data with category, rank, and stock columns.",
+  summary: "Upload aggregated SKU × warehouse × channel totals.",
+};
+
+const MODE_FILTERS: { value: ModeFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "base", label: "Base" },
+  { value: "summary", label: "Summary" },
+];
 
 const fetchSessions = async (search: string): Promise<Session[]> => {
   const params = search.trim() ? { search: search.trim() } : undefined;
@@ -25,9 +95,15 @@ const fetchSessions = async (search: string): Promise<Session[]> => {
 
 const getErrorMessage = (error: unknown, fallback: string) => {
   if (axios.isAxiosError(error)) {
-    const detail = (error.response?.data as { detail?: string } | undefined)?.detail;
-    if (detail) {
+    const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail;
+    if (typeof detail === "string") {
       return detail;
+    }
+    if (detail && typeof detail === "object" && !Array.isArray(detail) && "message" in detail) {
+      const message = (detail as { message?: string }).message;
+      if (typeof message === "string") {
+        return message;
+      }
     }
     if (error.message) {
       return error.message;
@@ -42,28 +118,51 @@ const getErrorMessage = (error: unknown, fallback: string) => {
 export default function SessionsPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [formState, setFormState] = useState<SessionFormState>({ title: "", description: "" });
+  const [formState, setFormState] = useState<SessionFormState>({
+    title: "",
+    description: "",
+    data_mode: "base",
+  });
   const [status, setStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
-  const [uploadStatus, setUploadStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [uploadStatus, setUploadStatus] = useState<{ type: "success" | "error"; text: string } | null>(
+    null,
+  );
   const [uploadingSessionId, setUploadingSessionId] = useState<string | null>(null);
   const [searchDraft, setSearchDraft] = useState<string>("");
   const [appliedSearch, setAppliedSearch] = useState<string>("");
+  const [modeFilter, setModeFilter] = useState<ModeFilter>("all");
+  const [uploadDialogSession, setUploadDialogSession] = useState<Session | null>(null);
+  const [selectedUploadFile, setSelectedUploadFile] = useState<File | null>(null);
+  const [uploadResult, setUploadResult] = useState<UploadResponse | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [duplicateKeys, setDuplicateKeys] = useState<DuplicateKey[]>([]);
 
   const sessionsQuery = useQuery({
     queryKey: ["sessions", appliedSearch],
     queryFn: () => fetchSessions(appliedSearch),
   });
 
+  const filteredSessions = useMemo(() => {
+    if (!sessionsQuery.data) {
+      return [];
+    }
+    if (modeFilter === "all") {
+      return sessionsQuery.data;
+    }
+    return sessionsQuery.data.filter((session) => session.data_mode === modeFilter);
+  }, [modeFilter, sessionsQuery.data]);
+
   const createSession = useMutation<Session, unknown, SessionFormState>({
     mutationFn: async (payload: SessionFormState) => {
       const { data } = await api.post<Session>("/sessions/", {
         title: payload.title,
         description: payload.description?.trim() ? payload.description.trim() : undefined,
+        data_mode: payload.data_mode,
       });
       return data;
     },
     onSuccess: () => {
-      setFormState({ title: "", description: "" });
+      setFormState({ title: "", description: "", data_mode: "base" });
       setStatus({ type: "success", text: "Session created successfully." });
       queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
@@ -109,23 +208,23 @@ export default function SessionsPage() {
   });
 
   const uploadMutation = useMutation<
-    unknown,
+    UploadResponse,
     unknown,
     UploadVariables,
-    { sessionTitle: string }
+    { sessionTitle: string; dataMode: DataMode }
   >({
     mutationFn: async ({ file, sessionId }: UploadVariables) => {
       const formData = new FormData();
       formData.append("file", file);
 
       try {
-        const { data } = await api.post(`/psi/${sessionId}/upload`, formData, {
+        const { data } = await api.post<UploadResponse>(`/psi/${sessionId}/upload`, formData, {
           headers: { "Content-Type": "multipart/form-data" },
         });
         return data;
       } catch (error) {
         if (axios.isAxiosError(error) && error.response?.status === 404) {
-          const { data } = await api.post("/psi/upload", formData, {
+          const { data } = await api.post<UploadResponse>("/psi/upload", formData, {
             params: sessionId ? { session_id: sessionId } : undefined,
             headers: { "Content-Type": "multipart/form-data" },
           });
@@ -134,23 +233,46 @@ export default function SessionsPage() {
         throw error;
       }
     },
-    onMutate: ({ sessionId, sessionTitle }: UploadVariables) => {
+    onMutate: ({ sessionId, sessionTitle, dataMode }: UploadVariables) => {
       setUploadStatus(null);
       setUploadingSessionId(sessionId);
-      return { sessionTitle };
+      setUploadResult(null);
+      setUploadError(null);
+      setDuplicateKeys([]);
+      return { sessionTitle, dataMode };
     },
-    onSuccess: (_data, _variables, context) => {
-      if (context?.sessionTitle) {
-        setUploadStatus({ type: "success", text: `Uploaded CSV for ${context.sessionTitle}.` });
-      } else {
-        setUploadStatus({ type: "success", text: "Upload completed." });
-      }
+    onSuccess: (data, _variables, context) => {
+      setUploadResult(data);
+      setUploadError(null);
+      setDuplicateKeys([]);
+      setSelectedUploadFile(null);
+      const title = context?.sessionTitle ?? "session";
+      const label = MODE_LABELS[data.mode];
+      setUploadStatus({ type: "success", text: `Uploaded ${data.rows} rows (${label}) for ${title}.` });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
     onError: (error) => {
-      setUploadStatus({
-        type: "error",
-        text: getErrorMessage(error, "Upload failed. Check the CSV file and try again."),
-      });
+      setUploadResult(null);
+      const detail = axios.isAxiosError(error)
+        ? (error.response?.data as { detail?: unknown } | undefined)?.detail
+        : undefined;
+      if (detail && typeof detail === "object" && !Array.isArray(detail) && "duplicates" in detail) {
+        const duplicates = Array.isArray((detail as { duplicates?: unknown }).duplicates)
+          ? ((detail as { duplicates: DuplicateKey[] }).duplicates ?? [])
+          : [];
+        const message =
+          typeof (detail as { message?: string }).message === "string"
+            ? (detail as { message: string }).message
+            : "Duplicate keys detected. Resolve the conflicts and try again.";
+        setDuplicateKeys(duplicates);
+        setUploadError(message);
+        setUploadStatus({ type: "error", text: message });
+        return;
+      }
+
+      const message = getErrorMessage(error, "Upload failed. Check the CSV file and try again.");
+      setUploadError(message);
+      setUploadStatus({ type: "error", text: message });
     },
     onSettled: () => {
       setUploadingSessionId(null);
@@ -163,15 +285,44 @@ export default function SessionsPage() {
     createSession.mutate({
       title: formState.title.trim(),
       description: formState.description,
+      data_mode: formState.data_mode,
     });
   };
 
-  const handleUploadForSession = (sessionId: string, sessionTitle: string, file: File | null) => {
-    if (!file) {
+  const handleDataModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value as DataMode;
+    setFormState((prev) => ({ ...prev, data_mode: value }));
+  };
+
+  const handleOpenUploadDialog = (session: Session) => {
+    setUploadDialogSession(session);
+    setSelectedUploadFile(null);
+    setUploadResult(null);
+    setUploadError(null);
+    setDuplicateKeys([]);
+  };
+
+  const handleUploadDialogClose = () => {
+    if (uploadMutation.isPending) {
       return;
     }
+    setUploadDialogSession(null);
+    setSelectedUploadFile(null);
+    setUploadResult(null);
+    setUploadError(null);
+    setDuplicateKeys([]);
+  };
 
-    uploadMutation.mutate({ file, sessionId, sessionTitle });
+  const handleUploadSubmit = () => {
+    if (!uploadDialogSession || !selectedUploadFile) {
+      return;
+    }
+    uploadMutation.mutate({
+      file: selectedUploadFile,
+      sessionId: uploadDialogSession.id,
+      sessionTitle: uploadDialogSession.title,
+      dataMode: uploadDialogSession.data_mode,
+    });
   };
 
   const handleOpenPsiTable = (sessionId: string) => {
@@ -218,6 +369,29 @@ export default function SessionsPage() {
               placeholder="Optional"
             />
           </label>
+          <fieldset className="data-mode-fieldset">
+            <legend>Data Mode</legend>
+            <label>
+              <input
+                type="radio"
+                name="data-mode"
+                value="base"
+                checked={formState.data_mode === "base"}
+                onChange={handleDataModeChange}
+              />
+              Base (daily PSI)
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="data-mode"
+                value="summary"
+                checked={formState.data_mode === "summary"}
+                onChange={handleDataModeChange}
+              />
+              Summary (aggregated)
+            </label>
+          </fieldset>
           <button type="submit" disabled={createSession.isPending}>
             {createSession.isPending ? "Saving..." : "Create"}
           </button>
@@ -226,28 +400,31 @@ export default function SessionsPage() {
 
       <section>
         <h2>Existing Sessions</h2>
-        <form className="search-form" onSubmit={handleApplySearch}>
-          <label>
-            Search
-            <input
-              type="search"
-              value={searchDraft}
-              onChange={(event) => setSearchDraft(event.target.value)}
-              placeholder="Title, description, or username"
-            />
-          </label>
-          <div className="search-actions">
-            <button type="submit">Search</button>
-            <button
-              type="button"
-              className="secondary"
-              onClick={handleResetSearch}
-              disabled={!searchDraft && !appliedSearch}
-            >
-              Reset
-            </button>
-          </div>
-        </form>
+        <div className="sessions-toolbar">
+          <form className="search-form" onSubmit={handleApplySearch}>
+            <label>
+              Search
+              <input
+                type="search"
+                value={searchDraft}
+                onChange={(event) => setSearchDraft(event.target.value)}
+                placeholder="Title, description, or username"
+              />
+            </label>
+            <div className="search-actions">
+              <button type="submit">Search</button>
+              <button
+                type="button"
+                className="secondary"
+                onClick={handleResetSearch}
+                disabled={!searchDraft && !appliedSearch}
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+          <ModeFilterControls value={modeFilter} onChange={setModeFilter} />
+        </div>
         {sessionsQuery.isLoading && <p>Loading sessions...</p>}
         {sessionsQuery.isError && (
           <p role="alert" className="error">
@@ -260,77 +437,91 @@ export default function SessionsPage() {
           </p>
         )}
         {sessionsQuery.data && sessionsQuery.data.length > 0 ? (
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Title</th>
-                <th>Description</th>
-                <th>Created By</th>
-                <th>Updated By</th>
-                <th>Leader</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sessionsQuery.data.map((session) => {
-                const isMakingLeader = makeLeader.isPending && makeLeader.variables === session.id;
-                const isDeleting = deleteSession.isPending && deleteSession.variables === session.id;
-                const isUploading = uploadMutation.isPending && uploadingSessionId === session.id;
+          filteredSessions.length > 0 ? (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Description</th>
+                  <th>Mode</th>
+                  <th>Created By</th>
+                  <th>Updated By</th>
+                  <th>Leader</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredSessions.map((session) => {
+                  const isMakingLeader = makeLeader.isPending && makeLeader.variables === session.id;
+                  const isDeleting = deleteSession.isPending && deleteSession.variables === session.id;
+                  const isUploading = uploadMutation.isPending && uploadingSessionId === session.id;
 
-                return (
-                  <tr key={session.id}>
-                    <td>
-                      <div className="session-title">
-                        <strong>{session.title}</strong>
+                  return (
+                    <tr key={session.id}>
+                      <td>
+                        <div className="session-title">
+                          <strong>{session.title}</strong>
+                          <button
+                            type="button"
+                            className="icon-button"
+                            onClick={() => handleOpenPsiTable(session.id)}
+                            aria-label={`Open PSI table for ${session.title}`}
+                          >
+                            ✏️
+                          </button>
+                        </div>
+                      </td>
+                      <td>{session.description || "—"}</td>
+                      <td>
+                        <ModeBadge mode={session.data_mode} />
+                      </td>
+                      <td>
+                        <div>{session.created_by_username ?? "—"}</div>
+                        <small>{new Date(session.created_at).toLocaleString()}</small>
+                      </td>
+                      <td>
+                        <div>{session.updated_by_username ?? "—"}</div>
+                        <small>{new Date(session.updated_at).toLocaleString()}</small>
+                      </td>
+                      <td>{session.is_leader ? "⭐" : ""}</td>
+                      <td className="actions">
                         <button
                           type="button"
-                          className="icon-button"
-                          onClick={() => handleOpenPsiTable(session.id)}
-                          aria-label={`Open PSI table for ${session.title}`}
+                          onClick={() => makeLeader.mutate(session.id)}
+                          disabled={session.is_leader || isMakingLeader}
                         >
-                          ✏️
+                          {session.is_leader
+                            ? "Leader"
+                            : isMakingLeader
+                            ? "Updating..."
+                            : "Make Leader"}
                         </button>
-                      </div>
-                    </td>
-                    <td>{session.description || "—"}</td>
-                    <td>
-                      <div>{session.created_by_username ?? "—"}</div>
-                      <small>{new Date(session.created_at).toLocaleString()}</small>
-                    </td>
-                    <td>
-                      <div>{session.updated_by_username ?? "—"}</div>
-                      <small>{new Date(session.updated_at).toLocaleString()}</small>
-                    </td>
-                    <td>{session.is_leader ? "⭐" : ""}</td>
-                    <td className="actions">
-                      <button
-                        type="button"
-                        onClick={() => makeLeader.mutate(session.id)}
-                        disabled={session.is_leader || isMakingLeader}
-                      >
-                        {session.is_leader
-                          ? "Leader"
-                          : isMakingLeader
-                          ? "Updating..."
-                          : "Make Leader"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => deleteSession.mutate(session.id)}
-                        disabled={isDeleting}
-                      >
-                        {isDeleting ? "Deleting..." : "Delete"}
-                      </button>
-                      <CSVUploadButton
-                        isUploading={isUploading}
-                        onFileSelected={(file) => handleUploadForSession(session.id, session.title, file)}
-                      />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                        <button
+                          type="button"
+                          onClick={() => deleteSession.mutate(session.id)}
+                          disabled={isDeleting}
+                        >
+                          {isDeleting ? "Deleting..." : "Delete"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleOpenUploadDialog(session)}
+                          disabled={isUploading}
+                          aria-label={`Upload CSV for ${session.title}`}
+                        >
+                          {isUploading
+                            ? "Uploading..."
+                            : `Upload CSV (${MODE_LABELS[session.data_mode]})`}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : (
+            !sessionsQuery.isLoading && <p>No sessions match the selected mode.</p>
+          )
         ) : (
           !sessionsQuery.isLoading && <p>No sessions yet.</p>
         )}
@@ -338,40 +529,214 @@ export default function SessionsPage() {
           <p className={uploadStatus.type === "error" ? "error" : "success"}>{uploadStatus.text}</p>
         )}
       </section>
+
+      {uploadDialogSession && (
+        <UploadDialog
+          session={uploadDialogSession}
+          onClose={handleUploadDialogClose}
+          selectedFile={selectedUploadFile}
+          onFileChange={setSelectedUploadFile}
+          onSubmit={handleUploadSubmit}
+          isUploading={uploadMutation.isPending}
+          error={uploadError}
+          result={uploadResult}
+          duplicateKeys={duplicateKeys}
+        />
+      )}
     </div>
   );
 }
 
-interface CSVUploadButtonProps {
-  onFileSelected: (file: File | null) => void;
-  isUploading: boolean;
+function ModeBadge({ mode }: { mode: DataMode }) {
+  return <span className={`mode-badge mode-badge--${mode}`}>{MODE_LABELS[mode]}</span>;
 }
 
-function CSVUploadButton({ onFileSelected, isUploading }: CSVUploadButtonProps) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
+function ModeFilterControls({ value, onChange }: { value: ModeFilter; onChange: (value: ModeFilter) => void }) {
+  return (
+    <div className="mode-filter" role="group" aria-label="Filter sessions by data mode">
+      {MODE_FILTERS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          className={value === option.value ? "active" : undefined}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
-  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+interface UploadDialogProps {
+  session: Session;
+  onClose: () => void;
+  selectedFile: File | null;
+  onFileChange: (file: File | null) => void;
+  onSubmit: () => void;
+  isUploading: boolean;
+  error: string | null;
+  result: UploadResponse | null;
+  duplicateKeys: DuplicateKey[];
+}
+
+function UploadDialog({
+  session,
+  onClose,
+  selectedFile,
+  onFileChange,
+  onSubmit,
+  isUploading,
+  error,
+  result,
+  duplicateKeys,
+}: UploadDialogProps) {
+  const requiredColumns = REQUIRED_COLUMNS[session.data_mode];
+  const aliasNotes = session.data_mode === "summary" ? SUMMARY_ALIAS_NOTES : [];
+  const warnings = result?.warnings ?? [];
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && !isUploading) {
+      onClose();
+    }
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0] ?? null;
-    onFileSelected(file);
+    onFileChange(file);
     event.target.value = "";
   };
 
-  const handleButtonClick = () => {
-    inputRef.current?.click();
-  };
-
   return (
-    <>
-      <input
-        type="file"
-        accept=".csv,text/csv"
-        className="visually-hidden"
-        ref={inputRef}
-        onChange={handleInputChange}
-      />
-      <button type="button" onClick={handleButtonClick} disabled={isUploading} aria-label="Upload CSV">
-        {isUploading ? "Uploading..." : "Upload CSV"}
-      </button>
-    </>
+    <div className="upload-dialog-backdrop" role="presentation" onClick={handleBackdropClick}>
+      <div
+        className="upload-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="upload-dialog-title"
+        aria-describedby="upload-dialog-description"
+      >
+        <header className="upload-dialog__header">
+          <div>
+            <h3 id="upload-dialog-title">Upload CSV for {session.title}</h3>
+            <p id="upload-dialog-description">{MODE_DESCRIPTIONS[session.data_mode]}</p>
+          </div>
+          <ModeBadge mode={session.data_mode} />
+        </header>
+        <form
+          className="upload-dialog__form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
+          <div className="upload-dialog__help">
+            <h4>Required columns</h4>
+            <RequiredColumnsList columns={requiredColumns} />
+            {aliasNotes.length > 0 && (
+              <div className="upload-dialog__aliases">
+                <p>Alias mappings:</p>
+                <ul>
+                  {aliasNotes.map((note) => (
+                    <li key={note}>{note}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <a
+              href={SAMPLE_LINKS[session.data_mode]}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="upload-dialog__sample"
+            >
+              Download sample CSV
+            </a>
+          </div>
+          <div className="upload-dialog__file">
+            <label className="upload-dialog__file-label">
+              <span>Select CSV file</span>
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={handleFileChange}
+                disabled={isUploading}
+              />
+            </label>
+            {selectedFile ? (
+              <p className="upload-dialog__file-name">{selectedFile.name}</p>
+            ) : (
+              <p className="upload-dialog__file-placeholder">No file selected.</p>
+            )}
+          </div>
+          {error && <p className="upload-dialog__status upload-dialog__status--error">{error}</p>}
+          {result && (
+            <div className="upload-dialog__result" aria-live="polite">
+              <h4>Upload summary</h4>
+              <p>
+                <strong>{result.rows}</strong> rows imported.
+              </p>
+              {result.dates.length > 0 && (
+                <p>Dates affected: {result.dates.join(", ")}</p>
+              )}
+              {warnings.length > 0 ? (
+                <div className="upload-dialog__warnings">
+                  <h5>Warnings</h5>
+                  <ul>
+                    {warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : (
+                <p className="upload-dialog__no-warnings">No warnings.</p>
+              )}
+            </div>
+          )}
+          {duplicateKeys.length > 0 && (
+            <div className="upload-dialog__duplicates">
+              <h4>Duplicate rows</h4>
+              <table>
+                <thead>
+                  <tr>
+                    <th>SKU</th>
+                    <th>Warehouse</th>
+                    <th>Channel</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {duplicateKeys.map((key) => (
+                    <tr key={`${key.sku_code}-${key.warehouse_name}-${key.channel}`}>
+                      <td>{key.sku_code}</td>
+                      <td>{key.warehouse_name}</td>
+                      <td>{key.channel}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          <footer className="upload-dialog__footer">
+            <button type="button" className="secondary" onClick={onClose} disabled={isUploading}>
+              Close
+            </button>
+            <button type="submit" disabled={!selectedFile || isUploading}>
+              {isUploading ? "Uploading..." : `Upload ${MODE_LABELS[session.data_mode]}`}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function RequiredColumnsList({ columns }: { columns: string[] }) {
+  return (
+    <ul className="upload-dialog__columns">
+      {columns.map((column) => (
+        <li key={column}>
+          <code>{column}</code>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,6 +3,8 @@ export interface Session {
   title: string;
   description?: string | null;
   is_leader: boolean;
+  data_mode: "base" | "summary";
+  data_type?: "base" | "summary";
   created_by: string | null;
   updated_by: string | null;
   created_at: string;
@@ -199,6 +201,16 @@ export interface TransferPlanLine {
 export interface TransferPlanWithLines {
   plan: TransferPlan;
   lines: TransferPlanLine[];
+}
+
+export interface UploadResponse {
+  ok: boolean;
+  mode: "base" | "summary";
+  rows: number;
+  rows_imported: number;
+  session_id: string;
+  dates: string[];
+  warnings: string[];
 }
 
 export interface PSIMetricDefinition {


### PR DESCRIPTION
## Summary
- add data mode selection to session creation, persist it immutably, and expose it in API responses
- split PSI CSV ingestion by session mode with summary-table writes, channel normalization, and duplicate detection
- enhance the sessions UI with mode badges and filters, mode-specific upload guidance, and new sample CSV assets

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e14a1c7444832e8d1876fd64d82809