### PR TITLE
Allow recommendations without date range for summary sessions

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -415,8 +415,8 @@ class TransferPlanRecommendRequest(BaseModel):
     """Payload describing the scope of a recommendation run."""
 
     session_id: UUID
-    start: date
-    end: date
+    start: date | None = None
+    end: date | None = None
     sku_codes: list[str] | None = None
     warehouses: list[str] | None = None
     channels: list[str] | None = None

--- a/frontend/src/hooks/useTransferPlans.ts
+++ b/frontend/src/hooks/useTransferPlans.ts
@@ -16,6 +16,13 @@ export interface MatrixQueryArgs {
   skuCodes?: string[];
 }
 
+export interface RecommendPlanArgs {
+  sessionId: string;
+  start?: string;
+  end?: string;
+  skuCodes?: string[];
+}
+
 export interface TransferPlanLineWrite {
   line_id?: string;
   plan_id?: string;
@@ -69,17 +76,22 @@ export const useMatrixQuery = (args: MatrixQueryArgs | null) =>
     enabled: Boolean(args?.sessionId && args?.start && args?.end),
   });
 
-const recommendPlan = async (
-  payload: Omit<MatrixQueryArgs, "planId"> & {
-    skuCodes?: string[];
-  },
-): Promise<TransferPlanRecommendResponse> => {
-  const body = {
+const recommendPlan = async (payload: RecommendPlanArgs): Promise<TransferPlanRecommendResponse> => {
+  const body: {
+    session_id: string;
+    start?: string;
+    end?: string;
+    sku_codes?: string[];
+  } = {
     session_id: payload.sessionId,
-    start: payload.start,
-    end: payload.end,
     sku_codes: payload.skuCodes,
   };
+  if (payload.start) {
+    body.start = payload.start;
+  }
+  if (payload.end) {
+    body.end = payload.end;
+  }
   const { data } = await api.post<TransferPlanRecommendResponse>(
     "/api/transfer-plans/recommend",
     body,


### PR DESCRIPTION
## Summary
- allow transfer plan recommendations to accept optional date ranges by adding summary matrix support on the backend
- default summary-session plans to the snapshot date while keeping base sessions strict about start/end inputs
- update the reallocation UI and hooks so summary sessions can create and load plans without entering dates

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e159d6c2bc832eb5914aa1d733f2d7