### PR TITLE
Add pagination and shared SKU search to reallocation plan lines

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -342,6 +342,57 @@ body {
   gap: 0.75rem;
 }
 
+.reallocation-page .reallocation-filter-section {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border-subtle, #d1d5db);
+  border-radius: 0.75rem;
+  background: var(--surface-panel, #f9fafb);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reallocation-page .reallocation-filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.reallocation-page .reallocation-filter-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.reallocation-page .reallocation-filter-toggle {
+  border: none;
+  background: transparent;
+  color: var(--accent-primary, #2563eb);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease;
+}
+
+.reallocation-page .reallocation-filter-toggle:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.reallocation-page .reallocation-filter-toggle:focus-visible {
+  outline: 2px solid var(--accent-primary, #2563eb);
+  outline-offset: 2px;
+}
+
+.reallocation-page .reallocation-filter-section.collapsed {
+  gap: 0.5rem;
+}
+
+.reallocation-page .reallocation-filter-section.collapsed .reallocation-filter-form {
+  display: none;
+}
+
 .reallocation-page .reallocation-filter-form {
   display: grid;
   gap: 1.25rem;
@@ -385,6 +436,46 @@ body {
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+}
+
+.reallocation-page .plan-lines-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.reallocation-page .plan-lines-count {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary, var(--text-primary));
+}
+
+.reallocation-page .plan-lines-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reallocation-page .plan-lines-pagination button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-default, #d1d5db);
+  background: var(--surface-panel, #f9fafb);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.reallocation-page .plan-lines-pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reallocation-page .plan-lines-pagination span {
+  font-size: 0.9rem;
+  color: var(--text-subtle, #6b7280);
 }
 
 .reallocation-page .reallocation-filter-status {
@@ -626,6 +717,16 @@ body {
   padding: 0.35rem 0.5rem;
   border-radius: 0.375rem;
   border: 1px solid var(--border-subtle, #d1d5db);
+}
+
+.reallocation-page .plan-lines-section th:first-child,
+.reallocation-page .plan-lines-section td:first-child {
+  min-width: 140px;
+  white-space: nowrap;
+}
+
+.reallocation-page .plan-lines-section td:first-child input {
+  min-width: 140px;
 }
 
 .action-buttons {

--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -37,9 +37,18 @@ interface PSIMatrixTabsProps {
   skuList: string[];
   initialSkuIndex?: number;
   onSkuChange?: (index: number) => void;
+  skuSearch?: string;
+  onSkuSearchChange?: (value: string) => void;
 }
 
-export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: PSIMatrixTabsProps) {
+export function PSIMatrixTabs({
+  data,
+  skuList,
+  initialSkuIndex,
+  onSkuChange,
+  skuSearch,
+  onSkuSearchChange,
+}: PSIMatrixTabsProps) {
   const normalizedSkuList = useMemo(() => {
     if (skuList.length > 0) {
       return skuList;
@@ -64,7 +73,18 @@ export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: P
     const nextIndex = initialSkuIndex ?? 0;
     return Math.min(Math.max(nextIndex, 0), normalizedSkuList.length - 1);
   });
-  const [skuSearch, setSkuSearch] = useState("");
+  const [internalSkuSearch, setInternalSkuSearch] = useState("");
+  const isSkuSearchControlled = typeof skuSearch === "string";
+  const skuSearchValue = isSkuSearchControlled ? skuSearch : internalSkuSearch;
+
+  const handleSkuSearchChange = (value: string) => {
+    if (onSkuSearchChange) {
+      onSkuSearchChange(value);
+    }
+    if (!isSkuSearchControlled) {
+      setInternalSkuSearch(value);
+    }
+  };
 
   const skuMetadataMap = useMemo(() => {
     const map = new Map<string, SkuMetadata>();
@@ -99,7 +119,7 @@ export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: P
     return map;
   }, [data]);
 
-  const normalizedSkuSearch = skuSearch.trim().toLowerCase();
+  const normalizedSkuSearch = skuSearchValue.trim().toLowerCase();
 
   const filteredSkuList = useMemo(() => {
     if (!normalizedSkuSearch) {
@@ -235,9 +255,9 @@ export function PSIMatrixTabs({ data, skuList, initialSkuIndex, onSkuChange }: P
               <span>SKU検索</span>
               <input
                 type="search"
-                value={skuSearch}
+                value={skuSearchValue}
                 placeholder="SKUコード・名称を検索"
-                onChange={(event) => setSkuSearch(event.target.value)}
+                onChange={(event) => handleSkuSearchChange(event.target.value)}
               />
             </label>
             <div className="sku-navigation-summary">


### PR DESCRIPTION
## Summary
- make the reallocation page session/plan controls collapsible so the filters can be hidden when not in use
- reuse the PSI matrix SKU search for transfer plan lines, showing results sorted by SKU with five-line pagination and improved CSV export ordering
- update styles to prevent SKU codes from clipping and to support the new toolbar and pagination controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15ff2c570832e8bcd4689c3e4b131