### PR TITLE
Refine reallocation matrix search layout and styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -816,6 +816,23 @@ body {
   outline-offset: 1px;
 }
 
+.reallocation-page .plan-lines-section .data-table {
+  font-size: 0.9em;
+}
+
+.reallocation-page .plan-lines-section .data-table th {
+  font-size: 0.95em;
+}
+
+.reallocation-page .plan-lines-section .data-table td {
+  font-size: 0.9em;
+}
+
+.reallocation-page .plan-lines-section .data-table input,
+.reallocation-page .plan-lines-section .data-table select {
+  font-size: 0.9em;
+}
+
 .table-container {
   border: 1px solid var(--border-subtle, #d1d5db);
   border-radius: 0.75rem;

--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -34,7 +34,6 @@ type SkuSuggestion = {
 
 const MIN_SEARCH_LENGTH = 3;
 const MAX_SUGGESTION_RESULTS = 8;
-const MAX_RECENT_SKUS = 6;
 
 const copySkuCode = async (code: string) => {
   if (!code || typeof navigator === "undefined" || !navigator.clipboard) {
@@ -94,7 +93,6 @@ export function PSIMatrixTabs({
     return Math.min(Math.max(nextIndex, 0), normalizedSkuList.length - 1);
   });
   const [internalSkuSearch, setInternalSkuSearch] = useState("");
-  const [recentSkus, setRecentSkus] = useState<string[]>([]);
   const isSkuSearchControlled = typeof skuSearch === "string";
   const skuSearchValue = isSkuSearchControlled ? skuSearch : internalSkuSearch;
   const [isSuggestionsVisible, setSuggestionsVisible] = useState(false);
@@ -293,16 +291,6 @@ export function PSIMatrixTabs({
   const skuPositionLabel = safeSkuIndex === -1 ? "0 / 0" : `${safeSkuIndex + 1} / ${filteredSkuList.length}`;
 
   useEffect(() => {
-    if (!currentSku) {
-      return;
-    }
-    setRecentSkus((prev) => {
-      const next = [currentSku, ...prev.filter((item) => item !== currentSku)];
-      return next.slice(0, MAX_RECENT_SKUS);
-    });
-  }, [currentSku]);
-
-  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
         return;
@@ -385,37 +373,20 @@ export function PSIMatrixTabs({
       <div className="psi-matrix-toolbar">
         <div className="sku-navigation" role="region" aria-label="SKU navigation">
           <div className="sku-navigation-card">
-            <div className="sku-navigation-search-area">
-              <label className="sku-navigation-search">
-                <span>SKU検索</span>
-                <input
-                  type="search"
-                  value={skuSearchValue}
-                  placeholder="SKUコード・名称・カテゴリを検索"
-                  onChange={(event) => handleSkuSearchChange(event.target.value)}
-                  onFocus={() => setSuggestionsVisible(true)}
-                  onBlur={() => {
-                    // Delay hiding suggestions slightly to allow click handlers to run.
-                    setTimeout(() => setSuggestionsVisible(false), 120);
-                  }}
-                  aria-label="SKUコード・名称・カテゴリを検索"
-                />
-              </label>
-              {recentSkus.length > 0 && (
-                <div className="sku-recent-pills" aria-label="最近検索したSKU">
-                  {recentSkus.map((skuCode) => (
-                    <button
-                      key={skuCode}
-                      type="button"
-                      className="sku-recent-pill"
-                      onClick={() => setSkuIndexByCode(skuCode)}
-                      aria-label={`SKU ${skuCode} を表示`}
-                    >
-                      {skuCode}
-                    </button>
-                  ))}
-                </div>
-              )}
+            <div className="sku-search-row">
+              <input
+                type="search"
+                value={skuSearchValue}
+                placeholder="SKUコード・名称・カテゴリを検索"
+                onChange={(event) => handleSkuSearchChange(event.target.value)}
+                onFocus={() => setSuggestionsVisible(true)}
+                onBlur={() => {
+                  // Delay hiding suggestions slightly to allow click handlers to run.
+                  setTimeout(() => setSuggestionsVisible(false), 120);
+                }}
+                aria-label="SKUコード・名称・カテゴリを検索"
+                className="sku-search-input"
+              />
               {isSuggestionsVisible && skuSuggestions.length > 0 && (
                 <div className="sku-search-suggestions" role="listbox">
                   {skuSuggestions.map((suggestion) => (
@@ -434,45 +405,49 @@ export function PSIMatrixTabs({
                 </div>
               )}
             </div>
-            <div className="sku-navigation-summary">
-              <div className="sku-navigation-header">
-                <div className="sku-navigation-title" role="status" aria-live="polite">
-                  <span className="sku-code-badge" aria-label="SKUコード">
-                    <code>{currentSku ?? "—"}</code>
-                    {currentSku && (
-                      <button
-                        type="button"
-                        className="sku-copy-button"
-                        onClick={() => copySkuCode(currentSku)}
-                        aria-label={`${currentSku} をコピー`}
-                      >
-                        📋
-                      </button>
-                    )}
-                  </span>
-                  <span className="sku-title-text">{skuNameDisplay}</span>
-                </div>
-                <span className="sku-navigation-meta">{skuPositionLabel}</span>
+            <div className="sku-summary-row">
+              <div className="sku-summary-info" role="status" aria-live="polite">
+                <span className="sku-code-badge" aria-label="SKUコード">
+                  <code>{currentSku ?? "—"}</code>
+                  {currentSku && (
+                    <button
+                      type="button"
+                      className="sku-copy-button"
+                      onClick={() => copySkuCode(currentSku)}
+                      aria-label={`${currentSku} をコピー`}
+                    >
+                      📋
+                    </button>
+                  )}
+                </span>
+                <span className="sku-summary-text">
+                  <span className="sku-name-text">{skuNameDisplay}</span>
+                  {categoryLabel !== "—" && (
+                    <span className="sku-category-text">• {categoryLabel}</span>
+                  )}
+                </span>
               </div>
-              <div className="sku-navigation-categories">{categoryLabel}</div>
-            </div>
-            <div className="sku-navigation-actions">
-              <button
-                type="button"
-                onClick={handlePrevSku}
-                disabled={safeSkuIndex <= 0}
-                aria-label="前のSKUを表示"
-              >
-                ‹ 前のSKU
-              </button>
-              <button
-                type="button"
-                onClick={handleNextSku}
-                disabled={safeSkuIndex === -1 || safeSkuIndex >= filteredSkuList.length - 1}
-                aria-label="次のSKUを表示"
-              >
-                次のSKU ›
-              </button>
+              <div className="sku-navigation-actions">
+                <button
+                  type="button"
+                  onClick={handlePrevSku}
+                  disabled={safeSkuIndex <= 0}
+                  aria-label="前のSKUを表示"
+                >
+                  ‹ 前のSKU
+                </button>
+                <span className="sku-position" aria-live="polite">
+                  {skuPositionLabel}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleNextSku}
+                  disabled={safeSkuIndex === -1 || safeSkuIndex >= filteredSkuList.length - 1}
+                  aria-label="次のSKUを表示"
+                >
+                  次のSKU ›
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -139,24 +139,18 @@ export default function CrossTableView({ rows, metrics, orientation = "warehouse
       return <span className="psi-matrix-value value-neutral">-</span>;
     }
     const className = `psi-matrix-value ${getValueClassName(value)}`;
-    const icon = value > 0 ? "▲" : value < 0 ? "▼" : "◆";
     return (
       <span className={className}>
-        <span aria-hidden className="value-icon">
-          {icon}
-        </span>
-        <span className="value-number">{formatMetricValue(value)}</span>
+        <span className="value-number">{formatMetricValue(Math.abs(value))}</span>
       </span>
     );
   };
 
   const renderTotalValue = (value: number) => {
     const className = `psi-matrix-value ${getValueClassName(value)}`;
-    const icon = value > 0 ? "▲" : value < 0 ? "▼" : "◆";
     return (
       <span className={className}>
-        <span aria-hidden className="value-icon">{icon}</span>
-        <span className="value-number">{formatMetricValue(value)}</span>
+        <span className="value-number">{formatMetricValue(Math.abs(value))}</span>
       </span>
     );
   };

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -11,7 +11,7 @@
 .psi-matrix-toolbar {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 0.75rem;
 }
 
 .psi-matrix-tabs .sku-navigation {
@@ -20,65 +20,36 @@
 
 .psi-matrix-tabs .sku-navigation-card {
   display: grid;
-  gap: 1rem;
-  padding: 1.25rem;
+  gap: 0.6rem;
+  padding: 0.75rem 0.9rem;
   border-radius: 0.75rem;
   border: 1px solid var(--border-default);
   background: var(--surface-panel-soft, rgba(226, 232, 240, 0.35));
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+  line-height: 1.2;
 }
 
-.psi-matrix-tabs .sku-navigation-search-area {
+.psi-matrix-tabs .sku-search-row {
   position: relative;
-  display: grid;
-  gap: 0.5rem;
 }
 
-.psi-matrix-tabs .sku-navigation-search {
-  display: grid;
-  gap: 0.3rem;
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-}
-
-.psi-matrix-tabs .sku-navigation-search input {
+.psi-matrix-tabs .sku-search-input {
+  width: 100%;
   background: var(--surface-input);
   border: 1px solid var(--border-input);
-  border-radius: 0.65rem;
-  padding: 0.55rem 0.75rem;
+  border-radius: 0.6rem;
+  padding: 0.5rem 0.75rem;
   color: var(--text-primary);
-  min-width: min(100%, 32rem);
+  min-width: min(100%, 30rem);
   max-width: 100%;
   font-size: 0.95rem;
+  line-height: 1.2;
 }
 
-.psi-matrix-tabs .sku-navigation-search input:focus {
+.psi-matrix-tabs .sku-search-input:focus {
   outline: 2px solid var(--border-focus);
   outline-offset: 1px;
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
-}
-
-.psi-matrix-tabs .sku-recent-pills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.psi-matrix-tabs .sku-recent-pill {
-  border: 1px solid var(--border-default);
-  border-radius: 999px;
-  padding: 0.25rem 0.65rem;
-  background: rgba(59, 130, 246, 0.08);
-  color: var(--accent-blue, #2563eb);
-  font-weight: 600;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.psi-matrix-tabs .sku-recent-pill:focus-visible {
-  outline: 2px solid var(--accent-blue, #2563eb);
-  outline-offset: 2px;
 }
 
 .psi-matrix-tabs .sku-search-suggestions {
@@ -127,34 +98,6 @@
   font-size: 0.85rem;
 }
 
-.psi-matrix-tabs .sku-navigation-summary {
-  display: grid;
-  gap: 0.5rem;
-  justify-items: center;
-  text-align: center;
-}
-
-.psi-matrix-tabs .sku-navigation-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 0.65rem;
-}
-
-.psi-matrix-tabs .sku-navigation-title {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  font-weight: 600;
-  font-size: 1.1rem;
-  color: var(--text-primary);
-}
-
-.psi-matrix-tabs .sku-title-text {
-  font-weight: 600;
-}
-
 .psi-matrix-tabs .sku-code-badge {
   display: inline-flex;
   align-items: center;
@@ -179,27 +122,54 @@
   font-size: 0.95rem;
 }
 
-.psi-matrix-tabs .sku-navigation-meta {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
+.psi-matrix-tabs .sku-summary-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-.psi-matrix-tabs .sku-navigation-categories {
-  font-size: 0.9rem;
+.psi-matrix-tabs .sku-summary-info {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 1.5rem;
+}
+
+.psi-matrix-tabs .sku-summary-text {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.psi-matrix-tabs .sku-name-text {
+  font-weight: 600;
+}
+
+.psi-matrix-tabs .sku-category-text {
+  font-size: 0.85rem;
   color: var(--text-secondary);
+  font-weight: 500;
 }
 
 .psi-matrix-tabs .sku-navigation-actions {
   display: flex;
-  gap: 0.75rem;
-  justify-content: center;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .psi-matrix-tabs .sku-navigation-actions button {
   background: linear-gradient(180deg, rgba(59, 130, 246, 0.16), rgba(59, 130, 246, 0.05));
   border: 1px solid rgba(59, 130, 246, 0.4);
   border-radius: 999px;
-  padding: 0.45rem 0.9rem;
+  padding: 0.35rem 0.8rem;
   color: var(--accent-blue, #1d4ed8);
   cursor: pointer;
   font-weight: 600;
@@ -216,18 +186,28 @@
   cursor: not-allowed;
 }
 
+.psi-matrix-tabs .sku-position {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 960px) {
   .psi-matrix-tabs .sku-navigation-card {
-    padding: 1rem;
+    padding: 0.75rem;
   }
 
-  .psi-matrix-tabs .sku-navigation-search input {
-    min-width: min(100%, 20rem);
+  .psi-matrix-tabs .sku-search-input {
+    min-width: min(100%, 18rem);
   }
 
-  .psi-matrix-tabs .sku-navigation-summary {
-    justify-items: start;
-    text-align: left;
+  .psi-matrix-tabs .sku-summary-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.6rem;
+  }
+
+  .psi-matrix-tabs .sku-navigation-actions {
+    justify-content: space-between;
   }
 }
 
@@ -367,12 +347,7 @@
 .psi-matrix-value {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
   font-weight: 600;
-}
-
-.psi-matrix-value .value-icon {
-  font-size: 0.85rem;
 }
 
 .psi-matrix-value.value-positive {


### PR DESCRIPTION
## Summary
- simplify the PSI matrix SKU navigation panel with a compact two-row layout and persistent navigation controls
- adjust PSI cross table cells to show absolute values with color-coded emphasis only
- reduce the Transfer Plan table typography for denser presentation

## Testing
- npm --prefix frontend install
- npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1c8e933c4832ea78bcf95310702a2