### PR TITLE
Improve PSI matrix presentation and transfer plan guidance

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -881,6 +881,11 @@ body {
   min-width: 140px;
 }
 
+.reallocation-page .plan-lines-section th:nth-child(2),
+.reallocation-page .plan-lines-section td:nth-child(2) {
+  min-width: 11rem;
+}
+
 .action-buttons {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -133,27 +133,34 @@ export default function CrossTableView({ rows, metrics, orientation = "warehouse
     return label;
   };
 
-  const renderValue = (metricKey: MetricDefinition["key"], columnKey: string) => {
-    const value = getMetricValue(rowMap.get(columnKey), metricKey);
+  const renderNumberCell = (value: number | null) => {
     if (value === null) {
       return <span className="psi-matrix-value value-neutral">-</span>;
     }
     const className = `psi-matrix-value ${getValueClassName(value)}`;
+    const isNegative = value < 0;
+    const formatted = formatMetricValue(Math.abs(value));
     return (
       <span className={className}>
-        <span className="value-number">{formatMetricValue(Math.abs(value))}</span>
+        {isNegative ? (
+          <>
+            <span className="visually-hidden">マイナス</span>
+            <span aria-hidden="true" className="value-prefix">
+              ➖
+            </span>
+          </>
+        ) : null}
+        <span className="value-number">{formatted}</span>
       </span>
     );
   };
 
-  const renderTotalValue = (value: number) => {
-    const className = `psi-matrix-value ${getValueClassName(value)}`;
-    return (
-      <span className={className}>
-        <span className="value-number">{formatMetricValue(Math.abs(value))}</span>
-      </span>
-    );
+  const renderValue = (metricKey: MetricDefinition["key"], columnKey: string) => {
+    const value = getMetricValue(rowMap.get(columnKey), metricKey);
+    return renderNumberCell(value);
   };
+
+  const renderTotalValue = (value: number) => renderNumberCell(value);
 
   return (
     <div className="psi-matrix-scroll">

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -227,6 +227,24 @@ const BASE_REASON_OPTIONS = [
   "fill main channel (inter main)",
 ];
 
+const REASON_TOOLTIPS: Record<string, string> = {
+  "Manual adjustment": "担当者による手動調整です。緊急や例外対応のために在庫を移動します。",
+  "Demand spike": "需要急増に対応するための補充です。販売機会の損失を避けます。",
+  "Inventory balancing": "在庫偏りを是正し、各チャネルの在庫水準を均一化します。",
+  "Seasonal allocation": "季節要因に合わせて在庫配分を見直します。",
+  "fill main channel (intra)": "同一倉庫内でメインチャネルを優先的に満たします。",
+  "fill main channel (inter non-main)": "他倉庫の非メインチャネルからメインチャネルへ在庫を補填します。",
+  "fill main channel (inter main)": "他倉庫のメインチャネルからメインチャネルへ在庫を融通します。",
+};
+
+const getReasonTooltip = (reason: string) => {
+  const trimmed = reason.trim();
+  if (!trimmed) {
+    return "理由を選択してください。";
+  }
+  return REASON_TOOLTIPS[trimmed] ?? "ユーザーが追加したカスタム理由です。";
+};
+
 const formatRelativeTimeFromNow = (value: string) => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -1374,6 +1392,8 @@ export default function ReallocationPage() {
                       const toChannelOptions = ensureOption(toChannelBase, line.to_channel);
                       const errors = lineErrorMap.get(line.line_id) ?? {};
                       const isSelected = selectedLineIds.includes(line.line_id);
+                      const reasonTooltip = getReasonTooltip(line.reason);
+                      const reasonDescriptionId = `reason-tooltip-${line.line_id}`;
 
                       return (
                         <tr key={line.line_id} className={isSelected ? "line-selected" : undefined}>
@@ -1510,14 +1530,24 @@ export default function ReallocationPage() {
                               onChange={(event) =>
                                 handleLineChange(line.line_id, { reason: event.target.value })
                               }
+                              title={reasonTooltip}
+                              aria-describedby={reasonDescriptionId}
                             >
-                              <option value="">理由を選択</option>
-                              {reasonOptions.map((option) => (
-                                <option key={option} value={option}>
-                                  {option}
-                                </option>
-                              ))}
+                              <option value="" title={getReasonTooltip("")}>
+                                理由を選択
+                              </option>
+                              {reasonOptions.map((option) => {
+                                const optionTooltip = getReasonTooltip(option);
+                                return (
+                                  <option key={option} value={option} title={optionTooltip}>
+                                    {option}
+                                  </option>
+                                );
+                              })}
                             </select>
+                            <span id={reasonDescriptionId} className="visually-hidden">
+                              {reasonTooltip}
+                            </span>
                           </td>
                           <td>
                             <button

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -350,6 +350,12 @@
   font-weight: 600;
 }
 
+.psi-matrix-value .value-prefix {
+  margin-right: 0.2rem;
+  font-size: 0.85em;
+  line-height: 1;
+}
+
 .psi-matrix-value.value-positive {
   color: var(--accent-green, #16a34a);
 }


### PR DESCRIPTION
## Summary
- show negative PSI matrix values with a red ➖ prefix and expose metric totals
- widen the transfer plan SKU column and surface Japanese tooltips for each reason option

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e1cde2d6b0832ea404548687ed9e41