### PR TITLE
Adjust PSI matrix total column width and negative indicator

### DIFF
--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -146,7 +146,7 @@ export default function CrossTableView({ rows, metrics, orientation = "warehouse
           <>
             <span className="visually-hidden">マイナス</span>
             <span aria-hidden="true" className="value-prefix">
-              ➖
+              🔺
             </span>
           </>
         ) : null}

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -325,7 +325,9 @@
   background: var(--surface-table-header-highlight, var(--surface-table-header));
   font-weight: 700;
   text-align: right;
-  min-width: 120px;
+  width: calc(6ch + 1.2rem);
+  min-width: calc(6ch + 1.2rem);
+  max-width: calc(6ch + 1.2rem);
 }
 
 .psi-matrix-table .total-cell {
@@ -334,6 +336,9 @@
   z-index: 1;
   font-weight: 600;
   background: var(--surface-table-total, rgba(59, 130, 246, 0.08));
+  width: calc(6ch + 1.2rem);
+  min-width: calc(6ch + 1.2rem);
+  max-width: calc(6ch + 1.2rem);
 }
 
 .psi-matrix-table tbody th {
@@ -354,6 +359,7 @@
   margin-right: 0.2rem;
   font-size: 0.85em;
   line-height: 1;
+  color: currentColor;
 }
 
 .psi-matrix-value.value-positive {


### PR DESCRIPTION
## Summary
- fix the PSI matrix total column width to a compact 6-character layout
- replace the minus symbol with a red triangle indicator that inherits the negative value color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d2dbf940832eb1d95d75592db6ce