### PR TITLE
Implement session dataset editor and SKU-aware manual line

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -127,6 +127,9 @@ class Settings(BaseModel):
     expose_audit_fields: bool = Field(
         default_factory=lambda: _env_flag("EXPOSE_AUDIT_FIELDS", default=False)
     )
+    session_editable_tables_raw: str = Field(
+        default_factory=lambda: os.getenv("SESSION_EDITABLE_TABLES", "psi_base")
+    )
 
     @field_validator("database_url", mode="before")
     @classmethod
@@ -174,6 +177,16 @@ class Settings(BaseModel):
             return default_origins
 
         return origins
+
+    @property
+    def session_editable_tables(self) -> list[str]:
+        """Return the list of session-scoped tables that can be edited."""
+
+        raw = self.session_editable_tables_raw.strip()
+        if not raw:
+            return ["psi_base"]
+        tables = [part.strip() for part in raw.split(",") if part.strip()]
+        return tables or ["psi_base"]
 
     @property
     def csrf_header(self) -> str:

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -2,11 +2,29 @@
 """Session related API routes."""
 from __future__ import annotations
 
-from typing import Optional
+import csv
+import io
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy import func, or_, select, update
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi.responses import StreamingResponse
+from sqlalchemy import and_, delete, func, or_, select, text, tuple_, update
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import (
     Session as DBSession,
     aliased,
@@ -17,8 +35,376 @@ from sqlalchemy.orm import (
 from .. import models, schemas
 from ..config import settings
 from ..deps import get_current_user, get_db
+from ..services.cache import invalidate_reallocation_cache
 
 router = APIRouter()
+
+
+NUMERIC_ZERO_DEFAULT = {
+    "stock_at_anchor",
+    "inbound_qty",
+    "outbound_qty",
+    "net_flow",
+    "stock_closing",
+    "safety_stock",
+    "movable_stock",
+}
+
+
+@dataclass(frozen=True)
+class DatasetDefinition:
+    """Describe an editable dataset scoped to a session."""
+
+    name: str
+    label: str
+    description: str
+    model: type[models.PSIBase]
+    primary_key: tuple[str, ...]
+    columns: tuple[str, ...]
+    editable_columns: tuple[str, ...]
+    numeric_columns: tuple[str, ...]
+    date_columns: tuple[str, ...]
+    read_only_columns: tuple[str, ...]
+    default_order: tuple[str, ...]
+
+
+PSI_BASE_COLUMNS: tuple[str, ...] = (
+    "session_id",
+    "sku_code",
+    "sku_name",
+    "category_1",
+    "category_2",
+    "category_3",
+    "fw_rank",
+    "ss_rank",
+    "warehouse_name",
+    "channel",
+    "date",
+    "stock_at_anchor",
+    "inbound_qty",
+    "outbound_qty",
+    "net_flow",
+    "stock_closing",
+    "safety_stock",
+    "movable_stock",
+    "stdstock",
+    "gap",
+)
+
+PSI_BASE_EDITABLE_COLUMNS: tuple[str, ...] = (
+    "sku_name",
+    "category_1",
+    "category_2",
+    "category_3",
+    "fw_rank",
+    "ss_rank",
+    "stock_at_anchor",
+    "inbound_qty",
+    "outbound_qty",
+    "safety_stock",
+    "movable_stock",
+)
+
+PSI_BASE_NUMERIC_COLUMNS: tuple[str, ...] = (
+    "stock_at_anchor",
+    "inbound_qty",
+    "outbound_qty",
+    "net_flow",
+    "stock_closing",
+    "safety_stock",
+    "movable_stock",
+    "stdstock",
+    "gap",
+)
+
+PSI_BASE_DATE_COLUMNS: tuple[str, ...] = ("date",)
+
+PSI_BASE_READ_ONLY_COLUMNS: tuple[str, ...] = (
+    "net_flow",
+    "stock_closing",
+    "stdstock",
+    "gap",
+)
+
+PSI_BASE_PRIMARY_KEY: tuple[str, ...] = (
+    "session_id",
+    "sku_code",
+    "warehouse_name",
+    "channel",
+    "date",
+)
+
+PSI_BASE_DEFAULT_ORDER: tuple[str, ...] = (
+    "date",
+    "sku_code",
+    "warehouse_name",
+    "channel",
+)
+
+DATASET_DEFINITIONS: dict[str, DatasetDefinition] = {
+    "psi_base": DatasetDefinition(
+        name="psi_base",
+        label="PSI Base",
+        description="Daily PSI base data scoped to a session.",
+        model=models.PSIBase,
+        primary_key=PSI_BASE_PRIMARY_KEY,
+        columns=PSI_BASE_COLUMNS,
+        editable_columns=PSI_BASE_EDITABLE_COLUMNS,
+        numeric_columns=PSI_BASE_NUMERIC_COLUMNS,
+        date_columns=PSI_BASE_DATE_COLUMNS,
+        read_only_columns=PSI_BASE_READ_ONLY_COLUMNS,
+        default_order=PSI_BASE_DEFAULT_ORDER,
+    ),
+}
+
+
+COLUMN_LABELS: dict[str, dict[str, str]] = {
+    "psi_base": {
+        "session_id": "Session ID",
+        "sku_code": "SKU",
+        "sku_name": "SKU name",
+        "category_1": "Category 1",
+        "category_2": "Category 2",
+        "category_3": "Category 3",
+        "fw_rank": "FW rank",
+        "ss_rank": "SS rank",
+        "warehouse_name": "Warehouse",
+        "channel": "Channel",
+        "date": "Date",
+        "stock_at_anchor": "Stock at anchor",
+        "inbound_qty": "Inbound qty",
+        "outbound_qty": "Outbound qty",
+        "net_flow": "Net flow",
+        "stock_closing": "Stock closing",
+        "safety_stock": "Safety stock",
+        "movable_stock": "Movable stock",
+        "stdstock": "Std stock",
+        "gap": "Gap",
+    }
+}
+
+
+@dataclass
+class RowValidationError:
+    row: int
+    field: str
+    message: str
+
+
+def _dataset_definition_or_404(name: str) -> DatasetDefinition:
+    allowed = {table.lower() for table in settings.session_editable_tables}
+    if name.lower() not in allowed:
+        raise HTTPException(status_code=404, detail="dataset not enabled")
+    definition = DATASET_DEFINITIONS.get(name)
+    if not definition:
+        raise HTTPException(status_code=404, detail="dataset not found")
+    return definition
+
+
+def _build_dataset_metadata(definition: DatasetDefinition) -> schemas.SessionDatasetMetadata:
+    labels = COLUMN_LABELS.get(definition.name, {})
+    columns: list[schemas.DatasetColumnMetadata] = []
+    for column in definition.columns:
+        column_type: Literal["string", "number", "date"]
+        if column in definition.numeric_columns:
+            column_type = "number"
+        elif column in definition.date_columns:
+            column_type = "date"
+        else:
+            column_type = "string"
+        columns.append(
+            schemas.DatasetColumnMetadata(
+                name=column,
+                label=labels.get(column, column.replace("_", " ").title()),
+                type=column_type,
+                editable=column in definition.editable_columns,
+                required=column in definition.primary_key,
+                max_length=2 if column in {"fw_rank", "ss_rank"} else None,
+            )
+        )
+    return schemas.SessionDatasetMetadata(
+        name=definition.name,
+        label=definition.label,
+        description=definition.description,
+        primary_key=list(definition.primary_key),
+        columns=columns,
+        read_only_columns=list(definition.read_only_columns),
+        numeric_columns=list(definition.numeric_columns),
+        date_columns=list(definition.date_columns),
+    )
+
+
+def _normalize_decimal(value: Any, column: str, *, errors: list[RowValidationError], row_index: int) -> Decimal | None:
+    if value is None:
+        return Decimal("0") if column in NUMERIC_ZERO_DEFAULT else None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return Decimal("0") if column in NUMERIC_ZERO_DEFAULT else None
+        try:
+            return Decimal(stripped)
+        except InvalidOperation:
+            errors.append(RowValidationError(row=row_index, field=column, message="must be a numeric value"))
+            return None
+    errors.append(RowValidationError(row=row_index, field=column, message="unsupported numeric type"))
+    return None
+
+
+def _normalize_date(value: Any, column: str, *, errors: list[RowValidationError], row_index: int) -> date | None:
+    if value is None:
+        errors.append(RowValidationError(row=row_index, field=column, message="date is required"))
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        try:
+            parsed = datetime.strptime(value.strip(), "%Y-%m-%d").date()
+            return parsed
+        except ValueError:
+            errors.append(RowValidationError(row=row_index, field=column, message="must use YYYY-MM-DD"))
+            return None
+    errors.append(RowValidationError(row=row_index, field=column, message="unsupported date type"))
+    return None
+
+
+def _ensure_session_exists(db: DBSession, session_id: UUID) -> models.Session:
+    session = db.get(models.Session, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    return session
+
+
+def _raise_validation_errors(errors: Iterable[RowValidationError]) -> None:
+    collected = list(errors)
+    if not collected:
+        return
+    detail = {
+        "message": "Validation failed",
+        "errors": [
+            {"row": error.row, "field": error.field, "message": error.message}
+            for error in collected
+        ],
+    }
+    raise HTTPException(status_code=400, detail=detail)
+
+
+def _parse_filters(raw_filters: str | None) -> dict[str, Any]:
+    if not raw_filters:
+        return {}
+    try:
+        parsed = json.loads(raw_filters)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+        raise HTTPException(status_code=400, detail="filters must be a JSON object") from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=400, detail="filters must be a JSON object")
+    return parsed
+
+
+def _serialize_psibase(row: models.PSIBase) -> schemas.PSIBaseRecord:
+    return schemas.PSIBaseRecord(
+        session_id=row.session_id,
+        sku_code=row.sku_code,
+        sku_name=row.sku_name,
+        category_1=row.category_1,
+        category_2=row.category_2,
+        category_3=row.category_3,
+        fw_rank=row.fw_rank,
+        ss_rank=row.ss_rank,
+        warehouse_name=row.warehouse_name,
+        channel=row.channel,
+        date=row.date,
+        stock_at_anchor=row.stock_at_anchor,
+        inbound_qty=row.inbound_qty,
+        outbound_qty=row.outbound_qty,
+        net_flow=row.net_flow,
+        stock_closing=row.stock_closing,
+        safety_stock=row.safety_stock,
+        movable_stock=row.movable_stock,
+        stdstock=row.stdstock,
+        gap=row.gap,
+        updated_at=None,
+        updated_by=None,
+        updated_by_username=None,
+    )
+
+
+def _format_csv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    return str(value)
+
+
+def _parse_filter_date_value(value: Any, key: str) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.strptime(value.strip(), "%Y-%m-%d").date()
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"filters.{key} must use YYYY-MM-DD format",
+            ) from exc
+    raise HTTPException(status_code=400, detail=f"filters.{key} must be a string")
+
+
+def _build_psibase_conditions(session_id: UUID, filter_values: dict[str, Any]) -> list[Any]:
+    conditions: list[Any] = [models.PSIBase.session_id == session_id]
+
+    sku_code = filter_values.get("sku_code")
+    if isinstance(sku_code, str) and sku_code.strip():
+        lowered = f"%{sku_code.strip().lower()}%"
+        conditions.append(func.lower(models.PSIBase.sku_code).like(lowered))
+
+    warehouse_name = filter_values.get("warehouse_name")
+    if isinstance(warehouse_name, str) and warehouse_name.strip():
+        lowered = f"%{warehouse_name.strip().lower()}%"
+        conditions.append(func.lower(models.PSIBase.warehouse_name).like(lowered))
+
+    channel = filter_values.get("channel")
+    if isinstance(channel, str) and channel.strip():
+        lowered = f"%{channel.strip().lower()}%"
+        conditions.append(func.lower(models.PSIBase.channel).like(lowered))
+
+    fw_rank = filter_values.get("fw_rank")
+    if isinstance(fw_rank, str) and fw_rank.strip():
+        conditions.append(func.lower(models.PSIBase.fw_rank).like(f"%{fw_rank.strip().lower()}%"))
+
+    ss_rank = filter_values.get("ss_rank")
+    if isinstance(ss_rank, str) and ss_rank.strip():
+        conditions.append(func.lower(models.PSIBase.ss_rank).like(f"%{ss_rank.strip().lower()}%"))
+
+    exact_date = _parse_filter_date_value(filter_values.get("date"), "date")
+    if exact_date is not None:
+        conditions.append(models.PSIBase.date == exact_date)
+
+    start_date = _parse_filter_date_value(
+        filter_values.get("date_start") or filter_values.get("start"),
+        "date_start",
+    )
+    if start_date is not None:
+        conditions.append(models.PSIBase.date >= start_date)
+
+    end_date = _parse_filter_date_value(
+        filter_values.get("date_end") or filter_values.get("end"),
+        "date_end",
+    )
+    if end_date is not None:
+        conditions.append(models.PSIBase.date <= end_date)
+
+    return conditions
 
 # ---- collection（/sessions と /sessions/ の両方を許容） ----
 @router.get(
@@ -125,6 +511,501 @@ def _get_session_or_404(db: DBSession, session_id: UUID) -> models.Session:
     if session is None:
         raise HTTPException(status_code=404, detail="session not found")
     return session
+
+
+@router.get(
+    "/{session_id}/datasets",
+    response_model=list[schemas.SessionDatasetMetadata],
+    response_model_exclude_none=True,
+)
+def list_session_datasets(
+    session_id: UUID,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> list[schemas.SessionDatasetMetadata]:
+    """Return the datasets available for editing within the session."""
+
+    _ = current_user
+    _ensure_session_exists(db, session_id)
+
+    metadata: list[schemas.SessionDatasetMetadata] = []
+    for table in settings.session_editable_tables:
+        key = table.lower()
+        definition = DATASET_DEFINITIONS.get(key)
+        if not definition:
+            continue
+        metadata.append(_build_dataset_metadata(definition))
+    return metadata
+
+
+@router.get(
+    "/{session_id}/psi_base",
+    response_model=schemas.PSIBasePage,
+    response_model_exclude_none=True,
+)
+def list_session_psi_base(
+    session_id: UUID,
+    filters: str | None = Query(default=None, description="JSON encoded filter object"),
+    page: int = Query(1, ge=1),
+    size: int = Query(100, ge=1, le=500),
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.PSIBasePage:
+    """Return paginated psi_base rows scoped to the session."""
+
+    _ = current_user
+    definition = _dataset_definition_or_404("psi_base")
+    _ensure_session_exists(db, session_id)
+
+    filter_values = _parse_filters(filters)
+    conditions = _build_psibase_conditions(session_id, filter_values)
+
+    base_query = select(models.PSIBase).where(and_(*conditions))
+    order_columns = [getattr(models.PSIBase, column) for column in definition.default_order]
+    query = base_query.order_by(*order_columns)
+
+    total = db.scalar(select(func.count()).select_from(base_query.subquery())) or 0
+
+    offset = (page - 1) * size
+    rows = db.scalars(query.offset(offset).limit(size)).all()
+
+    return schemas.PSIBasePage(
+        page=page,
+        size=size,
+        total=total,
+        rows=[_serialize_psibase(row) for row in rows],
+    )
+
+
+@router.patch(
+    "/{session_id}/psi_base",
+    response_model=dict[str, int],
+)
+def patch_session_psi_base(
+    session_id: UUID,
+    payload: schemas.PSIBasePatchRequest,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict[str, int]:
+    """Apply bulk updates to psi_base rows."""
+
+    _ = current_user
+    definition = _dataset_definition_or_404("psi_base")
+    _ensure_session_exists(db, session_id)
+
+    if not payload.rows:
+        return {"updated": 0}
+
+    validation_errors: list[RowValidationError] = []
+    updates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+    for index, row in enumerate(payload.rows, start=1):
+        if row.session_id != session_id:
+            validation_errors.append(
+                RowValidationError(row=index, field="session_id", message="session mismatch"),
+            )
+
+        key_data = {
+            field: getattr(row, field)
+            for field in definition.primary_key
+        }
+        for field_name, value in key_data.items():
+            if value is None or (isinstance(value, str) and not value.strip()):
+                validation_errors.append(
+                    RowValidationError(row=index, field=field_name, message="is required"),
+                )
+
+        row_dict = row.model_dump(exclude_unset=True)
+
+        for read_only in definition.read_only_columns:
+            if read_only in row_dict and row_dict[read_only] is not None:
+                validation_errors.append(
+                    RowValidationError(row=index, field=read_only, message="field is read-only"),
+                )
+
+        update_data: dict[str, Any] = {}
+        for column in definition.editable_columns:
+            if column not in row_dict:
+                continue
+            value = row_dict[column]
+            if column in definition.numeric_columns:
+                normalized = _normalize_decimal(value, column, errors=validation_errors, row_index=index)
+            else:
+                if isinstance(value, str):
+                    normalized = value.strip() or None
+                else:
+                    normalized = value
+                if column in {"fw_rank", "ss_rank"} and normalized:
+                    value_str = str(normalized)
+                    if len(value_str) > 2:
+                        validation_errors.append(
+                            RowValidationError(
+                                row=index,
+                                field=column,
+                                message="must be at most 2 characters",
+                            ),
+                        )
+            update_data[column] = normalized
+
+        updates.append((key_data, update_data))
+
+    _raise_validation_errors(validation_errors)
+
+    updated = 0
+    post_validation: list[RowValidationError] = []
+
+    for index, (key_data, update_values) in enumerate(updates, start=1):
+        if not update_values:
+            continue
+        stmt = (
+            update(models.PSIBase)
+            .where(
+                models.PSIBase.session_id == key_data["session_id"],
+                models.PSIBase.sku_code == key_data["sku_code"],
+                models.PSIBase.warehouse_name == key_data["warehouse_name"],
+                models.PSIBase.channel == key_data["channel"],
+                models.PSIBase.date == key_data["date"],
+            )
+            .values(**update_values)
+        )
+        result = db.execute(stmt)
+        if result.rowcount == 0:
+            post_validation.append(
+                RowValidationError(row=index, field="key", message="record not found"),
+            )
+        else:
+            updated += int(result.rowcount)
+
+    if post_validation:
+        db.rollback()
+        _raise_validation_errors(post_validation)
+
+    db.commit()
+    if updated:
+        invalidate_reallocation_cache(session_id)
+
+    return {"updated": updated}
+
+
+@router.delete(
+    "/{session_id}/psi_base",
+    response_model=dict[str, int],
+)
+def delete_session_psi_base(
+    session_id: UUID,
+    payload: schemas.PSIBaseDeleteRequest,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict[str, int]:
+    """Delete psi_base rows in bulk."""
+
+    _ = current_user
+    _dataset_definition_or_404("psi_base")
+    _ensure_session_exists(db, session_id)
+
+    if not payload.rows:
+        return {"deleted": 0}
+
+    errors: list[RowValidationError] = []
+    keys: list[dict[str, Any]] = []
+
+    for index, row in enumerate(payload.rows, start=1):
+        if row.session_id != session_id:
+            errors.append(RowValidationError(row=index, field="session_id", message="session mismatch"))
+        key_data = {
+            "session_id": row.session_id,
+            "sku_code": row.sku_code,
+            "warehouse_name": row.warehouse_name,
+            "channel": row.channel,
+            "date": row.date,
+        }
+        for field_name, value in key_data.items():
+            if value is None or (isinstance(value, str) and not value.strip()):
+                errors.append(RowValidationError(row=index, field=field_name, message="is required"))
+        keys.append(key_data)
+
+    _raise_validation_errors(errors)
+
+    deleted = 0
+    missing: list[RowValidationError] = []
+
+    for index, key_data in enumerate(keys, start=1):
+        stmt = (
+            delete(models.PSIBase)
+            .where(
+                models.PSIBase.session_id == key_data["session_id"],
+                models.PSIBase.sku_code == key_data["sku_code"],
+                models.PSIBase.warehouse_name == key_data["warehouse_name"],
+                models.PSIBase.channel == key_data["channel"],
+                models.PSIBase.date == key_data["date"],
+            )
+            .execution_options(synchronize_session=False)
+        )
+        result = db.execute(stmt)
+        if result.rowcount == 0:
+            missing.append(RowValidationError(row=index, field="key", message="record not found"))
+        else:
+            deleted += int(result.rowcount)
+
+    if missing:
+        db.rollback()
+        _raise_validation_errors(missing)
+
+    db.commit()
+    if deleted:
+        invalidate_reallocation_cache(session_id)
+
+    return {"deleted": deleted}
+
+
+@router.get(
+    "/{session_id}/psi_base/export",
+    response_class=StreamingResponse,
+)
+def export_session_psi_base(
+    session_id: UUID,
+    filters: str | None = Query(default=None, description="JSON encoded filter object"),
+    all: bool = Query(default=False, description="Export all matching rows"),
+    page: int = Query(1, ge=1),
+    size: int = Query(100, ge=1, le=1000),
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> StreamingResponse:
+    """Stream psi_base rows as CSV."""
+
+    _ = current_user
+    definition = _dataset_definition_or_404("psi_base")
+    _ensure_session_exists(db, session_id)
+
+    filter_values = _parse_filters(filters)
+    conditions = _build_psibase_conditions(session_id, filter_values)
+
+    query = select(models.PSIBase).where(and_(*conditions))
+    order_columns = [getattr(models.PSIBase, column) for column in definition.default_order]
+    query = query.order_by(*order_columns)
+
+    if not all:
+        offset = (page - 1) * size
+        query = query.offset(offset).limit(size)
+
+    rows = db.scalars(query).all()
+    columns = definition.columns
+
+    def row_iterator():
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(columns)
+        yield buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+        for row in rows:
+            writer.writerow([_format_csv_value(getattr(row, column)) for column in columns])
+            yield buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+    filename = f"psi_base_{session_id}.csv"
+    response = StreamingResponse(row_iterator(), media_type="text/csv")
+    response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+    return response
+
+
+@router.get(
+    "/{session_id}/psi_base/template",
+    response_class=StreamingResponse,
+)
+def download_psi_base_template(
+    session_id: UUID,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> StreamingResponse:
+    """Provide a CSV template for psi_base uploads."""
+
+    _ = current_user
+    definition = _dataset_definition_or_404("psi_base")
+    _ensure_session_exists(db, session_id)
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(definition.columns)
+    sample_row = []
+    for column in definition.columns:
+        if column == "session_id":
+            sample_row.append(str(session_id))
+        elif column in definition.date_columns:
+            sample_row.append("YYYY-MM-DD")
+        elif column in definition.numeric_columns:
+            sample_row.append("0")
+        else:
+            sample_row.append(column.upper())
+    writer.writerow(sample_row)
+    output.seek(0)
+
+    response = StreamingResponse(iter([output.getvalue()]), media_type="text/csv")
+    response.headers["Content-Disposition"] = f"attachment; filename=psi_base_template_{session_id}.csv"
+    return response
+
+
+@router.post(
+    "/{session_id}/psi_base/import",
+    response_model=schemas.PSIBaseImportResponse,
+)
+async def import_session_psi_base(
+    session_id: UUID,
+    file: UploadFile = File(...),
+    mode: str = Query("replace", pattern="^(replace|upsert)$"),
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.PSIBaseImportResponse:
+    """Import psi_base rows from a CSV upload."""
+
+    _ = current_user
+    definition = _dataset_definition_or_404("psi_base")
+    _ensure_session_exists(db, session_id)
+
+    content = await file.read()
+    try:
+        text_data = content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail="Uploaded file must be UTF-8 encoded") from exc
+
+    reader = csv.DictReader(io.StringIO(text_data))
+    header = reader.fieldnames or []
+    expected_columns = set(definition.columns)
+    unknown_columns = [column for column in header if column not in expected_columns]
+    if unknown_columns:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "Unknown columns in CSV", "columns": unknown_columns},
+        )
+
+    missing_columns = [column for column in definition.primary_key if column not in header]
+    if missing_columns:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "Missing required columns", "columns": missing_columns},
+        )
+
+    rows_to_import: list[dict[str, Any]] = []
+    errors: list[RowValidationError] = []
+    seen_keys: set[tuple[Any, ...]] = set()
+
+    for index, raw_row in enumerate(reader, start=2):
+        row_dict = {key: raw_row.get(key) for key in header}
+        row_errors: list[RowValidationError] = []
+
+        for field in definition.primary_key:
+            value = row_dict.get(field)
+            if value is None or not str(value).strip():
+                row_errors.append(RowValidationError(row=index, field=field, message="is required"))
+
+        if row_dict.get("session_id") not in {None, ""} and str(row_dict.get("session_id")).strip() != str(session_id):
+            row_errors.append(RowValidationError(row=index, field="session_id", message="session mismatch"))
+
+        normalized_row: dict[str, Any] = {column: None for column in definition.columns}
+        normalized_row["session_id"] = session_id
+
+        for column in definition.columns:
+            raw_value = row_dict.get(column)
+            if column == "session_id":
+                continue
+            if column in definition.numeric_columns:
+                normalized_value = _normalize_decimal(raw_value, column, errors=row_errors, row_index=index)
+            elif column in definition.date_columns:
+                normalized_value = _normalize_date(
+                    raw_value, column, errors=row_errors, row_index=index
+                )
+            else:
+                normalized_value = raw_value.strip() if isinstance(raw_value, str) else raw_value
+                if isinstance(normalized_value, str):
+                    normalized_value = normalized_value or None
+                if column in {"fw_rank", "ss_rank"} and normalized_value and len(str(normalized_value)) > 2:
+                    row_errors.append(
+                        RowValidationError(row=index, field=column, message="must be at most 2 characters"),
+                    )
+            normalized_row[column] = normalized_value
+
+        key_tuple = tuple(
+            normalized_row[field] if field != "session_id" else session_id
+            for field in definition.primary_key
+        )
+        if key_tuple in seen_keys:
+            row_errors.append(RowValidationError(row=index, field="key", message="duplicate row in file"))
+        else:
+            seen_keys.add(key_tuple)
+
+        if row_errors:
+            errors.extend(row_errors)
+            continue
+
+        rows_to_import.append(normalized_row)
+
+    _raise_validation_errors(errors)
+
+    if not rows_to_import:
+        return schemas.PSIBaseImportResponse(added=0, updated=0, deleted=0, warnings=[])
+
+    mode_normalized = mode.lower()
+    added = 0
+    updated = 0
+    deleted = 0
+
+    if mode_normalized == "replace":
+        existing_count = db.scalar(
+            select(func.count()).where(models.PSIBase.session_id == session_id)
+        ) or 0
+        db.execute(delete(models.PSIBase).where(models.PSIBase.session_id == session_id))
+        db.execute(insert(models.PSIBase), rows_to_import)
+        deleted = int(existing_count)
+        added = len(rows_to_import)
+    else:  # upsert
+        key_expr = tuple_(
+            models.PSIBase.session_id,
+            models.PSIBase.sku_code,
+            models.PSIBase.warehouse_name,
+            models.PSIBase.channel,
+            models.PSIBase.date,
+        )
+        key_values = [
+            (
+                session_id,
+                row["sku_code"],
+                row["warehouse_name"],
+                row["channel"],
+                row["date"],
+            )
+            for row in rows_to_import
+        ]
+        existing_keys: set[tuple[Any, ...]] = set()
+        if key_values:
+            existing_keys = {
+                tuple(row)
+                for row in db.execute(
+                    select(key_expr).where(
+                        models.PSIBase.session_id == session_id,
+                        key_expr.in_(key_values),
+                    )
+                )
+            }
+        added = len(rows_to_import)
+        updated = len(existing_keys)
+        if updated:
+            added -= updated
+        insert_stmt = insert(models.PSIBase).values(rows_to_import)
+        update_columns = {
+            column: getattr(insert_stmt.excluded, column)
+            for column in definition.editable_columns
+        }
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=list(definition.primary_key),
+            set_=update_columns,
+        )
+        db.execute(upsert_stmt)
+
+    db.commit()
+    invalidate_reallocation_cache(session_id)
+
+    return schemas.PSIBaseImportResponse(added=added, updated=updated, deleted=deleted, warnings=[])
 
 
 @router.get(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -59,6 +59,31 @@ class SessionRead(SessionBase):
     model_config = {"from_attributes": True}
 
 
+class DatasetColumnMetadata(BaseModel):
+    """Describe a single column within an editable dataset."""
+
+    name: str
+    label: str
+    type: Literal["string", "number", "date"] = "string"
+    editable: bool = True
+    required: bool = False
+    max_length: int | None = None
+    description: str | None = None
+
+
+class SessionDatasetMetadata(BaseModel):
+    """Metadata describing a dataset that can be edited per session."""
+
+    name: str
+    label: str
+    description: str | None = None
+    primary_key: list[str]
+    columns: list[DatasetColumnMetadata]
+    read_only_columns: list[str] = Field(default_factory=list)
+    numeric_columns: list[str] = Field(default_factory=list)
+    date_columns: list[str] = Field(default_factory=list)
+
+
 class DailyPSI(BaseModel):
     """Aggregated PSI metrics for a single day."""
 
@@ -153,6 +178,102 @@ class PSIEditRead(BaseModel):
     updated_by_username: str | None = None
 
     model_config = {"from_attributes": True}
+
+
+class PSIBaseRecord(BaseModel):
+    """Row within the ``psi_base`` table scoped to a session."""
+
+    session_id: UUID
+    sku_code: str
+    sku_name: str | None = None
+    category_1: str | None = None
+    category_2: str | None = None
+    category_3: str | None = None
+    fw_rank: str | None = None
+    ss_rank: str | None = None
+    warehouse_name: str
+    channel: str
+    date: date
+    stock_at_anchor: Decimal | None = None
+    inbound_qty: Decimal | None = None
+    outbound_qty: Decimal | None = None
+    net_flow: Decimal | None = None
+    stock_closing: Decimal | None = None
+    safety_stock: Decimal | None = None
+    movable_stock: Decimal | None = None
+    stdstock: Decimal | None = None
+    gap: Decimal | None = None
+    updated_at: datetime | None = None
+    updated_by: UUID | None = None
+    updated_by_username: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PSIBasePage(BaseModel):
+    """Paginated result set for ``psi_base`` rows."""
+
+    page: int
+    size: int
+    total: int
+    rows: list[PSIBaseRecord]
+
+
+class PSIBasePatchRow(BaseModel):
+    """Payload describing updates for ``psi_base`` rows."""
+
+    session_id: UUID
+    sku_code: str
+    warehouse_name: str
+    channel: str
+    date: date
+    sku_name: str | None = None
+    category_1: str | None = None
+    category_2: str | None = None
+    category_3: str | None = None
+    fw_rank: str | None = Field(default=None, max_length=2)
+    ss_rank: str | None = Field(default=None, max_length=2)
+    stock_at_anchor: Decimal | None = None
+    inbound_qty: Decimal | None = None
+    outbound_qty: Decimal | None = None
+    net_flow: Decimal | None = None
+    stock_closing: Decimal | None = None
+    safety_stock: Decimal | None = None
+    movable_stock: Decimal | None = None
+    stdstock: Decimal | None = None
+    gap: Decimal | None = None
+    updated_at: datetime | None = None
+
+
+class PSIBasePatchRequest(BaseModel):
+    """Bulk patch request body."""
+
+    rows: list[PSIBasePatchRow]
+
+
+class PSIBaseDeleteRow(BaseModel):
+    """Key identifying a ``psi_base`` record to delete."""
+
+    session_id: UUID
+    sku_code: str
+    warehouse_name: str
+    channel: str
+    date: date
+
+
+class PSIBaseDeleteRequest(BaseModel):
+    """Bulk delete request body."""
+
+    rows: list[PSIBaseDeleteRow]
+
+
+class PSIBaseImportResponse(BaseModel):
+    """Summary returned after importing ``psi_base`` rows."""
+
+    added: int
+    updated: int
+    deleted: int
+    warnings: list[str] = Field(default_factory=list)
 
 
 class PSISessionSummary(BaseModel):

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -1,0 +1,19 @@
+"""Utilities for cache invalidation hooks."""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+def invalidate_reallocation_cache(session_id: UUID) -> None:
+    """Invalidate any cached reallocation artefacts for the session.
+
+    The real integration point for cache invalidation lives in a separate service.
+    For now this helper simply logs the request so the call sites remain stable
+    when wiring the final implementation.
+    """
+
+    logger.info("Reallocation cache invalidation requested", extra={"session_id": str(session_id)})

--- a/backend/tests/test_sessions_api.py
+++ b/backend/tests/test_sessions_api.py
@@ -2,19 +2,32 @@
 from __future__ import annotations
 
 import asyncio
+import csv
 import json
 import os
 import sys
 import uuid
+from decimal import Decimal
+from functools import lru_cache
+from io import BytesIO, StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import urlencode
 
 import pytest
+from fastapi import HTTPException, UploadFile
+from sqlalchemy import select
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@lru_cache(maxsize=1)
+def _get_sessions_router():
+    from backend.app.routers import sessions as sessions_router
+
+    return sessions_router
 
 
 def _perform_request(
@@ -148,10 +161,12 @@ def app_env(tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
     assert settings.db_schema == ""
 
     with engine.begin() as connection:
+        models.PSIBase.__table__.drop(bind=connection, checkfirst=True)
         models.Session.__table__.drop(bind=connection, checkfirst=True)
         models.User.__table__.drop(bind=connection, checkfirst=True)
         models.User.__table__.create(bind=connection, checkfirst=True)
         models.Session.__table__.create(bind=connection, checkfirst=True)
+        models.PSIBase.__table__.create(bind=connection, checkfirst=True)
 
     asyncio.run(app.router.startup())
 
@@ -168,6 +183,7 @@ def app_env(tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
 @pytest.fixture(autouse=True)
 def clear_database(app_env: SimpleNamespace) -> None:
     with app_env.engine.begin() as connection:
+        connection.execute(app_env.models.PSIBase.__table__.delete())
         connection.execute(app_env.models.Session.__table__.delete())
         connection.execute(app_env.models.User.__table__.delete())
     yield
@@ -363,3 +379,105 @@ def test_list_sessions_supports_search(
     )
     assert status == 200
     assert [item["title"] for item in by_username] == ["Gamma"]
+
+
+def _create_csv_payload(session_id: uuid.UUID, *, date_value: str = "2024-01-01") -> bytes:
+    definition = _get_sessions_router().DATASET_DEFINITIONS["psi_base"]
+    row = {column: "" for column in definition.columns}
+    row.update(
+        {
+            "session_id": str(session_id),
+            "sku_code": "SKU-001",
+            "sku_name": "Widget",
+            "warehouse_name": "Main",
+            "channel": "ONLINE",
+            "date": date_value,
+            "stock_at_anchor": "5",
+            "inbound_qty": "3",
+            "outbound_qty": "2",
+            "safety_stock": "4",
+            "movable_stock": "1",
+        }
+    )
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(definition.columns)
+    writer.writerow([row[column] for column in definition.columns])
+    return buffer.getvalue().encode("utf-8")
+
+
+def _invoke_import(
+    session_id: uuid.UUID,
+    csv_bytes: bytes,
+    *,
+    app_env: SimpleNamespace,
+    current_user,
+) -> object:
+    router = _get_sessions_router()
+    upload = UploadFile(filename="psi_base.csv", file=BytesIO(csv_bytes))
+    upload.file.seek(0)
+    with app_env.SessionLocal() as db_session:
+        return asyncio.run(
+            router.import_session_psi_base(
+                session_id=session_id,
+                file=upload,
+                mode="replace",
+                db=db_session,
+                current_user=current_user,
+            )
+        )
+
+
+def test_import_psi_base_blank_numeric_defaults_to_zero(
+    app_env: SimpleNamespace, auth_user
+) -> None:
+    status, _, created = _perform_json_request(
+        app_env.app, "POST", "/sessions", {"title": "Import"}
+    )
+    assert status == 201
+    session_id = uuid.UUID(created["id"])
+
+    response = _invoke_import(
+        session_id,
+        _create_csv_payload(session_id),
+        app_env=app_env,
+        current_user=auth_user,
+    )
+    assert response.added == 1
+    assert response.updated == 0
+    assert response.deleted == 0
+
+    with app_env.SessionLocal() as check_session:
+        stored = check_session.scalars(select(app_env.models.PSIBase)).one()
+        assert stored.net_flow == Decimal("0")
+        assert stored.stock_closing == Decimal("0")
+
+
+def test_import_psi_base_invalid_date_reports_row_error(
+    app_env: SimpleNamespace, auth_user
+) -> None:
+    status, _, created = _perform_json_request(
+        app_env.app, "POST", "/sessions", {"title": "Import"}
+    )
+    assert status == 201
+    session_id = uuid.UUID(created["id"])
+
+    invalid_csv = _create_csv_payload(session_id, date_value="20240101")
+
+    with pytest.raises(HTTPException) as exc_info:
+        _invoke_import(
+            session_id,
+            invalid_csv,
+            app_env=app_env,
+            current_user=auth_user,
+        )
+
+    error = exc_info.value
+    assert error.status_code == 400
+    assert error.detail["message"] == "Validation failed"
+    assert error.detail["errors"] == [
+        {"row": 2, "field": "date", "message": "must use YYYY-MM-DD"}
+    ]
+
+    with app_env.SessionLocal() as check_session:
+        assert check_session.scalars(select(app_env.models.PSIBase)).first() is None

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -310,6 +310,230 @@ body {
   color: #b91c1c;
 }
 
+.card {
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 200px;
+}
+
+.form-field input,
+.form-field select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.dataset-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dataset-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  background-color: #f8fafc;
+}
+
+.dataset-option input {
+  margin-right: 0.5rem;
+}
+
+.dataset-label {
+  font-weight: 600;
+}
+
+.dataset-description {
+  color: #475569;
+  font-size: 0.875rem;
+}
+
+.tab-header {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-header button {
+  border: none;
+  background-color: #e2e8f0;
+  color: #0f172a;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.tab-header button.active {
+  background-color: #0f172a;
+  color: #ffffff;
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filter-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filter-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.filter-grid input {
+  width: 100%;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.table-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.table-toolbar-left {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.table-toolbar-right {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.table-wrapper {
+  border: 1px solid #dbe0f0;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.data-table input {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 4px;
+}
+
+.select-column {
+  width: 60px;
+}
+
+.row-edited {
+  background-color: #fef9c3;
+}
+
+.pagination {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.pagination button {
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #cbd5f5;
+  background-color: #f1f5f9;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.csv-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.csv-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.import-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+}
+
+.import-summary {
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  padding: 1rem;
+  background-color: #f8fafc;
+}
+
+.import-summary ul {
+  margin: 0.5rem 0 0 1rem;
+}
+
+.radio {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .reallocation-page .table-wrapper {
   margin-top: 0.5rem;
   overflow-x: auto;
@@ -341,6 +565,18 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.reallocation-page .current-sku-display {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.reallocation-page .current-sku-display code {
+  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background-color: #e2e8f0;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
 }
 
 .reallocation-page .save-indicator {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,6 +100,12 @@ function ProtectedLayout() {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/edits" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              <span className="menu-icon" aria-hidden="true">✏️</span>
+              <span className="menu-label">Edits</span>
+            </NavLink>
+          </li>
+          <li>
             <NavLink to="/test-algo" className={({ isActive }) => (isActive ? "active" : undefined)}>
               <span className="menu-icon" aria-hidden="true">🧪</span>
               <span className="menu-label">Test_Algo</span>

--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -56,6 +56,7 @@ interface PSIMatrixTabsProps {
   skuList: string[];
   initialSkuIndex?: number;
   onSkuChange?: (index: number) => void;
+  onSkuCodeChange?: (code: string | null) => void;
   skuSearch?: string;
   onSkuSearchChange?: (value: string) => void;
 }
@@ -65,6 +66,7 @@ export function PSIMatrixTabs({
   skuList,
   initialSkuIndex,
   onSkuChange,
+  onSkuCodeChange,
   skuSearch,
   onSkuSearchChange,
 }: PSIMatrixTabsProps) {
@@ -269,6 +271,16 @@ export function PSIMatrixTabs({
       onSkuChange(originalIndex);
     }
   }, [filteredSkuList, normalizedSkuList, onSkuChange, skuIndex]);
+
+  useEffect(() => {
+    if (onSkuCodeChange) {
+      const currentSkuCode =
+        filteredSkuList.length > 0
+          ? filteredSkuList[Math.min(Math.max(skuIndex, 0), filteredSkuList.length - 1)]
+          : null;
+      onSkuCodeChange(currentSkuCode);
+    }
+  }, [filteredSkuList, onSkuCodeChange, skuIndex]);
 
   const safeSkuIndex =
     filteredSkuList.length === 0 ? -1 : Math.min(Math.max(skuIndex, 0), filteredSkuList.length - 1);

--- a/frontend/src/pages/EditsPage.tsx
+++ b/frontend/src/pages/EditsPage.tsx
@@ -1,33 +1,67 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import {
+  ChangeEvent,
+  FormEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
 import api from "../lib/api";
 import { useSessionsQuery } from "../hooks/usePsiQueries";
-import type { PSIEditRecord } from "../types";
-
-interface FilterState {
-  sku_code: string;
-  warehouse_name: string;
-  updated_at: string;
-  username: string;
-}
+import type {
+  PsiBaseImportResponse,
+  PsiBasePage,
+  PsiBaseRecord,
+  Session,
+  SessionDatasetMetadata,
+} from "../types";
 
 type StatusMessage = { type: "success" | "error"; text: string };
 
-const getTodayIso = () => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
+interface PsiBaseFilters {
+  sku_code: string;
+  warehouse_name: string;
+  channel: string;
+  fw_rank: string;
+  ss_rank: string;
+  date_start: string;
+  date_end: string;
+}
+
+const defaultFilters = (): PsiBaseFilters => ({
+  sku_code: "",
+  warehouse_name: "",
+  channel: "",
+  fw_rank: "",
+  ss_rank: "",
+  date_start: "",
+  date_end: "",
+});
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+
+const ROW_KEY_DELIMITER = "\u0000";
+
+const makeRowKey = (row: Pick<PsiBaseRecord, "sku_code" | "warehouse_name" | "channel" | "date">) =>
+  [row.sku_code, row.warehouse_name, row.channel, row.date].join(
+    ROW_KEY_DELIMITER,
+  );
 
 const getErrorMessage = (error: unknown, fallback: string) => {
   if (axios.isAxiosError(error)) {
-    const detail = (error.response?.data as { detail?: string } | undefined)?.detail;
-    if (detail) {
-      return detail;
+    const detailPayload = (error.response?.data as { detail?: unknown } | undefined)?.detail;
+    if (typeof detailPayload === "string" && detailPayload.trim().length > 0) {
+      return detailPayload;
+    }
+    if (
+      detailPayload &&
+      typeof detailPayload === "object" &&
+      "message" in detailPayload &&
+      typeof (detailPayload as { message?: unknown }).message === "string"
+    ) {
+      return String((detailPayload as { message: string }).message);
     }
     if (error.message) {
       return error.message;
@@ -38,118 +72,444 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   return fallback;
 };
 
-const defaultFilters = (): FilterState => ({
-  sku_code: "",
-  warehouse_name: "",
-  updated_at: getTodayIso(),
-  username: "",
-});
-
-const fetchEdits = async (
-  sessionId: string,
-  filters: FilterState,
-): Promise<PSIEditRecord[]> => {
-  const params: Record<string, string> = { session_id: sessionId };
-  if (filters.sku_code.trim()) {
-    params.sku_code = filters.sku_code.trim();
-  }
-  if (filters.warehouse_name.trim()) {
-    params.warehouse_name = filters.warehouse_name.trim();
-  }
-  if (filters.updated_at) {
-    params.updated_at = filters.updated_at;
-  }
-  if (filters.username.trim()) {
-    params.username = filters.username.trim();
-  }
-
-  const { data } = await api.get<PSIEditRecord[]>("/psi-edits/", { params });
+const fetchDatasets = async (sessionId: string): Promise<SessionDatasetMetadata[]> => {
+  const { data } = await api.get<SessionDatasetMetadata[]>(
+    `/sessions/${sessionId}/datasets`,
+  );
   return data;
 };
 
+const fetchPsiBasePage = async (
+  sessionId: string,
+  filters: Record<string, string>,
+  page: number,
+  size: number,
+): Promise<PsiBasePage> => {
+  const params: Record<string, string> = {
+    page: String(page),
+    size: String(size),
+  };
+  if (Object.keys(filters).length > 0) {
+    params.filters = JSON.stringify(filters);
+  }
+  const { data } = await api.get<PsiBasePage>(
+    `/sessions/${sessionId}/psi_base`,
+    { params },
+  );
+  return data;
+};
+
+const savePsiBaseEdits = async (
+  sessionId: string,
+  rows: Record<string, unknown>[],
+) => {
+  await api.patch(`/sessions/${sessionId}/psi_base`, { rows });
+};
+
+const deletePsiBaseRows = async (
+  sessionId: string,
+  rows: Pick<PsiBaseRecord, "session_id" | "sku_code" | "warehouse_name" | "channel" | "date">[],
+) => {
+  await api.delete(`/sessions/${sessionId}/psi_base`, { data: { rows } });
+};
+
+const exportPsiBase = async (
+  sessionId: string,
+  filters: Record<string, string>,
+  includeAll: boolean,
+  page: number,
+  size: number,
+) => {
+  const params: Record<string, string> = {
+    all: includeAll ? "true" : "false",
+    page: String(page),
+    size: String(size),
+  };
+  if (Object.keys(filters).length > 0) {
+    params.filters = JSON.stringify(filters);
+  }
+  const response = await api.get<Blob>(
+    `/sessions/${sessionId}/psi_base/export`,
+    {
+      params,
+      responseType: "blob",
+    },
+  );
+  return response;
+};
+
+const downloadTemplate = async (sessionId: string) => {
+  const response = await api.get<Blob>(
+    `/sessions/${sessionId}/psi_base/template`,
+    { responseType: "blob" },
+  );
+  return response;
+};
+
+const importPsiBase = async (
+  sessionId: string,
+  mode: "replace" | "upsert",
+  file: File,
+): Promise<PsiBaseImportResponse> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  const { data } = await api.post<PsiBaseImportResponse>(
+    `/sessions/${sessionId}/psi_base/import`,
+    formData,
+    {
+      params: { mode },
+      headers: { "Content-Type": "multipart/form-data" },
+    },
+  );
+  return data;
+};
+
+const sanitizeFilters = (filters: PsiBaseFilters): Record<string, string> => {
+  const entries = Object.entries(filters)
+    .map(([key, value]) => [key, value.trim()] as const)
+    .filter(([, value]) => value.length > 0);
+  return Object.fromEntries(entries);
+};
+
+const getSessionLabel = (session: Session) =>
+  session.title ?? session.id.slice(0, 8);
+
 export default function EditsPage() {
+  const queryClient = useQueryClient();
   const sessionsQuery = useSessionsQuery();
   const sessions = sessionsQuery.data ?? [];
-  const leaderSession = useMemo(
-    () => sessions.find((session) => session.is_leader) ?? null,
-    [sessions],
-  );
 
+  const [sessionSearch, setSessionSearch] = useState("");
   const [selectedSessionId, setSelectedSessionId] = useState<string>("");
-  const [filterDraft, setFilterDraft] = useState<FilterState>(defaultFilters);
-  const [appliedFilters, setAppliedFilters] = useState<FilterState>(defaultFilters);
+  const [selectedDatasetName, setSelectedDatasetName] = useState<string>("");
+  const [activeTab, setActiveTab] = useState<"table" | "csv">("table");
+  const [tableFilters, setTableFilters] = useState<PsiBaseFilters>(defaultFilters);
+  const [pendingFilters, setPendingFilters] = useState<PsiBaseFilters>(defaultFilters);
+  const [pageSize, setPageSize] = useState<number>(50);
+  const [page, setPage] = useState<number>(1);
   const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [importMode, setImportMode] = useState<"replace" | "upsert">("replace");
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importResult, setImportResult] = useState<PsiBaseImportResponse | null>(null);
 
-  useEffect(() => {
-    if (!selectedSessionId && sessions.length) {
-      const fallback = leaderSession ?? sessions[0];
-      setSelectedSessionId(fallback.id);
+  const filteredSessions = useMemo(() => {
+    const term = sessionSearch.trim().toLowerCase();
+    if (!term) {
+      return sessions;
     }
-  }, [leaderSession, selectedSessionId, sessions]);
+    return sessions.filter((session) =>
+      [session.title, session.description]
+        .filter(Boolean)
+        .some((value) => value?.toLowerCase().includes(term)),
+    );
+  }, [sessionSearch, sessions]);
 
   useEffect(() => {
-    const defaults = defaultFilters();
-    setFilterDraft(defaults);
-    setAppliedFilters(defaults);
+    if (!selectedSessionId && filteredSessions.length > 0) {
+      setSelectedSessionId(filteredSessions[0].id);
+    }
+  }, [filteredSessions, selectedSessionId]);
+
+  useEffect(() => {
+    setSelectedDatasetName("");
+    setTableFilters(defaultFilters());
+    setPendingFilters(defaultFilters());
+    setPage(1);
+    setStatus(null);
+    setImportFile(null);
+    setImportResult(null);
   }, [selectedSessionId]);
 
-  const editsQueryKey = useMemo(
-    () => [
-      "psi-edit-list",
-      selectedSessionId,
-      appliedFilters.sku_code,
-      appliedFilters.warehouse_name,
-      appliedFilters.updated_at,
-      appliedFilters.username,
-    ],
-    [selectedSessionId, appliedFilters],
-  );
-
-  const editsQuery = useQuery({
-    queryKey: editsQueryKey,
-    queryFn: () => fetchEdits(selectedSessionId, appliedFilters),
+  const datasetsQuery = useQuery({
+    queryKey: ["session-datasets", selectedSessionId],
+    queryFn: () => fetchDatasets(selectedSessionId),
     enabled: Boolean(selectedSessionId),
   });
 
-  const edits = editsQuery.data ?? [];
+  const datasets = datasetsQuery.data ?? [];
 
-  const handleApplyFilters = (event: FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    if (datasets.length === 0) {
+      setSelectedDatasetName("");
+      return;
+    }
+    if (!selectedDatasetName) {
+      setSelectedDatasetName(datasets[0].name);
+      return;
+    }
+    const exists = datasets.some((dataset) => dataset.name === selectedDatasetName);
+    if (!exists) {
+      setSelectedDatasetName(datasets[0].name);
+    }
+  }, [datasets, selectedDatasetName]);
+
+  const selectedDataset = useMemo(
+    () => datasets.find((dataset) => dataset.name === selectedDatasetName) ?? null,
+    [datasets, selectedDatasetName],
+  );
+
+  const sanitizedFilters = useMemo(
+    () => sanitizeFilters(tableFilters),
+    [tableFilters],
+  );
+
+  const tableQuery = useQuery({
+    queryKey: [
+      "session-psi-base",
+      selectedSessionId,
+      selectedDataset?.name,
+      sanitizedFilters.sku_code ?? "",
+      sanitizedFilters.warehouse_name ?? "",
+      sanitizedFilters.channel ?? "",
+      sanitizedFilters.fw_rank ?? "",
+      sanitizedFilters.ss_rank ?? "",
+      sanitizedFilters.date_start ?? "",
+      sanitizedFilters.date_end ?? "",
+      page,
+      pageSize,
+    ],
+    queryFn: () =>
+      fetchPsiBasePage(selectedSessionId, sanitizedFilters, page, pageSize),
+    enabled:
+      Boolean(selectedSessionId) && selectedDataset?.name === "psi_base",
+    placeholderData: (previous) => previous ?? undefined,
+  });
+
+  const originalRows = tableQuery.data?.rows ?? [];
+  const originalRowMap = useMemo(() => {
+    const map = new Map<string, PsiBaseRecord>();
+    originalRows.forEach((row) => {
+      map.set(makeRowKey(row), row);
+    });
+    return map;
+  }, [originalRows]);
+
+  const [localRows, setLocalRows] = useState<PsiBaseRecord[]>([]);
+  const [edits, setEdits] = useState<Map<string, Record<string, string>>>(
+    () => new Map(),
+  );
+  const [selectedRowKeys, setSelectedRowKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  useEffect(() => {
+    setLocalRows(originalRows);
+    setEdits(new Map());
+    setSelectedRowKeys(new Set());
+  }, [originalRows]);
+
+  const editableColumns = useMemo(() => {
+    if (!selectedDataset) {
+      return new Set<string>();
+    }
+    return new Set(
+      selectedDataset.columns
+        .filter((column) => column.editable)
+        .map((column) => column.name),
+    );
+  }, [selectedDataset]);
+
+  const numericColumns = useMemo(() => {
+    if (!selectedDataset) {
+      return new Set<string>();
+    }
+    return new Set(selectedDataset.numeric_columns);
+  }, [selectedDataset]);
+
+  const hasEdits = edits.size > 0;
+
+  const handleFilterSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setAppliedFilters(filterDraft);
+    setTableFilters(pendingFilters);
+    setPage(1);
     setStatus(null);
   };
 
-  const handleResetFilters = () => {
-    const defaults = defaultFilters();
-    setFilterDraft(defaults);
-    setAppliedFilters(defaults);
+  const handleFilterChange = (
+    event: ChangeEvent<HTMLInputElement>,
+    field: keyof PsiBaseFilters,
+  ) => {
+    const value = event.target.value;
+    setPendingFilters((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+    setSelectedRowKeys(new Set());
+  };
+
+  const handlePageSizeChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextSize = Number(event.target.value);
+    setPageSize(nextSize);
+    setPage(1);
+  };
+
+  const handleCellChange = (
+    rowKey: string,
+    field: string,
+    value: string,
+  ) => {
+    setLocalRows((prev) =>
+      prev.map((row) =>
+        makeRowKey(row) === rowKey ? { ...row, [field]: value } : row,
+      ),
+    );
+    setEdits((prev) => {
+      const next = new Map(prev);
+      const original = originalRowMap.get(rowKey);
+      const base = next.get(rowKey) ?? {};
+      const normalizedValue = value;
+      const originalValue = original
+        ? (original[field as keyof PsiBaseRecord] ?? "")
+        : "";
+      const normalizedOriginal =
+        originalValue === null || originalValue === undefined
+          ? ""
+          : String(originalValue);
+      if (normalizedValue === normalizedOriginal) {
+        const updated = { ...base } as Record<string, string>;
+        delete updated[field];
+        if (Object.keys(updated).length === 0) {
+          next.delete(rowKey);
+        } else {
+          next.set(rowKey, updated);
+        }
+      } else {
+        next.set(rowKey, { ...base, [field]: normalizedValue });
+      }
+      return next;
+    });
+  };
+
+  const handleRowSelection = (rowKey: string, checked: boolean) => {
+    setSelectedRowKeys((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(rowKey);
+      } else {
+        next.delete(rowKey);
+      }
+      return next;
+    });
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedSessionId || edits.size === 0) {
+        return;
+      }
+      const rows: Record<string, unknown>[] = [];
+      edits.forEach((changes, key) => {
+        const original = originalRowMap.get(key);
+        if (!original) {
+          return;
+        }
+        const payload: Record<string, unknown> = {
+          session_id: selectedSessionId,
+          sku_code: original.sku_code,
+          warehouse_name: original.warehouse_name,
+          channel: original.channel,
+          date: original.date,
+        };
+        Object.entries(changes).forEach(([field, rawValue]) => {
+          if (!editableColumns.has(field)) {
+            return;
+          }
+          const value = rawValue ?? "";
+          if (numericColumns.has(field)) {
+            const trimmed = typeof value === "string" ? value.trim() : String(value ?? "");
+            payload[field] = trimmed.length === 0 ? null : trimmed;
+          } else {
+            payload[field] = typeof value === "string" ? value.trim() : value;
+          }
+        });
+        rows.push(payload);
+      });
+      if (rows.length === 0) {
+        return;
+      }
+      await savePsiBaseEdits(selectedSessionId, rows);
+    },
+    onSuccess: () => {
+      setStatus({ type: "success", text: "Changes saved." });
+      setEdits(new Map());
+      void queryClient.invalidateQueries({ queryKey: ["session-psi-base"] });
+    },
+    onError: (error) => {
+      setStatus({ type: "error", text: getErrorMessage(error, "Failed to save changes.") });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedSessionId || selectedRowKeys.size === 0) {
+        return;
+      }
+      const rows = Array.from(selectedRowKeys)
+        .map((key) => originalRowMap.get(key))
+        .filter((row): row is PsiBaseRecord => Boolean(row))
+        .map((row) => ({
+          session_id: selectedSessionId,
+          sku_code: row.sku_code,
+          warehouse_name: row.warehouse_name,
+          channel: row.channel,
+          date: row.date,
+        }));
+      if (rows.length === 0) {
+        return;
+      }
+      await deletePsiBaseRows(selectedSessionId, rows);
+    },
+    onSuccess: () => {
+      setStatus({ type: "success", text: "Rows deleted." });
+      setSelectedRowKeys(new Set());
+      setEdits(new Map());
+      void queryClient.invalidateQueries({ queryKey: ["session-psi-base"] });
+    },
+    onError: (error) => {
+      setStatus({ type: "error", text: getErrorMessage(error, "Failed to delete rows.") });
+    },
+  });
+
+  const importMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedSessionId || !importFile) {
+        throw new Error("ファイルを選択してください");
+      }
+      return importPsiBase(selectedSessionId, importMode, importFile);
+    },
+    onSuccess: (result) => {
+      setImportResult(result);
+      setImportFile(null);
+      setStatus({
+        type: "success",
+        text: `Import completed. Added ${result.added}, updated ${result.updated}, deleted ${result.deleted}.`,
+      });
+      void queryClient.invalidateQueries({ queryKey: ["session-psi-base"] });
+    },
+    onError: (error) => {
+      setStatus({ type: "error", text: getErrorMessage(error, "Failed to import CSV.") });
+    },
+  });
+
+  const handleDiscard = () => {
+    setLocalRows(originalRows);
+    setEdits(new Map());
     setStatus(null);
   };
 
-  const handleDownload = async () => {
+  const handleDownloadCsv = async (includeAll: boolean) => {
     if (!selectedSessionId) {
       return;
     }
     try {
-      const params: Record<string, string> = {};
-      if (appliedFilters.sku_code.trim()) {
-        params.sku_code = appliedFilters.sku_code.trim();
-      }
-      if (appliedFilters.warehouse_name.trim()) {
-        params.warehouse_name = appliedFilters.warehouse_name.trim();
-      }
-      if (appliedFilters.updated_at) {
-        params.updated_at = appliedFilters.updated_at;
-      }
-      if (appliedFilters.username.trim()) {
-        params.username = appliedFilters.username.trim();
-      }
-
-      const response = await api.get<Blob>(`/psi-edits/${selectedSessionId}/export`, {
-        params,
-        responseType: "blob",
-      });
-
+      const response = await exportPsiBase(
+        selectedSessionId,
+        sanitizedFilters,
+        includeAll,
+        page,
+        pageSize,
+      );
       const blob = new Blob(["\ufeff", response.data], {
         type: response.headers["content-type"] ?? "text/csv;charset=utf-8",
       });
@@ -157,163 +517,476 @@ export default function EditsPage() {
       const link = document.createElement("a");
       link.href = url;
       const disposition = response.headers["content-disposition"];
-      const match = typeof disposition === "string" ? disposition.match(/filename="?([^";]+)"?/i) : null;
-      const filename = match?.[1] ?? `psi-edits-${selectedSessionId}.csv`;
-      link.setAttribute("download", filename);
+      const match =
+        typeof disposition === "string"
+          ? disposition.match(/filename="?([^";]+)"?/i)
+          : null;
+      link.download = match?.[1] ?? `psi-base-${selectedSessionId}.csv`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
       window.URL.revokeObjectURL(url);
       setStatus({ type: "success", text: "CSV download started." });
     } catch (error) {
-      setStatus({ type: "error", text: getErrorMessage(error, "Unable to download CSV.") });
+      setStatus({ type: "error", text: getErrorMessage(error, "Failed to download CSV.") });
     }
   };
 
+  const handleDownloadTemplate = async () => {
+    if (!selectedSessionId) {
+      return;
+    }
+    try {
+      const response = await downloadTemplate(selectedSessionId);
+      const blob = new Blob(["\ufeff", response.data], {
+        type: response.headers["content-type"] ?? "text/csv;charset=utf-8",
+      });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `psi-base-template-${selectedSessionId}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      setStatus({ type: "error", text: getErrorMessage(error, "Failed to download template.") });
+    }
+  };
+
+  const handleImportSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus(null);
+    setImportResult(null);
+    try {
+      await importMutation.mutateAsync();
+    } catch (error) {
+      setStatus({
+        type: "error",
+        text: getErrorMessage(error, "Failed to import CSV."),
+      });
+    }
+  };
+
+  const totalRows = tableQuery.data?.total ?? 0;
+  const totalPages = totalRows === 0 ? 1 : Math.max(1, Math.ceil(totalRows / pageSize));
+
   return (
     <div className="page transfer-page">
-      <header>
-        <h1>PSI Edits</h1>
-        <p>Review manual PSI overrides and audit who made each change.</p>
+      <header className="page-header">
+        <div>
+          <h1>Edits</h1>
+          <p>Manage session scoped PSI datasets with inline edits or CSV uploads.</p>
+        </div>
+        <a
+          className="button"
+          href="/reallocation"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Reallocationへ
+        </a>
       </header>
 
-      {status ? <div className={`status-message ${status.type}`}>{status.text}</div> : null}
+      {status && <div className={`status-message ${status.type}`}>{status.text}</div>}
 
-      <section className="filters">
-        <h2>Filters</h2>
-        <form className="filter-form" onSubmit={handleApplyFilters}>
-          <label>
-            Session
+      <section className="card">
+        <h2>Step 1: Select session</h2>
+        <div className="form-row">
+          <label className="form-field">
+            <span>検索</span>
+            <input
+              type="search"
+              value={sessionSearch}
+              onChange={(event) => setSessionSearch(event.target.value)}
+              placeholder="Search sessions"
+            />
+          </label>
+          <label className="form-field">
+            <span>Session</span>
             <select
               value={selectedSessionId}
-              onChange={(event) => {
-                setSelectedSessionId(event.target.value);
-                setStatus(null);
-              }}
-              required
+              onChange={(event) => setSelectedSessionId(event.target.value)}
             >
               <option value="" disabled>
                 Select session
               </option>
-              {sessions.map((session) => (
+              {filteredSessions.map((session) => (
                 <option key={session.id} value={session.id}>
-                  {session.title}
+                  {getSessionLabel(session)}
                 </option>
               ))}
             </select>
           </label>
-          <label>
-            SKU Code
-            <input
-              type="text"
-              value={filterDraft.sku_code}
-              onChange={(event) =>
-                setFilterDraft((previous) => ({ ...previous, sku_code: event.target.value }))
-              }
-              placeholder="Contains…"
-            />
-          </label>
-          <label>
-            Warehouse
-            <input
-              type="text"
-              value={filterDraft.warehouse_name}
-              onChange={(event) =>
-                setFilterDraft((previous) => ({ ...previous, warehouse_name: event.target.value }))
-              }
-              placeholder="Contains…"
-            />
-          </label>
-          <label>
-            Updated Date
-            <input
-              type="date"
-              value={filterDraft.updated_at}
-              onChange={(event) =>
-                setFilterDraft((previous) => ({ ...previous, updated_at: event.target.value }))
-              }
-            />
-          </label>
-          <label>
-            Username
-            <input
-              type="text"
-              value={filterDraft.username}
-              onChange={(event) =>
-                setFilterDraft((previous) => ({ ...previous, username: event.target.value }))
-              }
-              placeholder="Contains…"
-            />
-          </label>
-          <div className="filter-actions">
-            <button type="submit" disabled={!selectedSessionId}>
-              apply
-            </button>
-            <button type="button" className="secondary" onClick={handleResetFilters}>
-              reset
+        </div>
+      </section>
+
+      <section className="card">
+        <h2>Step 2: Choose dataset</h2>
+        {datasetsQuery.isLoading && <p>Loading datasets…</p>}
+        {datasetsQuery.isError && <p className="error-text">Failed to load dataset list.</p>}
+        {datasets.length === 0 && !datasetsQuery.isLoading && (
+          <p>No editable datasets are configured for this session.</p>
+        )}
+        {datasets.length > 0 && (
+          <div className="dataset-selector">
+            {datasets.map((dataset) => (
+              <label key={dataset.name} className="dataset-option">
+                <input
+                  type="radio"
+                  name="dataset"
+                  value={dataset.name}
+                  checked={dataset.name === selectedDatasetName}
+                  onChange={(event) => setSelectedDatasetName(event.target.value)}
+                />
+                <span className="dataset-label">{dataset.label}</span>
+                {dataset.description && (
+                  <span className="dataset-description">{dataset.description}</span>
+                )}
+              </label>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {selectedDataset?.name === "psi_base" && (
+        <section className="card">
+          <h2>Step 3: Edit data</h2>
+          <div className="tab-header">
+            <button
+              type="button"
+              className={activeTab === "table" ? "active" : ""}
+              onClick={() => setActiveTab("table")}
+            >
+              Table editor
             </button>
             <button
               type="button"
-              className="secondary"
-              onClick={handleDownload}
-              disabled={!selectedSessionId}
+              className={activeTab === "csv" ? "active" : ""}
+              onClick={() => setActiveTab("csv")}
             >
-              DL
+              CSV import/export
             </button>
           </div>
-        </form>
-      </section>
 
-      <section>
-        <h2>PSI Edit Records</h2>
-        {editsQuery.isLoading && !edits.length ? <p>Loading edits…</p> : null}
-        {editsQuery.error ? (
-          <p className="error-text">Failed to load PSI edits. Please try again.</p>
-        ) : null}
-        <div className="table-container">
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>SKU</th>
-                <th>Warehouse</th>
-                <th>Channel</th>
-                <th>Inbound Qty</th>
-                <th>Outbound Qty</th>
-                <th>Safety Stock</th>
-                <th>Created By</th>
-                <th>Updated By</th>
-              </tr>
-            </thead>
-            <tbody>
-              {edits.map((edit) => (
-                <tr key={edit.id}>
-                  <td>{edit.date}</td>
-                  <td>{edit.sku_code}</td>
-                  <td>{edit.warehouse_name}</td>
-                  <td>{edit.channel}</td>
-                  <td>{edit.inbound_qty ?? "—"}</td>
-                  <td>{edit.outbound_qty ?? "—"}</td>
-                  <td>{edit.safety_stock ?? "—"}</td>
-                  <td>
-                    <div>{edit.created_by_username ?? "—"}</div>
-                    <small>{new Date(edit.created_at).toLocaleString()}</small>
-                  </td>
-                  <td>
-                    <div>{edit.updated_by_username ?? "—"}</div>
-                    <small>{new Date(edit.updated_at).toLocaleString()}</small>
-                  </td>
-                </tr>
-              ))}
-              {edits.length === 0 ? (
-                <tr>
-                  <td colSpan={9}>No edits match the selected filters.</td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
-        </div>
-      </section>
+          {activeTab === "table" && (
+            <div className="tab-panel">
+              <form className="filter-form" onSubmit={handleFilterSubmit}>
+                <div className="filter-grid">
+                  <label>
+                    <span>SKU</span>
+                    <input
+                      type="search"
+                      value={pendingFilters.sku_code}
+                      onChange={(event) => handleFilterChange(event, "sku_code")}
+                      placeholder="SKU code"
+                    />
+                  </label>
+                  <label>
+                    <span>Warehouse</span>
+                    <input
+                      type="search"
+                      value={pendingFilters.warehouse_name}
+                      onChange={(event) => handleFilterChange(event, "warehouse_name")}
+                      placeholder="Warehouse"
+                    />
+                  </label>
+                  <label>
+                    <span>Channel</span>
+                    <input
+                      type="search"
+                      value={pendingFilters.channel}
+                      onChange={(event) => handleFilterChange(event, "channel")}
+                      placeholder="Channel"
+                    />
+                  </label>
+                  <label>
+                    <span>FW rank</span>
+                    <input
+                      type="search"
+                      value={pendingFilters.fw_rank}
+                      onChange={(event) => handleFilterChange(event, "fw_rank")}
+                      placeholder="FW"
+                    />
+                  </label>
+                  <label>
+                    <span>SS rank</span>
+                    <input
+                      type="search"
+                      value={pendingFilters.ss_rank}
+                      onChange={(event) => handleFilterChange(event, "ss_rank")}
+                      placeholder="SS"
+                    />
+                  </label>
+                  <label>
+                    <span>Date start</span>
+                    <input
+                      type="date"
+                      value={pendingFilters.date_start}
+                      onChange={(event) => handleFilterChange(event, "date_start")}
+                    />
+                  </label>
+                  <label>
+                    <span>Date end</span>
+                    <input
+                      type="date"
+                      value={pendingFilters.date_end}
+                      onChange={(event) => handleFilterChange(event, "date_end")}
+                    />
+                  </label>
+                </div>
+                <div className="filter-actions">
+                  <button type="submit">Apply filters</button>
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={() => {
+                      const defaults = defaultFilters();
+                      setPendingFilters(defaults);
+                      setTableFilters(defaults);
+                      setPage(1);
+                      setStatus(null);
+                    }}
+                  >
+                    Reset
+                  </button>
+                </div>
+              </form>
+
+              <div className="table-toolbar">
+                <div className="table-toolbar-left">
+                  <span>
+                    {tableQuery.isLoading
+                      ? "Loading rows…"
+                      : `Showing ${localRows.length} / ${totalRows} rows`}
+                  </span>
+                  <span className="edit-indicator">
+                    {hasEdits ? "Unsaved changes" : "All changes saved"}
+                  </span>
+                </div>
+                <div className="table-toolbar-right">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void saveMutation.mutateAsync();
+                    }}
+                    disabled={!hasEdits || saveMutation.isPending}
+                  >
+                    {saveMutation.isPending ? "Saving…" : "Save"}
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={handleDiscard}
+                    disabled={!hasEdits}
+                  >
+                    Discard
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={() => {
+                      void deleteMutation.mutateAsync();
+                    }}
+                    disabled={selectedRowKeys.size === 0 || deleteMutation.isPending}
+                  >
+                    {deleteMutation.isPending ? "Deleting…" : "Delete selected"}
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={() => handleDownloadCsv(false)}
+                    disabled={tableQuery.isLoading}
+                  >
+                    CSV (current page)
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={() => handleDownloadCsv(true)}
+                    disabled={tableQuery.isLoading}
+                  >
+                    CSV (all results)
+                  </button>
+                </div>
+              </div>
+
+              <div className="table-wrapper">
+                <table className="data-table">
+                  <thead>
+                    <tr>
+                      <th className="select-column">選択</th>
+                      {selectedDataset.columns.map((column) => (
+                        <th key={column.name}>{column.label}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {tableQuery.isLoading && (
+                      <tr>
+                        <td colSpan={selectedDataset.columns.length + 1}>Loading…</td>
+                      </tr>
+                    )}
+                    {!tableQuery.isLoading && localRows.length === 0 && (
+                      <tr>
+                        <td colSpan={selectedDataset.columns.length + 1}>
+                          No rows found for the applied filters.
+                        </td>
+                      </tr>
+                    )}
+                    {localRows.map((row) => {
+                      const rowKey = makeRowKey(row);
+                      const isEdited = edits.has(rowKey);
+                      const isSelected = selectedRowKeys.has(rowKey);
+                      return (
+                        <tr key={rowKey} className={isEdited ? "row-edited" : undefined}>
+                          <td className="select-column">
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={(event) =>
+                                handleRowSelection(rowKey, event.target.checked)
+                              }
+                            />
+                          </td>
+                      {selectedDataset.columns.map((column) => {
+                        const cellValue = row[column.name as keyof PsiBaseRecord];
+                        const displayValue =
+                          cellValue === null || cellValue === undefined
+                            ? ""
+                            : String(cellValue);
+                        if (!editableColumns.has(column.name)) {
+                          return <td key={column.name}>{displayValue}</td>;
+                        }
+                        return (
+                          <td key={column.name}>
+                            <input
+                              type={column.type === "number" ? "number" : "text"}
+                              value={displayValue}
+                              onChange={(event) =>
+                                handleCellChange(rowKey, column.name, event.target.value)
+                              }
+                              maxLength={column.max_length ?? undefined}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+              </div>
+
+              <div className="pagination">
+                <button
+                  type="button"
+                  onClick={() => handlePageChange(Math.max(1, page - 1))}
+                  disabled={page <= 1}
+                >
+                  ‹ Prev
+                </button>
+                <span>
+                  Page {page} / {totalPages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handlePageChange(Math.min(totalPages, page + 1))}
+                  disabled={page >= totalPages}
+                >
+                  Next ›
+                </button>
+                <label className="page-size">
+                  <span>Rows per page</span>
+                  <select value={pageSize} onChange={handlePageSizeChange}>
+                    {PAGE_SIZE_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            </div>
+          )}
+
+          {activeTab === "csv" && (
+            <div className="tab-panel csv-panel">
+              <div className="csv-actions">
+                <button type="button" onClick={handleDownloadTemplate}>
+                  Download template
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => handleDownloadCsv(true)}
+                >
+                  Export current dataset
+                </button>
+              </div>
+              <form className="import-form" onSubmit={handleImportSubmit}>
+                <label className="form-field">
+                  <span>CSV file</span>
+                  <input
+                    type="file"
+                    accept=".csv,text/csv"
+                    onChange={(event) => {
+                      const [file] = event.target.files ?? [];
+                      setImportFile(file ?? null);
+                    }}
+                  />
+                </label>
+                <div className="form-field">
+                  <span>Import mode</span>
+                  <label className="radio">
+                    <input
+                      type="radio"
+                      name="import-mode"
+                      value="replace"
+                      checked={importMode === "replace"}
+                      onChange={() => setImportMode("replace")}
+                    />
+                    <span>Replace (truncate and reload)</span>
+                  </label>
+                  <label className="radio">
+                    <input
+                      type="radio"
+                      name="import-mode"
+                      value="upsert"
+                      checked={importMode === "upsert"}
+                      onChange={() => setImportMode("upsert")}
+                    />
+                    <span>Upsert (update existing, insert new)</span>
+                  </label>
+                </div>
+                <button type="submit" disabled={!importFile || importMutation.isPending}>
+                  {importMutation.isPending ? "Importing…" : "Run import"}
+                </button>
+              </form>
+              {importResult && (
+                <div className="import-summary">
+                  <h3>Last import summary</h3>
+                  <ul>
+                    <li>Added: {importResult.added}</li>
+                    <li>Updated: {importResult.updated}</li>
+                    <li>Deleted: {importResult.deleted}</li>
+                  </ul>
+                  {importResult.warnings.length > 0 && (
+                    <details>
+                      <summary>Warnings</summary>
+                      <ul>
+                        {importResult.warnings.map((warning, index) => (
+                          <li key={index}>{warning}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -291,6 +291,7 @@ export default function ReallocationPage() {
   const [hasAutoLoadedPlan, setHasAutoLoadedPlan] = useState(false);
   const [filtersExpanded, setFiltersExpanded] = useState(true);
   const [skuSearch, setSkuSearch] = useState("");
+  const [currentSkuCode, setCurrentSkuCode] = useState<string | null>(null);
   const [planLinesPage, setPlanLinesPage] = useState(1);
   const [planSearchTerm, setPlanSearchTerm] = useState("");
   const [selectedLineIds, setSelectedLineIds] = useState<string[]>([]);
@@ -451,10 +452,11 @@ export default function ReallocationPage() {
     if (!plan) {
       return;
     }
+    const defaultSku = currentSkuCode?.trim() ?? "";
     const newLine: LineDraft = {
       line_id: generateId(),
       plan_id: plan.plan_id,
-      sku_code: "",
+      sku_code: defaultSku,
       from_warehouse: "",
       from_channel: "",
       to_warehouse: "",
@@ -463,8 +465,11 @@ export default function ReallocationPage() {
       is_manual: true,
       reason: "",
     };
-    setLines((prev) => [...prev, newLine]);
-    setPlanLinesPage(Math.max(1, Math.ceil((lines.length + 1) / PLAN_LINES_PAGE_SIZE)));
+    setLines((prev) => {
+      const next = [...prev, newLine];
+      setPlanLinesPage(Math.max(1, Math.ceil(next.length / PLAN_LINES_PAGE_SIZE)));
+      return next;
+    });
     setPlanDirty(true);
   };
 
@@ -1243,6 +1248,7 @@ export default function ReallocationPage() {
             skuList={skuList}
             skuSearch={skuSearch}
             onSkuSearchChange={setSkuSearch}
+            onSkuCodeChange={setCurrentSkuCode}
           />
         )}
       </section>
@@ -1257,6 +1263,9 @@ export default function ReallocationPage() {
               aria-live="polite"
             >
               {planDirty ? "Unsaved changes" : "Saved"}
+            </span>
+            <span className="current-sku-display">
+              Current SKU: <code>{currentSkuCode ?? "—"}</code>
             </span>
           </div>
           <div className="plan-actions">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -199,6 +199,67 @@ export interface TransferPlanLine {
   reason?: string | null;
 }
 
+export interface DatasetColumnMetadata {
+  name: string;
+  label: string;
+  type: "string" | "number" | "date";
+  editable: boolean;
+  required: boolean;
+  max_length?: number | null;
+  description?: string | null;
+}
+
+export interface SessionDatasetMetadata {
+  name: string;
+  label: string;
+  description?: string | null;
+  primary_key: string[];
+  columns: DatasetColumnMetadata[];
+  read_only_columns: string[];
+  numeric_columns: string[];
+  date_columns: string[];
+}
+
+export interface PsiBaseRecord {
+  session_id: string;
+  sku_code: string;
+  sku_name?: string | null;
+  category_1?: string | null;
+  category_2?: string | null;
+  category_3?: string | null;
+  fw_rank?: string | null;
+  ss_rank?: string | null;
+  warehouse_name: string;
+  channel: string;
+  date: string;
+  stock_at_anchor?: string | null;
+  inbound_qty?: string | null;
+  outbound_qty?: string | null;
+  net_flow?: string | null;
+  stock_closing?: string | null;
+  safety_stock?: string | null;
+  movable_stock?: string | null;
+  stdstock?: string | null;
+  gap?: string | null;
+  updated_at?: string | null;
+  updated_by?: string | null;
+  updated_by_username?: string | null;
+}
+
+export interface PsiBasePage {
+  page: number;
+  size: number;
+  total: number;
+  rows: PsiBaseRecord[];
+}
+
+export interface PsiBaseImportResponse {
+  added: number;
+  updated: number;
+  deleted: number;
+  warnings: string[];
+}
+
 export interface TransferPlanWithLines {
   plan: TransferPlan;
   lines: TransferPlanLine[];


### PR DESCRIPTION
## Summary
- add FastAPI endpoints for session-scoped dataset metadata, pagination, bulk edits, CSV import/export, and cache invalidation hooks for psi_base
- replace the Edits page with a multi-step session/dataset workflow supporting inline table edits, CSV uploads, and new styling
- default new transfer plan manual lines to the PSI Matrix selection and surface the active SKU in the UI

## Testing
- pytest backend/tests -q
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e1feb78700832e80ac5415decea1f8