### PR TITLE
Handle missing base sessions on Edits page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -360,6 +360,21 @@ body {
   min-width: 220px;
 }
 
+.edits-page .session-hint {
+  margin: 0.5rem 0 0;
+  color: var(--text-secondary, var(--text-primary));
+  font-size: 0.95rem;
+}
+
+.edits-page .session-hint + .session-hint {
+  margin-top: 0.35rem;
+}
+
+.edits-page .session-hint-error {
+  color: #fca5a5;
+  font-weight: 600;
+}
+
 .edits-page .filter-form {
   gap: 1rem;
 }

--- a/frontend/src/pages/EditsPage.tsx
+++ b/frontend/src/pages/EditsPage.tsx
@@ -138,23 +138,32 @@ export default function EditsPage() {
   const baseSessions = useMemo(
     () =>
       sessions.filter((session) => {
-        const mode = (session.data_type ?? session.data_mode)?.toLowerCase();
+        const mode = (session.data_mode ?? session.data_type)?.toLowerCase();
         return mode === "base";
       }),
     [sessions],
   );
 
   const filteredSessions = useMemo(() => {
+    const source = baseSessions.length > 0 ? baseSessions : sessions;
     const term = sessionSearch.trim().toLowerCase();
     if (!term) {
-      return baseSessions;
+      return source;
     }
-    return baseSessions.filter((session) =>
+    return source.filter((session) =>
       [session.title, session.description]
         .filter(Boolean)
         .some((value) => value?.toLowerCase().includes(term)),
     );
-  }, [baseSessions, sessionSearch]);
+  }, [baseSessions, sessions, sessionSearch]);
+
+  const showNoSessions =
+    !sessionsQuery.isLoading && !sessionsQuery.isError && sessions.length === 0;
+  const showMissingBaseSessionHint =
+    !sessionsQuery.isLoading &&
+    !sessionsQuery.isError &&
+    sessions.length > 0 &&
+    baseSessions.length === 0;
 
   useEffect(() => {
     if (filteredSessions.length === 0) {
@@ -466,6 +475,20 @@ export default function EditsPage() {
             </select>
           </label>
         </div>
+        {sessionsQuery.isLoading && (
+          <p className="session-hint">セッションを読み込み中です…</p>
+        )}
+        {sessionsQuery.isError && (
+          <p className="session-hint session-hint-error">セッションの取得に失敗しました。</p>
+        )}
+        {showNoSessions && (
+          <p className="session-hint">利用可能なセッションがまだありません。</p>
+        )}
+        {showMissingBaseSessionHint && (
+          <p className="session-hint">
+            Baseモードのセッションがまだありません。PSI baseデータを編集するには base モードのセッションを作成してください。
+          </p>
+        )}
       </section>
 
       {selectedSessionId && datasetsQuery.isLoading && (


### PR DESCRIPTION
## Summary
- fall back to showing all sessions on the Edits page when no base-mode sessions exist so the dropdown is not empty
- surface loading, error, and guidance messages around the session selector for better feedback
- add styling for the new helper text in the Edits page session card

## Testing
- npm run lint -- --max-warnings=0 *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e20d080f30832e9c7fab4a5e7608c5