### PR TITLE
Prevent PSI base editing for summary sessions

### DIFF
--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -158,6 +158,25 @@ DATASET_DEFINITIONS: dict[str, DatasetDefinition] = {
 }
 
 
+def _session_supports_dataset(session: models.Session, dataset: str) -> bool:
+    """Return whether the provided session can work with the dataset."""
+
+    data_mode = (session.data_mode or "").lower()
+    if dataset == "psi_base":
+        return data_mode == "base"
+    return True
+
+
+def _ensure_session_supports_dataset(session: models.Session, dataset: str) -> None:
+    """Raise an HTTP error when the dataset is incompatible with the session."""
+
+    if not _session_supports_dataset(session, dataset):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"session does not support {dataset}",
+        )
+
+
 COLUMN_LABELS: dict[str, dict[str, str]] = {
     "psi_base": {
         "session_id": "Session ID",
@@ -526,13 +545,15 @@ def list_session_datasets(
     """Return the datasets available for editing within the session."""
 
     _ = current_user
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
 
     metadata: list[schemas.SessionDatasetMetadata] = []
     for table in settings.session_editable_tables:
         key = table.lower()
         definition = DATASET_DEFINITIONS.get(key)
         if not definition:
+            continue
+        if not _session_supports_dataset(session, key):
             continue
         metadata.append(_build_dataset_metadata(definition))
     return metadata
@@ -555,7 +576,8 @@ def list_session_psi_base(
 
     _ = current_user
     definition = _dataset_definition_or_404("psi_base")
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_base")
 
     filter_values = _parse_filters(filters)
     conditions = _build_psibase_conditions(session_id, filter_values)
@@ -591,7 +613,8 @@ def patch_session_psi_base(
 
     _ = current_user
     definition = _dataset_definition_or_404("psi_base")
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_base")
 
     if not payload.rows:
         return {"updated": 0}
@@ -701,7 +724,8 @@ def delete_session_psi_base(
 
     _ = current_user
     _dataset_definition_or_404("psi_base")
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_base")
 
     if not payload.rows:
         return {"deleted": 0}
@@ -775,7 +799,8 @@ def export_session_psi_base(
 
     _ = current_user
     definition = _dataset_definition_or_404("psi_base")
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_base")
 
     filter_values = _parse_filters(filters)
     conditions = _build_psibase_conditions(session_id, filter_values)
@@ -823,7 +848,8 @@ def download_psi_base_template(
 
     _ = current_user
     definition = _dataset_definition_or_404("psi_base")
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_base")
 
     output = io.StringIO()
     writer = csv.writer(output)
@@ -861,7 +887,8 @@ async def import_session_psi_base(
 
     _ = current_user
     definition = _dataset_definition_or_404("psi_base")
-    _ensure_session_exists(db, session_id)
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_base")
 
     content = await file.read()
     try:

--- a/backend/tests/test_sessions_api.py
+++ b/backend/tests/test_sessions_api.py
@@ -381,6 +381,52 @@ def test_list_sessions_supports_search(
     assert [item["title"] for item in by_username] == ["Gamma"]
 
 
+def test_session_datasets_respect_data_mode(
+    app_env: SimpleNamespace, auth_user
+) -> None:
+    status, _, base_session = _perform_json_request(
+        app_env.app, "POST", "/sessions", {"title": "Base session"}
+    )
+    assert status == 201
+    base_id = base_session["id"]
+
+    status, _, base_datasets = _perform_json_request(
+        app_env.app, "GET", f"/sessions/{base_id}/datasets"
+    )
+    assert status == 200
+    assert [dataset["name"] for dataset in base_datasets] == ["psi_base"]
+
+    summary_payload = {"title": "Summary session", "data_mode": "summary"}
+    status, _, summary_session = _perform_json_request(
+        app_env.app, "POST", "/sessions", summary_payload
+    )
+    assert status == 201
+    summary_id = summary_session["id"]
+
+    status, _, summary_datasets = _perform_json_request(
+        app_env.app, "GET", f"/sessions/{summary_id}/datasets"
+    )
+    assert status == 200
+    assert summary_datasets == []
+
+
+def test_psi_base_endpoints_reject_summary_sessions(
+    app_env: SimpleNamespace, auth_user
+) -> None:
+    payload = {"title": "Summary only", "data_mode": "summary"}
+    status, _, summary_session = _perform_json_request(
+        app_env.app, "POST", "/sessions", payload
+    )
+    assert status == 201
+    summary_id = summary_session["id"]
+
+    status, _, response = _perform_json_request(
+        app_env.app, "GET", f"/sessions/{summary_id}/psi_base"
+    )
+    assert status == 400
+    assert response == {"detail": "session does not support psi_base"}
+
+
 def _create_csv_payload(session_id: uuid.UUID, *, date_value: str = "2024-01-01") -> bytes:
     definition = _get_sessions_router().DATASET_DEFINITIONS["psi_base"]
     row = {column: "" for column in definition.columns}


### PR DESCRIPTION
## Summary
- ensure psi_base dataset endpoints only operate on base-mode sessions
- filter session dataset metadata to exclude unsupported datasets
- cover summary session behaviour with regression tests

## Testing
- pytest backend/tests/test_sessions_api.py::test_session_datasets_respect_data_mode backend/tests/test_sessions_api.py::test_psi_base_endpoints_reject_summary_sessions

------
https://chatgpt.com/codex/tasks/task_e_68e210590ad0832e8276d333b10b33ac