### PR TITLE
Enable summary dataset editing and adjust reallocation manual line behavior

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -128,7 +128,9 @@ class Settings(BaseModel):
         default_factory=lambda: _env_flag("EXPOSE_AUDIT_FIELDS", default=False)
     )
     session_editable_tables_raw: str = Field(
-        default_factory=lambda: os.getenv("SESSION_EDITABLE_TABLES", "psi_base")
+        default_factory=lambda: os.getenv(
+            "SESSION_EDITABLE_TABLES", "psi_base,psi_summary_base"
+        )
     )
 
     @field_validator("database_url", mode="before")

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import csv
 import io
 import json
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
@@ -48,6 +48,8 @@ NUMERIC_ZERO_DEFAULT = {
     "stock_closing",
     "safety_stock",
     "movable_stock",
+    "std_stock",
+    "stock",
 }
 
 
@@ -58,7 +60,7 @@ class DatasetDefinition:
     name: str
     label: str
     description: str
-    model: type[models.PSIBase]
+    model: type[models.PSIBase | models.PSISummaryBase]
     primary_key: tuple[str, ...]
     columns: tuple[str, ...]
     editable_columns: tuple[str, ...]
@@ -155,6 +157,29 @@ DATASET_DEFINITIONS: dict[str, DatasetDefinition] = {
         read_only_columns=PSI_BASE_READ_ONLY_COLUMNS,
         default_order=PSI_BASE_DEFAULT_ORDER,
     ),
+    "psi_summary_base": DatasetDefinition(
+        name="psi_summary_base",
+        label="PSI Summary Base",
+        description="Aggregated PSI summary data scoped to a session.",
+        model=models.PSISummaryBase,
+        primary_key=("session_id", "sku_code", "warehouse_name", "channel"),
+        columns=(
+            "session_id",
+            "sku_code",
+            "sku_name",
+            "warehouse_name",
+            "channel",
+            "inbound_qty",
+            "outbound_qty",
+            "std_stock",
+            "stock",
+        ),
+        editable_columns=("sku_name", "inbound_qty", "outbound_qty", "std_stock", "stock"),
+        numeric_columns=("inbound_qty", "outbound_qty", "std_stock", "stock"),
+        date_columns=(),
+        read_only_columns=(),
+        default_order=("sku_code", "warehouse_name", "channel"),
+    ),
 }
 
 
@@ -164,6 +189,8 @@ def _session_supports_dataset(session: models.Session, dataset: str) -> bool:
     data_mode = (session.data_mode or "").lower()
     if dataset == "psi_base":
         return data_mode == "base"
+    if dataset == "psi_summary_base":
+        return data_mode == "summary"
     return True
 
 
@@ -299,6 +326,12 @@ def _ensure_session_exists(db: DBSession, session_id: UUID) -> models.Session:
     return session
 
 
+def _ensure_summary_dataset_table(db: DBSession) -> None:
+    bind = db.get_bind()
+    if bind is not None:
+        models.ensure_psi_summary_base_table(bind)
+
+
 def _raise_validation_errors(errors: Iterable[RowValidationError]) -> None:
     collected = list(errors)
     if not collected:
@@ -351,6 +384,194 @@ def _serialize_psibase(row: models.PSIBase) -> schemas.PSIBaseRecord:
         updated_by=None,
         updated_by_username=None,
     )
+
+
+def _serialize_psisummary(row: models.PSISummaryBase) -> schemas.PSISummaryBaseRecord:
+    return schemas.PSISummaryBaseRecord(
+        session_id=row.session_id,
+        sku_code=row.sku_code,
+        sku_name=row.sku_name,
+        warehouse_name=row.warehouse_name,
+        channel=row.channel,
+        inbound_qty=row.inbound_qty,
+        outbound_qty=row.outbound_qty,
+        std_stock=row.std_stock,
+        stock=row.stock,
+        created_at=row.created_at,
+        updated_at=None,
+        updated_by=None,
+        updated_by_username=None,
+    )
+
+
+def _query_dataset_rows(
+    definition: DatasetDefinition,
+    session_id: UUID,
+    filter_values: dict[str, Any],
+    page: int,
+    size: int,
+    db: DBSession,
+    *,
+    condition_builder: Callable[[UUID, dict[str, Any]], list[Any]],
+    serializer: Callable[[Any], Any],
+) -> tuple[int, list[Any]]:
+    conditions = condition_builder(session_id, filter_values)
+
+    base_query = select(definition.model).where(and_(*conditions))
+    order_columns = [getattr(definition.model, column) for column in definition.default_order]
+    query = base_query.order_by(*order_columns)
+
+    total = db.scalar(select(func.count()).select_from(base_query.subquery())) or 0
+
+    offset = (page - 1) * size
+    rows = db.scalars(query.offset(offset).limit(size)).all()
+
+    return total, [serializer(row) for row in rows]
+
+
+def _patch_session_dataset(
+    definition: DatasetDefinition,
+    session_id: UUID,
+    rows: Iterable[Any],
+    db: DBSession,
+) -> int:
+    if not rows:
+        return 0
+
+    validation_errors: list[RowValidationError] = []
+    updates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+    for index, row in enumerate(rows, start=1):
+        row_session_id = getattr(row, "session_id", None)
+        if row_session_id != session_id:
+            validation_errors.append(
+                RowValidationError(row=index, field="session_id", message="session mismatch"),
+            )
+
+        key_data: dict[str, Any] = {}
+        for field in definition.primary_key:
+            value = getattr(row, field, None)
+            key_data[field] = value
+            if value is None or (isinstance(value, str) and not value.strip()):
+                validation_errors.append(
+                    RowValidationError(row=index, field=field, message="is required"),
+                )
+
+        row_dict = row.model_dump(exclude_unset=True)
+
+        for read_only in definition.read_only_columns:
+            if read_only in row_dict and row_dict[read_only] is not None:
+                validation_errors.append(
+                    RowValidationError(row=index, field=read_only, message="field is read-only"),
+                )
+
+        update_data: dict[str, Any] = {}
+        for column in definition.editable_columns:
+            if column not in row_dict:
+                continue
+            value = row_dict[column]
+            if column in definition.numeric_columns:
+                normalized = _normalize_decimal(value, column, errors=validation_errors, row_index=index)
+            else:
+                if isinstance(value, str):
+                    normalized = value.strip() or None
+                else:
+                    normalized = value
+                if column in {"fw_rank", "ss_rank"} and normalized:
+                    value_str = str(normalized)
+                    if len(value_str) > 2:
+                        validation_errors.append(
+                            RowValidationError(
+                                row=index,
+                                field=column,
+                                message="must be at most 2 characters",
+                            ),
+                        )
+            update_data[column] = normalized
+
+        updates.append((key_data, update_data))
+
+    _raise_validation_errors(validation_errors)
+
+    updated = 0
+    post_validation: list[RowValidationError] = []
+
+    for index, (key_data, update_values) in enumerate(updates, start=1):
+        if not update_values:
+            continue
+        conditions = [
+            getattr(definition.model, column) == key_data[column]
+            for column in definition.primary_key
+        ]
+        stmt = update(definition.model).where(*conditions).values(**update_values)
+        result = db.execute(stmt)
+        if result.rowcount == 0:
+            post_validation.append(
+                RowValidationError(row=index, field="key", message="record not found"),
+            )
+        else:
+            updated += int(result.rowcount)
+
+    if post_validation:
+        db.rollback()
+        _raise_validation_errors(post_validation)
+
+    db.commit()
+    return updated
+
+
+def _delete_session_dataset(
+    definition: DatasetDefinition,
+    session_id: UUID,
+    rows: Iterable[Any],
+    db: DBSession,
+) -> int:
+    if not rows:
+        return 0
+
+    errors: list[RowValidationError] = []
+    keys: list[dict[str, Any]] = []
+
+    for index, row in enumerate(rows, start=1):
+        row_session_id = getattr(row, "session_id", None)
+        if row_session_id != session_id:
+            errors.append(
+                RowValidationError(row=index, field="session_id", message="session mismatch"),
+            )
+
+        key_data: dict[str, Any] = {}
+        for field in definition.primary_key:
+            value = getattr(row, field, None)
+            key_data[field] = value
+            if value is None or (isinstance(value, str) and not value.strip()):
+                errors.append(RowValidationError(row=index, field=field, message="is required"))
+        keys.append(key_data)
+
+    _raise_validation_errors(errors)
+
+    deleted = 0
+    missing: list[RowValidationError] = []
+
+    for index, key_data in enumerate(keys, start=1):
+        conditions = [
+            getattr(definition.model, column) == key_data[column]
+            for column in definition.primary_key
+        ]
+        stmt = delete(definition.model).where(*conditions).execution_options(
+            synchronize_session=False
+        )
+        result = db.execute(stmt)
+        if result.rowcount == 0:
+            missing.append(RowValidationError(row=index, field="key", message="record not found"))
+        else:
+            deleted += int(result.rowcount)
+
+    if missing:
+        db.rollback()
+        _raise_validation_errors(missing)
+
+    db.commit()
+    return deleted
 
 
 def _format_csv_value(value: Any) -> str:
@@ -422,6 +643,27 @@ def _build_psibase_conditions(session_id: UUID, filter_values: dict[str, Any]) -
     )
     if end_date is not None:
         conditions.append(models.PSIBase.date <= end_date)
+
+    return conditions
+
+
+def _build_psisummary_conditions(session_id: UUID, filter_values: dict[str, Any]) -> list[Any]:
+    conditions: list[Any] = [models.PSISummaryBase.session_id == session_id]
+
+    sku_code = filter_values.get("sku_code")
+    if isinstance(sku_code, str) and sku_code.strip():
+        lowered = f"%{sku_code.strip().lower()}%"
+        conditions.append(func.lower(models.PSISummaryBase.sku_code).like(lowered))
+
+    warehouse_name = filter_values.get("warehouse_name")
+    if isinstance(warehouse_name, str) and warehouse_name.strip():
+        lowered = f"%{warehouse_name.strip().lower()}%"
+        conditions.append(func.lower(models.PSISummaryBase.warehouse_name).like(lowered))
+
+    channel = filter_values.get("channel")
+    if isinstance(channel, str) and channel.strip():
+        lowered = f"%{channel.strip().lower()}%"
+        conditions.append(func.lower(models.PSISummaryBase.channel).like(lowered))
 
     return conditions
 
@@ -580,23 +822,18 @@ def list_session_psi_base(
     _ensure_session_supports_dataset(session, "psi_base")
 
     filter_values = _parse_filters(filters)
-    conditions = _build_psibase_conditions(session_id, filter_values)
-
-    base_query = select(models.PSIBase).where(and_(*conditions))
-    order_columns = [getattr(models.PSIBase, column) for column in definition.default_order]
-    query = base_query.order_by(*order_columns)
-
-    total = db.scalar(select(func.count()).select_from(base_query.subquery())) or 0
-
-    offset = (page - 1) * size
-    rows = db.scalars(query.offset(offset).limit(size)).all()
-
-    return schemas.PSIBasePage(
-        page=page,
-        size=size,
-        total=total,
-        rows=[_serialize_psibase(row) for row in rows],
+    total, rows = _query_dataset_rows(
+        definition,
+        session_id,
+        filter_values,
+        page,
+        size,
+        db,
+        condition_builder=_build_psibase_conditions,
+        serializer=_serialize_psibase,
     )
+
+    return schemas.PSIBasePage(page=page, size=size, total=total, rows=rows)
 
 
 @router.patch(
@@ -616,94 +853,7 @@ def patch_session_psi_base(
     session = _ensure_session_exists(db, session_id)
     _ensure_session_supports_dataset(session, "psi_base")
 
-    if not payload.rows:
-        return {"updated": 0}
-
-    validation_errors: list[RowValidationError] = []
-    updates: list[tuple[dict[str, Any], dict[str, Any]]] = []
-
-    for index, row in enumerate(payload.rows, start=1):
-        if row.session_id != session_id:
-            validation_errors.append(
-                RowValidationError(row=index, field="session_id", message="session mismatch"),
-            )
-
-        key_data = {
-            field: getattr(row, field)
-            for field in definition.primary_key
-        }
-        for field_name, value in key_data.items():
-            if value is None or (isinstance(value, str) and not value.strip()):
-                validation_errors.append(
-                    RowValidationError(row=index, field=field_name, message="is required"),
-                )
-
-        row_dict = row.model_dump(exclude_unset=True)
-
-        for read_only in definition.read_only_columns:
-            if read_only in row_dict and row_dict[read_only] is not None:
-                validation_errors.append(
-                    RowValidationError(row=index, field=read_only, message="field is read-only"),
-                )
-
-        update_data: dict[str, Any] = {}
-        for column in definition.editable_columns:
-            if column not in row_dict:
-                continue
-            value = row_dict[column]
-            if column in definition.numeric_columns:
-                normalized = _normalize_decimal(value, column, errors=validation_errors, row_index=index)
-            else:
-                if isinstance(value, str):
-                    normalized = value.strip() or None
-                else:
-                    normalized = value
-                if column in {"fw_rank", "ss_rank"} and normalized:
-                    value_str = str(normalized)
-                    if len(value_str) > 2:
-                        validation_errors.append(
-                            RowValidationError(
-                                row=index,
-                                field=column,
-                                message="must be at most 2 characters",
-                            ),
-                        )
-            update_data[column] = normalized
-
-        updates.append((key_data, update_data))
-
-    _raise_validation_errors(validation_errors)
-
-    updated = 0
-    post_validation: list[RowValidationError] = []
-
-    for index, (key_data, update_values) in enumerate(updates, start=1):
-        if not update_values:
-            continue
-        stmt = (
-            update(models.PSIBase)
-            .where(
-                models.PSIBase.session_id == key_data["session_id"],
-                models.PSIBase.sku_code == key_data["sku_code"],
-                models.PSIBase.warehouse_name == key_data["warehouse_name"],
-                models.PSIBase.channel == key_data["channel"],
-                models.PSIBase.date == key_data["date"],
-            )
-            .values(**update_values)
-        )
-        result = db.execute(stmt)
-        if result.rowcount == 0:
-            post_validation.append(
-                RowValidationError(row=index, field="key", message="record not found"),
-            )
-        else:
-            updated += int(result.rowcount)
-
-    if post_validation:
-        db.rollback()
-        _raise_validation_errors(post_validation)
-
-    db.commit()
+    updated = _patch_session_dataset(definition, session_id, payload.rows, db)
     if updated:
         invalidate_reallocation_cache(session_id)
 
@@ -723,59 +873,97 @@ def delete_session_psi_base(
     """Delete psi_base rows in bulk."""
 
     _ = current_user
-    _dataset_definition_or_404("psi_base")
+    definition = _dataset_definition_or_404("psi_base")
     session = _ensure_session_exists(db, session_id)
     _ensure_session_supports_dataset(session, "psi_base")
 
-    if not payload.rows:
-        return {"deleted": 0}
+    deleted = _delete_session_dataset(definition, session_id, payload.rows, db)
+    if deleted:
+        invalidate_reallocation_cache(session_id)
 
-    errors: list[RowValidationError] = []
-    keys: list[dict[str, Any]] = []
+    return {"deleted": deleted}
 
-    for index, row in enumerate(payload.rows, start=1):
-        if row.session_id != session_id:
-            errors.append(RowValidationError(row=index, field="session_id", message="session mismatch"))
-        key_data = {
-            "session_id": row.session_id,
-            "sku_code": row.sku_code,
-            "warehouse_name": row.warehouse_name,
-            "channel": row.channel,
-            "date": row.date,
-        }
-        for field_name, value in key_data.items():
-            if value is None or (isinstance(value, str) and not value.strip()):
-                errors.append(RowValidationError(row=index, field=field_name, message="is required"))
-        keys.append(key_data)
 
-    _raise_validation_errors(errors)
+@router.get(
+    "/{session_id}/psi_summary_base",
+    response_model=schemas.PSISummaryBasePage,
+    response_model_exclude_none=True,
+)
+def list_session_psi_summary_base(
+    session_id: UUID,
+    filters: str | None = Query(default=None, description="JSON encoded filter object"),
+    page: int = Query(1, ge=1),
+    size: int = Query(100, ge=1, le=500),
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.PSISummaryBasePage:
+    """Return paginated psi_summary_base rows scoped to the session."""
 
-    deleted = 0
-    missing: list[RowValidationError] = []
+    _ = current_user
+    _ensure_summary_dataset_table(db)
+    definition = _dataset_definition_or_404("psi_summary_base")
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_summary_base")
 
-    for index, key_data in enumerate(keys, start=1):
-        stmt = (
-            delete(models.PSIBase)
-            .where(
-                models.PSIBase.session_id == key_data["session_id"],
-                models.PSIBase.sku_code == key_data["sku_code"],
-                models.PSIBase.warehouse_name == key_data["warehouse_name"],
-                models.PSIBase.channel == key_data["channel"],
-                models.PSIBase.date == key_data["date"],
-            )
-            .execution_options(synchronize_session=False)
-        )
-        result = db.execute(stmt)
-        if result.rowcount == 0:
-            missing.append(RowValidationError(row=index, field="key", message="record not found"))
-        else:
-            deleted += int(result.rowcount)
+    filter_values = _parse_filters(filters)
+    total, rows = _query_dataset_rows(
+        definition,
+        session_id,
+        filter_values,
+        page,
+        size,
+        db,
+        condition_builder=_build_psisummary_conditions,
+        serializer=_serialize_psisummary,
+    )
 
-    if missing:
-        db.rollback()
-        _raise_validation_errors(missing)
+    return schemas.PSISummaryBasePage(page=page, size=size, total=total, rows=rows)
 
-    db.commit()
+
+@router.patch(
+    "/{session_id}/psi_summary_base",
+    response_model=dict[str, int],
+)
+def patch_session_psi_summary_base(
+    session_id: UUID,
+    payload: schemas.PSISummaryBasePatchRequest,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict[str, int]:
+    """Apply bulk updates to psi_summary_base rows."""
+
+    _ = current_user
+    _ensure_summary_dataset_table(db)
+    definition = _dataset_definition_or_404("psi_summary_base")
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_summary_base")
+
+    updated = _patch_session_dataset(definition, session_id, payload.rows, db)
+    if updated:
+        invalidate_reallocation_cache(session_id)
+
+    return {"updated": updated}
+
+
+@router.delete(
+    "/{session_id}/psi_summary_base",
+    response_model=dict[str, int],
+)
+def delete_session_psi_summary_base(
+    session_id: UUID,
+    payload: schemas.PSISummaryBaseDeleteRequest,
+    db: DBSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict[str, int]:
+    """Delete psi_summary_base rows in bulk."""
+
+    _ = current_user
+    _ensure_summary_dataset_table(db)
+    definition = _dataset_definition_or_404("psi_summary_base")
+    session = _ensure_session_exists(db, session_id)
+    _ensure_session_supports_dataset(session, "psi_summary_base")
+
+    deleted = _delete_session_dataset(definition, session_id, payload.rows, db)
     if deleted:
         invalidate_reallocation_cache(session_id)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -219,6 +219,35 @@ class PSIBasePage(BaseModel):
     rows: list[PSIBaseRecord]
 
 
+class PSISummaryBaseRecord(BaseModel):
+    """Serialized ``psi_summary_base`` row."""
+
+    session_id: UUID
+    sku_code: str
+    sku_name: str | None = None
+    warehouse_name: str
+    channel: str
+    inbound_qty: Decimal | None = None
+    outbound_qty: Decimal | None = None
+    std_stock: Decimal | None = None
+    stock: Decimal | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    updated_by: UUID | None = None
+    updated_by_username: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PSISummaryBasePage(BaseModel):
+    """Paginated result set for ``psi_summary_base`` rows."""
+
+    page: int
+    size: int
+    total: int
+    rows: list[PSISummaryBaseRecord]
+
+
 class PSIBasePatchRow(BaseModel):
     """Payload describing updates for ``psi_base`` rows."""
 
@@ -265,6 +294,41 @@ class PSIBaseDeleteRequest(BaseModel):
     """Bulk delete request body."""
 
     rows: list[PSIBaseDeleteRow]
+
+
+class PSISummaryBasePatchRow(BaseModel):
+    """Payload describing updates for ``psi_summary_base`` rows."""
+
+    session_id: UUID
+    sku_code: str
+    warehouse_name: str
+    channel: str
+    sku_name: str | None = None
+    inbound_qty: Decimal | None = None
+    outbound_qty: Decimal | None = None
+    std_stock: Decimal | None = None
+    stock: Decimal | None = None
+
+
+class PSISummaryBasePatchRequest(BaseModel):
+    """Bulk patch request body for summary rows."""
+
+    rows: list[PSISummaryBasePatchRow]
+
+
+class PSISummaryBaseDeleteRow(BaseModel):
+    """Key identifying a ``psi_summary_base`` record to delete."""
+
+    session_id: UUID
+    sku_code: str
+    warehouse_name: str
+    channel: str
+
+
+class PSISummaryBaseDeleteRequest(BaseModel):
+    """Bulk delete request body for summary rows."""
+
+    rows: list[PSISummaryBaseDeleteRow]
 
 
 class PSIBaseImportResponse(BaseModel):

--- a/backend/tests/test_sessions_api.py
+++ b/backend/tests/test_sessions_api.py
@@ -407,7 +407,7 @@ def test_session_datasets_respect_data_mode(
         app_env.app, "GET", f"/sessions/{summary_id}/datasets"
     )
     assert status == 200
-    assert summary_datasets == []
+    assert [dataset["name"] for dataset in summary_datasets] == ["psi_summary_base"]
 
 
 def test_psi_base_endpoints_reject_summary_sessions(
@@ -425,6 +425,176 @@ def test_psi_base_endpoints_reject_summary_sessions(
     )
     assert status == 400
     assert response == {"detail": "session does not support psi_base"}
+
+
+def test_psi_summary_endpoints_reject_base_sessions(
+    app_env: SimpleNamespace, auth_user
+) -> None:
+    status, _, base_session = _perform_json_request(
+        app_env.app, "POST", "/sessions", {"title": "Base session"}
+    )
+    assert status == 201
+    base_id = base_session["id"]
+
+    status, _, response = _perform_json_request(
+        app_env.app, "GET", f"/sessions/{base_id}/psi_summary_base"
+    )
+    assert status == 400
+    assert response == {"detail": "session does not support psi_summary_base"}
+
+
+def test_list_session_psi_summary_base(app_env: SimpleNamespace, auth_user) -> None:
+    status, _, summary_session = _perform_json_request(
+        app_env.app,
+        "POST",
+        "/sessions",
+        {"title": "Summary session", "data_mode": "summary"},
+    )
+    assert status == 201
+    summary_id = summary_session["id"]
+    summary_uuid = uuid.UUID(summary_id)
+
+    with app_env.SessionLocal() as db:
+        db.execute(app_env.models.PSISummaryBase.__table__.delete())
+        db.add(
+            app_env.models.PSISummaryBase(
+                session_id=summary_uuid,
+                sku_code="SKU-100",
+                sku_name="Summary Widget",
+                warehouse_name="Main",
+                channel="ONLINE",
+                inbound_qty=Decimal("5"),
+                outbound_qty=Decimal("2"),
+                std_stock=Decimal("3"),
+                stock=Decimal("4"),
+            )
+        )
+        db.commit()
+
+    status, _, payload = _perform_json_request(
+        app_env.app,
+        "GET",
+        f"/sessions/{summary_id}/psi_summary_base",
+        query_params={"page": 1, "size": 50},
+    )
+    assert status == 200
+    assert payload["total"] == 1
+    row = payload["rows"][0]
+    assert row["sku_code"] == "SKU-100"
+    assert row["sku_name"] == "Summary Widget"
+    assert Decimal(str(row["inbound_qty"])) == Decimal("5")
+
+
+def test_patch_session_psi_summary_base(app_env: SimpleNamespace, auth_user) -> None:
+    status, _, summary_session = _perform_json_request(
+        app_env.app,
+        "POST",
+        "/sessions",
+        {"title": "Summary session", "data_mode": "summary"},
+    )
+    assert status == 201
+    summary_id = summary_session["id"]
+    summary_uuid = uuid.UUID(summary_id)
+
+    with app_env.SessionLocal() as db:
+        db.execute(app_env.models.PSISummaryBase.__table__.delete())
+        db.add(
+            app_env.models.PSISummaryBase(
+                session_id=summary_uuid,
+                sku_code="SKU-200",
+                warehouse_name="Main",
+                channel="ONLINE",
+                inbound_qty=Decimal("1"),
+                stock=Decimal("2"),
+            )
+        )
+        db.commit()
+
+    patch_payload = {
+        "rows": [
+            {
+                "session_id": summary_id,
+                "sku_code": "SKU-200",
+                "warehouse_name": "Main",
+                "channel": "ONLINE",
+                "inbound_qty": "10",
+                "stock": "25",
+            }
+        ]
+    }
+
+    status, _, response = _perform_json_request(
+        app_env.app,
+        "PATCH",
+        f"/sessions/{summary_id}/psi_summary_base",
+        patch_payload,
+    )
+    assert status == 200
+    assert response == {"updated": 1}
+
+    with app_env.SessionLocal() as check_session:
+        stored = check_session.scalars(
+            select(app_env.models.PSISummaryBase).where(
+                app_env.models.PSISummaryBase.session_id == summary_uuid,
+                app_env.models.PSISummaryBase.sku_code == "SKU-200",
+            )
+        ).one()
+        assert stored.inbound_qty == Decimal("10")
+        assert stored.stock == Decimal("25")
+
+
+def test_delete_session_psi_summary_base(app_env: SimpleNamespace, auth_user) -> None:
+    status, _, summary_session = _perform_json_request(
+        app_env.app,
+        "POST",
+        "/sessions",
+        {"title": "Summary session", "data_mode": "summary"},
+    )
+    assert status == 201
+    summary_id = summary_session["id"]
+    summary_uuid = uuid.UUID(summary_id)
+
+    with app_env.SessionLocal() as db:
+        db.execute(app_env.models.PSISummaryBase.__table__.delete())
+        db.add(
+            app_env.models.PSISummaryBase(
+                session_id=summary_uuid,
+                sku_code="SKU-300",
+                warehouse_name="Main",
+                channel="ONLINE",
+                inbound_qty=Decimal("1"),
+            )
+        )
+        db.commit()
+
+    delete_payload = {
+        "rows": [
+            {
+                "session_id": summary_id,
+                "sku_code": "SKU-300",
+                "warehouse_name": "Main",
+                "channel": "ONLINE",
+            }
+        ]
+    }
+
+    status, _, response = _perform_json_request(
+        app_env.app,
+        "DELETE",
+        f"/sessions/{summary_id}/psi_summary_base",
+        delete_payload,
+    )
+    assert status == 200
+    assert response == {"deleted": 1}
+
+    with app_env.SessionLocal() as check_session:
+        remaining = check_session.scalars(
+            select(app_env.models.PSISummaryBase).where(
+                app_env.models.PSISummaryBase.session_id == summary_uuid,
+                app_env.models.PSISummaryBase.sku_code == "SKU-300",
+            )
+        ).first()
+        assert remaining is None
 
 
 def _create_csv_payload(session_id: uuid.UUID, *, date_value: str = "2024-01-01") -> bytes:

--- a/frontend/src/pages/EditsPage.tsx
+++ b/frontend/src/pages/EditsPage.tsx
@@ -1,6 +1,7 @@
 import {
   ChangeEvent,
   FormEvent,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -10,16 +11,11 @@ import axios from "axios";
 
 import api from "../lib/api";
 import { useSessionsQuery } from "../hooks/usePsiQueries";
-import type {
-  PsiBasePage,
-  PsiBaseRecord,
-  Session,
-  SessionDatasetMetadata,
-} from "../types";
+import type { Session, SessionDatasetMetadata } from "../types";
 
 type StatusMessage = { type: "success" | "error"; text: string };
 
-interface PsiBaseFilters {
+interface DatasetFilters {
   sku_code: string;
   warehouse_name: string;
   channel: string;
@@ -29,7 +25,7 @@ interface PsiBaseFilters {
   date_end: string;
 }
 
-const defaultFilters = (): PsiBaseFilters => ({
+const defaultFilters = (): DatasetFilters => ({
   sku_code: "",
   warehouse_name: "",
   channel: "",
@@ -43,10 +39,17 @@ const PAGE_SIZE_OPTIONS = [25, 50, 100];
 
 const ROW_KEY_DELIMITER = "\u0000";
 
-const makeRowKey = (row: Pick<PsiBaseRecord, "sku_code" | "warehouse_name" | "channel" | "date">) =>
-  [row.sku_code, row.warehouse_name, row.channel, row.date].join(
-    ROW_KEY_DELIMITER,
-  );
+type DatasetRow = Record<string, unknown> & { session_id: string };
+
+interface DatasetPage {
+  page: number;
+  size: number;
+  total: number;
+  rows: DatasetRow[];
+}
+
+const makeRowKey = (row: DatasetRow, primaryKey: string[]) =>
+  primaryKey.map((column) => String(row[column] ?? "")).join(ROW_KEY_DELIMITER);
 
 const getErrorMessage = (error: unknown, fallback: string) => {
   if (axios.isAxiosError(error)) {
@@ -78,12 +81,31 @@ const fetchDatasets = async (sessionId: string): Promise<SessionDatasetMetadata[
   return data;
 };
 
-const fetchPsiBasePage = async (
+const DATASET_ENDPOINTS: Record<string, string> = {
+  psi_base: "psi_base",
+  psi_summary_base: "psi_summary_base",
+};
+
+const DATASET_FILTER_KEYS: Record<string, (keyof DatasetFilters)[]> = {
+  psi_base: [
+    "sku_code",
+    "warehouse_name",
+    "channel",
+    "fw_rank",
+    "ss_rank",
+    "date_start",
+    "date_end",
+  ],
+  psi_summary_base: ["sku_code", "warehouse_name", "channel"],
+};
+
+const fetchDatasetPage = async (
   sessionId: string,
+  datasetName: string,
   filters: Record<string, string>,
   page: number,
   size: number,
-): Promise<PsiBasePage> => {
+): Promise<DatasetPage> => {
   const params: Record<string, string> = {
     page: String(page),
     size: String(size),
@@ -91,29 +113,49 @@ const fetchPsiBasePage = async (
   if (Object.keys(filters).length > 0) {
     params.filters = JSON.stringify(filters);
   }
-  const { data } = await api.get<PsiBasePage>(
-    `/sessions/${sessionId}/psi_base`,
+  const endpoint = DATASET_ENDPOINTS[datasetName];
+  if (!endpoint) {
+    throw new Error(`Unsupported dataset: ${datasetName}`);
+  }
+  const { data } = await api.get<DatasetPage>(
+    `/sessions/${sessionId}/${endpoint}`,
     { params },
   );
   return data;
 };
 
-const savePsiBaseEdits = async (
+const saveDatasetEdits = async (
   sessionId: string,
+  datasetName: string,
   rows: Record<string, unknown>[],
 ) => {
-  await api.patch(`/sessions/${sessionId}/psi_base`, { rows });
+  const endpoint = DATASET_ENDPOINTS[datasetName];
+  if (!endpoint) {
+    throw new Error(`Unsupported dataset: ${datasetName}`);
+  }
+  await api.patch(`/sessions/${sessionId}/${endpoint}`, { rows });
 };
 
-const deletePsiBaseRows = async (
+const deleteDatasetRows = async (
   sessionId: string,
-  rows: Pick<PsiBaseRecord, "session_id" | "sku_code" | "warehouse_name" | "channel" | "date">[],
+  datasetName: string,
+  rows: Record<string, unknown>[],
 ) => {
-  await api.delete(`/sessions/${sessionId}/psi_base`, { data: { rows } });
+  const endpoint = DATASET_ENDPOINTS[datasetName];
+  if (!endpoint) {
+    throw new Error(`Unsupported dataset: ${datasetName}`);
+  }
+  await api.delete(`/sessions/${sessionId}/${endpoint}`, { data: { rows } });
 };
 
-const sanitizeFilters = (filters: PsiBaseFilters): Record<string, string> => {
+const sanitizeFilters = (
+  filters: DatasetFilters,
+  datasetName?: string,
+): Record<string, string> => {
+  const allowed = DATASET_FILTER_KEYS[datasetName ?? "psi_base"] ?? [];
+  const allowedSet = new Set<keyof DatasetFilters>(allowed);
   const entries = Object.entries(filters)
+    .filter(([key]) => (allowedSet.size === 0 ? true : allowedSet.has(key as keyof DatasetFilters)))
     .map(([key, value]) => [key, value.trim()] as const)
     .filter(([, value]) => value.length > 0);
   return Object.fromEntries(entries);
@@ -129,8 +171,8 @@ export default function EditsPage() {
 
   const [sessionSearch, setSessionSearch] = useState("");
   const [selectedSessionId, setSelectedSessionId] = useState<string>("");
-  const [tableFilters, setTableFilters] = useState<PsiBaseFilters>(defaultFilters);
-  const [pendingFilters, setPendingFilters] = useState<PsiBaseFilters>(defaultFilters);
+  const [tableFilters, setTableFilters] = useState<DatasetFilters>(defaultFilters);
+  const [pendingFilters, setPendingFilters] = useState<DatasetFilters>(defaultFilters);
   const [pageSize, setPageSize] = useState<number>(50);
   const [page, setPage] = useState<number>(1);
   const [status, setStatus] = useState<StatusMessage | null>(null);
@@ -145,17 +187,16 @@ export default function EditsPage() {
   );
 
   const filteredSessions = useMemo(() => {
-    const source = baseSessions.length > 0 ? baseSessions : sessions;
     const term = sessionSearch.trim().toLowerCase();
     if (!term) {
-      return source;
+      return sessions;
     }
-    return source.filter((session) =>
+    return sessions.filter((session) =>
       [session.title, session.description]
         .filter(Boolean)
         .some((value) => value?.toLowerCase().includes(term)),
     );
-  }, [baseSessions, sessions, sessionSearch]);
+  }, [sessions, sessionSearch]);
 
   const showNoSessions =
     !sessionsQuery.isLoading && !sessionsQuery.isError && sessions.length === 0;
@@ -203,42 +244,51 @@ export default function EditsPage() {
     return baseDataset ?? datasets[0];
   }, [datasets]);
 
+  const datasetPrimaryKey = useMemo(
+    () => (selectedDataset ? [...selectedDataset.primary_key] : []),
+    [selectedDataset],
+  );
+
+  const getRowKey = useCallback(
+    (row: DatasetRow) => makeRowKey(row, datasetPrimaryKey),
+    [datasetPrimaryKey],
+  );
+
   const sanitizedFilters = useMemo(
-    () => sanitizeFilters(tableFilters),
-    [tableFilters],
+    () => sanitizeFilters(tableFilters, selectedDataset?.name),
+    [tableFilters, selectedDataset?.name],
   );
 
   const tableQuery = useQuery({
     queryKey: [
-      "session-psi-base",
+      "session-dataset",
       selectedSessionId,
       selectedDataset?.name,
-      sanitizedFilters.sku_code ?? "",
-      sanitizedFilters.warehouse_name ?? "",
-      sanitizedFilters.channel ?? "",
-      sanitizedFilters.fw_rank ?? "",
-      sanitizedFilters.ss_rank ?? "",
-      sanitizedFilters.date_start ?? "",
-      sanitizedFilters.date_end ?? "",
+      JSON.stringify(sanitizedFilters),
       page,
       pageSize,
     ],
     queryFn: () =>
-      fetchPsiBasePage(selectedSessionId, sanitizedFilters, page, pageSize),
-    enabled:
-      Boolean(selectedSessionId) && selectedDataset?.name === "psi_base",
+      fetchDatasetPage(
+        selectedSessionId,
+        selectedDataset!.name,
+        sanitizedFilters,
+        page,
+        pageSize,
+      ),
+    enabled: Boolean(selectedSessionId && selectedDataset),
   });
 
   const originalRows = tableQuery.data?.rows ?? [];
   const originalRowMap = useMemo(() => {
-    const map = new Map<string, PsiBaseRecord>();
+    const map = new Map<string, DatasetRow>();
     originalRows.forEach((row) => {
-      map.set(makeRowKey(row), row);
+      map.set(getRowKey(row), row);
     });
     return map;
-  }, [originalRows]);
+  }, [getRowKey, originalRows]);
 
-  const [localRows, setLocalRows] = useState<PsiBaseRecord[]>([]);
+  const [localRows, setLocalRows] = useState<DatasetRow[]>([]);
   const [edits, setEdits] = useState<Map<string, Record<string, string>>>(
     () => new Map(),
   );
@@ -281,7 +331,7 @@ export default function EditsPage() {
 
   const handleFilterChange = (
     event: ChangeEvent<HTMLInputElement>,
-    field: keyof PsiBaseFilters,
+    field: keyof DatasetFilters,
   ) => {
     const value = event.target.value;
     setPendingFilters((prev) => ({ ...prev, [field]: value }));
@@ -305,7 +355,7 @@ export default function EditsPage() {
   ) => {
     setLocalRows((prev) =>
       prev.map((row) =>
-        makeRowKey(row) === rowKey ? { ...row, [field]: value } : row,
+        getRowKey(row) === rowKey ? { ...row, [field]: value } : row,
       ),
     );
     setEdits((prev) => {
@@ -313,9 +363,7 @@ export default function EditsPage() {
       const original = originalRowMap.get(rowKey);
       const base = next.get(rowKey) ?? {};
       const normalizedValue = value;
-      const originalValue = original
-        ? (original[field as keyof PsiBaseRecord] ?? "")
-        : "";
+      const originalValue = original ? (original[field] as unknown) : "";
       const normalizedOriginal =
         originalValue === null || originalValue === undefined
           ? ""
@@ -349,7 +397,7 @@ export default function EditsPage() {
 
   const saveMutation = useMutation({
     mutationFn: async () => {
-      if (!selectedSessionId || edits.size === 0) {
+      if (!selectedSessionId || edits.size === 0 || !selectedDataset) {
         return;
       }
       const rows: Record<string, unknown>[] = [];
@@ -358,13 +406,17 @@ export default function EditsPage() {
         if (!original) {
           return;
         }
-        const payload: Record<string, unknown> = {
-          session_id: selectedSessionId,
-          sku_code: original.sku_code,
-          warehouse_name: original.warehouse_name,
-          channel: original.channel,
-          date: original.date,
-        };
+        const payload: Record<string, unknown> = {};
+        datasetPrimaryKey.forEach((column) => {
+          if (column === "session_id") {
+            payload[column] = selectedSessionId;
+          } else {
+            payload[column] = original[column];
+          }
+        });
+        if (!("session_id" in payload)) {
+          payload.session_id = selectedSessionId;
+        }
         Object.entries(changes).forEach(([field, rawValue]) => {
           if (!editableColumns.has(field)) {
             return;
@@ -382,12 +434,12 @@ export default function EditsPage() {
       if (rows.length === 0) {
         return;
       }
-      await savePsiBaseEdits(selectedSessionId, rows);
+      await saveDatasetEdits(selectedSessionId, selectedDataset.name, rows);
     },
     onSuccess: () => {
       setStatus({ type: "success", text: "Changes saved." });
       setEdits(new Map());
-      void queryClient.invalidateQueries({ queryKey: ["session-psi-base"] });
+      void queryClient.invalidateQueries({ queryKey: ["session-dataset"] });
     },
     onError: (error) => {
       setStatus({ type: "error", text: getErrorMessage(error, "Failed to save changes.") });
@@ -396,29 +448,36 @@ export default function EditsPage() {
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      if (!selectedSessionId || selectedRowKeys.size === 0) {
+      if (!selectedSessionId || selectedRowKeys.size === 0 || !selectedDataset) {
         return;
       }
       const rows = Array.from(selectedRowKeys)
         .map((key) => originalRowMap.get(key))
-        .filter((row): row is PsiBaseRecord => Boolean(row))
-        .map((row) => ({
-          session_id: selectedSessionId,
-          sku_code: row.sku_code,
-          warehouse_name: row.warehouse_name,
-          channel: row.channel,
-          date: row.date,
-        }));
+        .filter((row): row is DatasetRow => Boolean(row))
+        .map((row) => {
+          const payload: Record<string, unknown> = {};
+          datasetPrimaryKey.forEach((column) => {
+            if (column === "session_id") {
+              payload[column] = selectedSessionId;
+            } else {
+              payload[column] = row[column];
+            }
+          });
+          if (!("session_id" in payload)) {
+            payload.session_id = selectedSessionId;
+          }
+          return payload;
+        });
       if (rows.length === 0) {
         return;
       }
-      await deletePsiBaseRows(selectedSessionId, rows);
+      await deleteDatasetRows(selectedSessionId, selectedDataset.name, rows);
     },
     onSuccess: () => {
       setStatus({ type: "success", text: "Rows deleted." });
       setSelectedRowKeys(new Set());
       setEdits(new Map());
-      void queryClient.invalidateQueries({ queryKey: ["session-psi-base"] });
+      void queryClient.invalidateQueries({ queryKey: ["session-dataset"] });
     },
     onError: (error) => {
       setStatus({ type: "error", text: getErrorMessage(error, "Failed to delete rows.") });
@@ -433,14 +492,21 @@ export default function EditsPage() {
 
   const totalRows = tableQuery.data?.total ?? 0;
   const totalPages = totalRows === 0 ? 1 : Math.max(1, Math.ceil(totalRows / pageSize));
-  const canEditPsiBase = Boolean(selectedSessionId && selectedDataset?.name === "psi_base");
+  const canEditDataset = Boolean(selectedSessionId && selectedDataset);
+  const datasetLabel = selectedDataset?.label ?? "PSI data";
+  const datasetDescription =
+    selectedDataset?.name === "psi_summary_base"
+      ? "PSI summaryデータ"
+      : selectedDataset?.name === "psi_base"
+      ? "PSI baseデータ"
+      : "PSIデータ";
 
   return (
     <div className="page edits-page">
       <header className="page-header">
         <div>
           <h1>Edits</h1>
-          <p>セッションのPSI baseデータを検索して、画面上で直接編集できます。</p>
+          <p>セッションの{datasetDescription}を検索して、画面上で直接編集できます。</p>
         </div>
       </header>
 
@@ -493,28 +559,28 @@ export default function EditsPage() {
 
       {selectedSessionId && datasetsQuery.isLoading && (
         <section className="card">
-          <h2>PSI base</h2>
+          <h2>{datasetLabel}</h2>
           <p>Loading dataset metadata…</p>
         </section>
       )}
 
       {selectedSessionId && datasetsQuery.isError && (
         <section className="card">
-          <h2>PSI base</h2>
+          <h2>{datasetLabel}</h2>
           <p className="error-text">Failed to load dataset metadata.</p>
         </section>
       )}
 
-      {selectedSessionId && !datasetsQuery.isLoading && selectedDataset?.name !== "psi_base" && (
+      {selectedSessionId && !datasetsQuery.isLoading && !selectedDataset && (
         <section className="card">
-          <h2>PSI base</h2>
-          <p>このセッションではPSI baseデータの編集が利用できません。</p>
+          <h2>PSI data</h2>
+          <p>このセッションでは編集可能なPSIデータセットがありません。</p>
         </section>
       )}
 
-      {canEditPsiBase && selectedDataset && (
+      {canEditDataset && selectedDataset && (
         <section className="card">
-          <h2>PSI base</h2>
+          <h2>{datasetLabel}</h2>
 
           <form className="filter-form" onSubmit={handleFilterSubmit}>
             <div className="filter-grid single">
@@ -612,7 +678,7 @@ export default function EditsPage() {
                   </tr>
                 )}
                 {localRows.map((row) => {
-                  const rowKey = makeRowKey(row);
+                  const rowKey = getRowKey(row);
                   const isEdited = edits.has(rowKey);
                   const isSelected = selectedRowKeys.has(rowKey);
                   return (
@@ -625,7 +691,7 @@ export default function EditsPage() {
                         />
                       </td>
                       {selectedDataset.columns.map((column) => {
-                        const cellValue = row[column.name as keyof PsiBaseRecord];
+                        const cellValue = row[column.name];
                         const displayValue =
                           cellValue === null || cellValue === undefined ? "" : String(cellValue);
                         if (!editableColumns.has(column.name)) {

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -467,7 +467,6 @@ export default function ReallocationPage() {
     };
     setLines((prev) => {
       const next = [...prev, newLine];
-      setPlanLinesPage(Math.max(1, Math.ceil(next.length / PLAN_LINES_PAGE_SIZE)));
       return next;
     });
     setPlanDirty(true);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -253,6 +253,29 @@ export interface PsiBasePage {
   rows: PsiBaseRecord[];
 }
 
+export interface PsiSummaryBaseRecord {
+  session_id: string;
+  sku_code: string;
+  sku_name?: string | null;
+  warehouse_name: string;
+  channel: string;
+  inbound_qty?: string | number | null;
+  outbound_qty?: string | number | null;
+  std_stock?: string | number | null;
+  stock?: string | number | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  updated_by?: string | null;
+  updated_by_username?: string | null;
+}
+
+export interface PsiSummaryBasePage {
+  page: number;
+  size: number;
+  total: number;
+  rows: PsiSummaryBaseRecord[];
+}
+
 export interface PsiBaseImportResponse {
   added: number;
   updated: number;


### PR DESCRIPTION
## Summary
- keep the Transfer Plan Lines pagination on the current page when a manual line is added
- extend session dataset APIs and the Edits page to support editing `psi_summary_base` data alongside `psi_base`
- add summary dataset models to the frontend types and backend tests, including automatic table provisioning

## Testing
- pytest backend/tests/test_sessions_api.py


------
https://chatgpt.com/codex/tasks/task_e_68e213fd6b94832e8c3f9c397be950c8