### PR TITLE
Fix PSI gap calculation to use stock start

### DIFF
--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -67,7 +67,7 @@ export const getMetricValue = (row: PsiRow | undefined, metric: MetricKey): numb
     case "gap": {
       const stdStock = safeNumber(row.stdStock);
       const stockStart = safeNumber(row.stockStart);
-      return stdStock - stockStart;
+      return stockStart - stdStock;
     }
     case "gapAfter": {
       const gap = getMetricValue(row, "gap");

--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -112,7 +112,7 @@ export default function CrossTableView({ rows, metrics, orientation = "warehouse
   const getMetricLabelContent = (metricKey: MetricDefinition["key"], label: string) => {
     if (metricKey === "gap") {
       return (
-        <span className="metric-label-text" title="Gap = Std Stock − Stock Closing">
+        <span className="metric-label-text" title="Gap = Stock @ Start − Std Stock">
           {label}
           <span className="metric-info" aria-hidden="true">
             i


### PR DESCRIPTION
## Summary
- update the PSI gap metric to subtract the standard stock from the starting stock
- align the PSI matrix tooltip description with the updated formula

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68e26cd4b400832e8ccd3dfa69a1ab23