### PR TITLE
Improve PSI matrix grid usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ A minimal GEN-like PSI (Production, Sales, Inventory) ERP prototype built with F
 
    The Vite dev server runs on <http://localhost:5173>. If you open a second instance (e.g. Vite preview) it usually listens on <http://localhost:5174>. Ensure both origins are present in `ALLOWED_ORIGINS` so that cookies can be shared when using `credentials: 'include'`. When exposing the dev server over your LAN (e.g. <http://192.168.11.64:5174>), append that host to `ALLOWED_ORIGINS` as well.
 
+## PSI matrix grid controls
+
+The PSI Matrix (Reallocation › PSI Matrix tabs) now ships with a fixed-width, scrollable grid that keeps the **Metric** and **Total** columns pinned on the left and prevents value columns from auto-expanding. Use the controls above the grid to tune the display:
+
+- **Compact mode** toggles between the regular layout and a condensed view that shortens headers, applies ellipsis with tooltips, and reduces line-height for dense, multi-metric comparisons.
+- **Row height** can be left on _Auto_ (cells grow with wrapped content) or switched to _Fixed_ (28 px in compact mode) for a predictable, spreadsheet-like layout across all PSI Matrix tabs.
+- The **column visibility panel** lets you expand/collapse each warehouse/channel group and toggle whole groups or individual channels on/off. Group headers in the grid act as shortcuts for collapse/expand, and collapsed groups show a single aggregated column so totals remain visible.
+- All numeric cells are right-aligned with tabular figures, tooltips expose the full warehouse × channel label, and totals use a dedicated sticky column for quick scanning.
+
 ## Authentication API quick check
 
 1. **Login**

--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -7,6 +7,7 @@ import BarsView from "./views/BarsView";
 import KpiView from "./views/KpiView";
 import type { PsiRow } from "./types";
 import { METRIC_DEFINITIONS, formatMetricValue, safeNumber } from "./utils";
+import { createDefaultGridState, PSI_GRID_CONFIG, type RowDensityMode } from "./gridLayoutConfig";
 import "../../../styles/psi-matrix.css";
 
 const TAB_CONFIG = [
@@ -98,6 +99,7 @@ export function PSIMatrixTabs({
   const isSkuSearchControlled = typeof skuSearch === "string";
   const skuSearchValue = isSkuSearchControlled ? skuSearch : internalSkuSearch;
   const [isSuggestionsVisible, setSuggestionsVisible] = useState(false);
+  const [gridState, setGridState] = useState(createDefaultGridState);
 
   const handleSkuSearchChange = (value: string) => {
     if (onSkuSearchChange) {
@@ -106,6 +108,20 @@ export function PSIMatrixTabs({
     if (!isSkuSearchControlled) {
       setInternalSkuSearch(value);
     }
+  };
+
+  const handleToggleCompact = () => {
+    setGridState((previous) => ({
+      ...previous,
+      compactMode: !previous.compactMode,
+    }));
+  };
+
+  const handleRowDensityChange = (value: RowDensityMode) => {
+    setGridState((previous) => ({
+      ...previous,
+      rowDensity: value,
+    }));
   };
 
   const skuMetadataMap = useMemo(() => {
@@ -358,16 +374,35 @@ export function PSIMatrixTabs({
         break;
       case "cross":
         tabContent = (
-          <CrossTableView rows={rowsForSku} metrics={METRIC_DEFINITIONS} orientation="warehouse-first" />
+          <CrossTableView
+            rows={rowsForSku}
+            metrics={METRIC_DEFINITIONS}
+            orientation="warehouse-first"
+            compactMode={gridState.compactMode}
+            rowDensity={gridState.rowDensity}
+          />
         );
         break;
       case "cross2":
         tabContent = (
-          <CrossTableView rows={rowsForSku} metrics={METRIC_DEFINITIONS} orientation="channel-first" />
+          <CrossTableView
+            rows={rowsForSku}
+            metrics={METRIC_DEFINITIONS}
+            orientation="channel-first"
+            compactMode={gridState.compactMode}
+            rowDensity={gridState.rowDensity}
+          />
         );
         break;
       case "heatmap":
-        tabContent = <HeatmapView rows={rowsForSku} metrics={METRIC_DEFINITIONS} />;
+        tabContent = (
+          <HeatmapView
+            rows={rowsForSku}
+            metrics={METRIC_DEFINITIONS}
+            compactMode={gridState.compactMode}
+            rowDensity={gridState.rowDensity}
+          />
+        );
         break;
       case "bars":
         tabContent = <BarsView rows={rowsForSku} />;
@@ -462,6 +497,22 @@ export function PSIMatrixTabs({
               </div>
             </div>
           </div>
+        </div>
+        <div className="psi-matrix-grid-controls" role="group" aria-label="グリッド表示設定">
+          <label className="psi-matrix-grid-toggle">
+            <input type="checkbox" checked={gridState.compactMode} onChange={handleToggleCompact} />
+            <span>コンパクトモード</span>
+          </label>
+          <label className="psi-matrix-grid-density">
+            <span>行の高さ</span>
+            <select
+              value={gridState.rowDensity}
+              onChange={(event) => handleRowDensityChange(event.target.value as RowDensityMode)}
+            >
+              <option value="auto">自動</option>
+              <option value="fixed">固定 ({PSI_GRID_CONFIG.compact.rowHeight}px)</option>
+            </select>
+          </label>
         </div>
       </div>
       <div className="psi-matrix-tablist" role="tablist" aria-label="PSI matrix views">

--- a/frontend/src/features/reallocation/psi/components/MatrixColumnVisibilityPanel.tsx
+++ b/frontend/src/features/reallocation/psi/components/MatrixColumnVisibilityPanel.tsx
@@ -1,0 +1,92 @@
+import type { MatrixGroupMeta } from "../gridUtils";
+
+interface MatrixColumnVisibilityPanelProps {
+  groups: MatrixGroupMeta[];
+  collapsedGroups: Set<string>;
+  visibleColumns: Set<string>;
+  onToggleGroupCollapse: (groupId: string) => void;
+  onToggleGroupVisibility: (groupId: string, visible: boolean) => void;
+  onToggleColumnVisibility: (columnId: string, visible: boolean) => void;
+}
+
+export function MatrixColumnVisibilityPanel({
+  groups,
+  collapsedGroups,
+  visibleColumns,
+  onToggleGroupCollapse,
+  onToggleGroupVisibility,
+  onToggleColumnVisibility,
+}: MatrixColumnVisibilityPanelProps) {
+  return (
+    <div className="psi-matrix-column-panel" role="region" aria-label="列表示コントロール">
+      <details open>
+        <summary>列表示を調整</summary>
+        <div className="psi-matrix-column-panel__content">
+          {groups.map((group) => {
+            const groupColumnIds = group.columns.map((column) => column.id);
+            const visibleCount = groupColumnIds.reduce((count, columnId) => count + (visibleColumns.has(columnId) ? 1 : 0), 0);
+            const isAllVisible = visibleCount === groupColumnIds.length;
+            const isNoneVisible = visibleCount === 0;
+            const groupCollapsed = collapsedGroups.has(group.id);
+
+            return (
+              <div key={group.id} className="psi-matrix-column-panel__group">
+                <div className="psi-matrix-column-panel__group-header">
+                  <div className="psi-matrix-column-panel__group-summary">
+                    <button
+                      type="button"
+                      className="psi-matrix-column-panel__toggle"
+                      onClick={() => onToggleGroupCollapse(group.id)}
+                      aria-label={`${group.fullLabel} を${groupCollapsed ? "展開" : "折りたたみ"}`}
+                    >
+                      {groupCollapsed ? "▸" : "▾"}
+                    </button>
+                    <span title={group.fullLabel}>{group.shortLabel}</span>
+                    <span className="psi-matrix-column-panel__count">
+                      {visibleCount}/{groupColumnIds.length}
+                    </span>
+                  </div>
+                  <div className="psi-matrix-column-panel__group-actions">
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={isAllVisible}
+                        aria-checked={isAllVisible ? "true" : isNoneVisible ? "false" : "mixed"}
+                        ref={(element) => {
+                          if (element) {
+                            element.indeterminate = !isAllVisible && !isNoneVisible;
+                          }
+                        }}
+                        onChange={(event) => onToggleGroupVisibility(group.id, event.target.checked)}
+                      />
+                      全表示
+                    </label>
+                  </div>
+                </div>
+                {!groupCollapsed && (
+                  <div className="psi-matrix-column-panel__channels">
+                    {group.columns.map((column) => {
+                      const isVisible = visibleColumns.has(column.id);
+                      return (
+                        <label key={column.id} title={column.tooltip} className="psi-matrix-column-panel__channel">
+                          <input
+                            type="checkbox"
+                            checked={isVisible}
+                            onChange={(event) => onToggleColumnVisibility(column.id, event.target.checked)}
+                          />
+                          <span>{column.shortLabel}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+export default MatrixColumnVisibilityPanel;

--- a/frontend/src/features/reallocation/psi/gridLayoutConfig.ts
+++ b/frontend/src/features/reallocation/psi/gridLayoutConfig.ts
@@ -1,0 +1,58 @@
+export type RowDensityMode = "auto" | "fixed";
+
+const DEFAULT_GROUP_ORDER = [
+  "住商グローバル・ロジスティクス",
+  "名鉄運輸",
+  "三井倉庫",
+  "上組",
+  "日通",
+];
+
+const DEFAULT_CHANNEL_ORDER = [
+  "online",
+  "retail",
+  "wholesale",
+  "outlet",
+  "other",
+];
+
+export const PSI_GRID_CONFIG = {
+  widths: {
+    metric: 180,
+    total: 96,
+    value: 118,
+  },
+  compact: {
+    enabledByDefault: false,
+    rowHeight: 28,
+    lineHeight: 1.2,
+  },
+  defaultRowHeight: 38,
+  pinnedLeft: ["metric", "total"] as const,
+  groupOrder: DEFAULT_GROUP_ORDER,
+  channelOrder: DEFAULT_CHANNEL_ORDER,
+  warehouseAbbreviations: {
+    "住商グローバル・ロジスティクス": "住商GL",
+    "名鉄運輸": "名鉄",
+    "三井倉庫": "三井",
+    "上組": "上組",
+    "日通": "日通",
+  } as Record<string, string>,
+  channelAbbreviations: {
+    online: "ONL",
+    retail: "RTL",
+    wholesale: "WHO",
+    outlet: "OUT",
+    other: "OTH",
+  } as Record<string, string>,
+};
+
+export interface GridStateConfig {
+  compactMode: boolean;
+  rowDensity: RowDensityMode;
+}
+
+export const createDefaultGridState = (): GridStateConfig => ({
+  compactMode: PSI_GRID_CONFIG.compact.enabledByDefault,
+  rowDensity: "auto",
+});

--- a/frontend/src/features/reallocation/psi/gridUtils.tsx
+++ b/frontend/src/features/reallocation/psi/gridUtils.tsx
@@ -1,0 +1,246 @@
+import type { Column } from "react-data-grid";
+
+import type { MetricDefinition, PsiRow } from "./types";
+import { PSI_GRID_CONFIG } from "./gridLayoutConfig";
+import { buildColumnGroups, formatMetricValue, getMetricValue, makeColumnKey, safeNumber } from "./utils";
+
+export interface MatrixColumnMeta {
+  id: string;
+  warehouse: string;
+  channel: string;
+  shortLabel: string;
+  fullLabel: string;
+  tooltip: string;
+}
+
+export interface MatrixGroupMeta {
+  id: string;
+  shortLabel: string;
+  fullLabel: string;
+  tooltip: string;
+  columns: MatrixColumnMeta[];
+}
+
+export interface MetricRowData {
+  id: string;
+  metricKey: MetricDefinition["key"];
+  metricLabel: string;
+  metricShortLabel?: string;
+  metricTooltip?: string;
+  total: string;
+  totalValue: number;
+  values: Record<string, number | null>;
+  groupTotals: Record<string, number>;
+}
+
+const abbreviate = (value: string, dictionary: Record<string, string>): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "-";
+  }
+  return dictionary[trimmed] ?? (trimmed.length <= 6 ? trimmed : trimmed.slice(0, 6));
+};
+
+const normalizeGroupOrder = (name: string, order: string[]): number => {
+  const index = order.indexOf(name);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+};
+
+export const buildWarehouseFirstGroups = (rows: PsiRow[]): MatrixGroupMeta[] => {
+  const groups = buildColumnGroups(rows);
+  const sortedGroups = groups.sort((a, b) => {
+    const orderA = normalizeGroupOrder(a.warehouse, PSI_GRID_CONFIG.groupOrder);
+    const orderB = normalizeGroupOrder(b.warehouse, PSI_GRID_CONFIG.groupOrder);
+    if (orderA !== orderB) {
+      return orderA - orderB;
+    }
+    return a.warehouse.localeCompare(b.warehouse);
+  });
+  return sortedGroups.map((group) => ({
+    id: `warehouse:${group.warehouse}`,
+    shortLabel: abbreviate(group.warehouse, PSI_GRID_CONFIG.warehouseAbbreviations),
+    fullLabel: group.warehouse,
+    tooltip: group.warehouse,
+    columns: group.channels
+      .sort((a, b) => {
+        const orderA = normalizeGroupOrder(a, PSI_GRID_CONFIG.channelOrder);
+        const orderB = normalizeGroupOrder(b, PSI_GRID_CONFIG.channelOrder);
+        if (orderA !== orderB) {
+          return orderA - orderB;
+        }
+        return a.localeCompare(b);
+      })
+      .map<MatrixColumnMeta>((channel) => ({
+        id: makeColumnKey(group.warehouse, channel),
+        warehouse: group.warehouse,
+        channel,
+        shortLabel: abbreviate(channel, PSI_GRID_CONFIG.channelAbbreviations),
+        fullLabel: channel,
+        tooltip: `${group.warehouse} × ${channel}`,
+      })),
+  }));
+};
+
+export const buildChannelFirstGroups = (rows: PsiRow[]): MatrixGroupMeta[] => {
+  const map = new Map<string, Set<string>>();
+  rows.forEach((row) => {
+    const channel = row.channel || "-";
+    const warehouse = row.warehouse || "-";
+    const set = map.get(channel) ?? new Set<string>();
+    set.add(warehouse);
+    map.set(channel, set);
+  });
+  return Array.from(map.entries())
+    .sort((a, b) => {
+      const orderA = normalizeGroupOrder(a[0], PSI_GRID_CONFIG.channelOrder);
+      const orderB = normalizeGroupOrder(b[0], PSI_GRID_CONFIG.channelOrder);
+      if (orderA !== orderB) {
+        return orderA - orderB;
+      }
+      return a[0].localeCompare(b[0]);
+    })
+    .map<MatrixGroupMeta>(([channel, warehouses]) => ({
+      id: `channel:${channel}`,
+      shortLabel: abbreviate(channel, PSI_GRID_CONFIG.channelAbbreviations),
+      fullLabel: channel,
+      tooltip: channel,
+      columns: Array.from(warehouses)
+        .sort((a, b) => {
+          const orderA = normalizeGroupOrder(a, PSI_GRID_CONFIG.groupOrder);
+          const orderB = normalizeGroupOrder(b, PSI_GRID_CONFIG.groupOrder);
+          if (orderA !== orderB) {
+            return orderA - orderB;
+          }
+          return a.localeCompare(b);
+        })
+        .map<MatrixColumnMeta>((warehouse) => ({
+          id: makeColumnKey(warehouse, channel),
+          warehouse,
+          channel,
+          shortLabel: abbreviate(warehouse, PSI_GRID_CONFIG.warehouseAbbreviations),
+          fullLabel: warehouse,
+          tooltip: `${warehouse} × ${channel}`,
+        })),
+    }));
+};
+
+export const buildMetricRows = (
+  rows: PsiRow[],
+  metrics: MetricDefinition[],
+  columnIds: string[],
+  columnGroups: MatrixGroupMeta[],
+) => {
+  const rowMap = new Map<string, PsiRow>();
+  rows.forEach((row) => {
+    rowMap.set(makeColumnKey(row.warehouse, row.channel), row);
+  });
+
+  return metrics.map<MetricRowData>((metric) => {
+    const values: Record<string, number | null> = {};
+    let metricTotal = 0;
+    const groupTotals: Record<string, number> = {};
+
+    columnIds.forEach((columnId) => {
+      const value = getMetricValue(rowMap.get(columnId), metric.key);
+      values[columnId] = value;
+      metricTotal += safeNumber(value);
+    });
+
+    columnGroups.forEach((group) => {
+      let sum = 0;
+      group.columns.forEach((column) => {
+        sum += safeNumber(values[column.id]);
+      });
+      groupTotals[group.id] = sum;
+    });
+
+    return {
+      id: metric.key,
+      metricKey: metric.key,
+      metricLabel: metric.label,
+      metricShortLabel: metric.shortLabel,
+      metricTooltip: metric.description,
+      totalValue: metricTotal,
+      total: formatMetricValue(metricTotal),
+      values,
+      groupTotals,
+    } satisfies MetricRowData;
+  });
+};
+
+export const buildColumnIdList = (groups: MatrixGroupMeta[]): string[] =>
+  groups.flatMap((group) => group.columns.map((column) => column.id));
+
+export const makeValueColumn = (
+  meta: MatrixColumnMeta,
+  options: {
+    compactMode: boolean;
+    hidden?: boolean;
+    className?: Column<MetricRowData>["className"];
+    headerClass?: string;
+    groupCollapsed?: boolean;
+  },
+): Column<MetricRowData> => ({
+  key: meta.id,
+  name: options.compactMode ? meta.shortLabel : meta.fullLabel,
+  width: PSI_GRID_CONFIG.widths.value,
+  headerCellClass: options.headerClass,
+  className: options.className ?? "psi-matrix-value-cell",
+  frozen: false,
+  renderCell: ({ row }) => {
+    const rawValue = row.values[meta.id];
+    const formatted = formatMetricValue(rawValue);
+    const numeric = rawValue ?? 0;
+    const trendClass = numeric === 0 ? "value-neutral" : numeric > 0 ? "value-positive" : "value-negative";
+    return (
+      <span className={`psi-matrix-value ${trendClass}`} title={`${meta.tooltip} : ${formatted}`}>
+        {formatted}
+      </span>
+    );
+  },
+  ...(options.hidden ? { width: 0, className: "psi-matrix-column-hidden" } : null),
+});
+
+export const makeCollapsedGroupColumn = (
+  group: MatrixGroupMeta,
+  options: {
+    compactMode: boolean;
+    renderValue?: (params: { row: MetricRowData; formatted: string }) => React.ReactNode;
+  },
+): Column<MetricRowData> => ({
+  key: `${group.id}::collapsed`,
+  name: options.compactMode ? group.shortLabel : group.fullLabel,
+  width: PSI_GRID_CONFIG.widths.value,
+  headerCellClass: "psi-matrix-header--collapsed",
+  className: "psi-matrix-cell--collapsed",
+  renderCell: ({ row }) => {
+    const value = row.groupTotals[group.id] ?? 0;
+    const formatted = formatMetricValue(value);
+    const trendClass = value === 0 ? "value-neutral" : value > 0 ? "value-positive" : "value-negative";
+    if (options.renderValue) {
+      return options.renderValue({ row, formatted });
+    }
+    return <span className={`psi-matrix-value ${trendClass}`}>{formatted}</span>;
+  },
+});
+
+export const buildGroupTotals = (
+  metrics: MetricDefinition[],
+  columnGroups: MatrixGroupMeta[],
+  metricRows: MetricRowData[],
+) => {
+  const totals = new Map<string, Map<string, number>>();
+  columnGroups.forEach((group) => {
+    const metricTotals = new Map<string, number>();
+    metrics.forEach((metric) => {
+      let sum = 0;
+      group.columns.forEach((column) => {
+        const value = metricRows.find((row) => row.metricKey === metric.key)?.values[column.id];
+        sum += safeNumber(value);
+      });
+      metricTotals.set(metric.key, sum);
+    });
+    totals.set(group.id, metricTotals);
+  });
+  return totals;
+};

--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -1,211 +1,268 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+import DataGrid, { type Column, type ColumnGroupDescriptor } from "react-data-grid";
 
 import type { MetricDefinition, PsiRow } from "../types";
 import {
-  buildColumnGroups,
-  formatMetricValue,
-  getMetricValue,
-  makeColumnKey,
-  safeNumber,
-} from "../utils";
+  buildChannelFirstGroups,
+  buildColumnIdList,
+  buildMetricRows,
+  buildWarehouseFirstGroups,
+  makeCollapsedGroupColumn,
+  makeValueColumn,
+  type MatrixGroupMeta,
+  type MetricRowData,
+} from "../gridUtils";
+import { PSI_GRID_CONFIG, type RowDensityMode } from "../gridLayoutConfig";
+import MatrixColumnVisibilityPanel from "../components/MatrixColumnVisibilityPanel";
+import { formatMetricValue } from "../utils";
 
 interface CrossTableViewProps {
   rows: PsiRow[];
   metrics: MetricDefinition[];
   orientation?: "warehouse-first" | "channel-first";
+  compactMode: boolean;
+  rowDensity: RowDensityMode;
 }
 
-interface HeaderColumn {
-  key: string;
-  warehouse: string;
-  channel: string;
-  label: string;
-  className: string;
-}
+const METRIC_COLUMN_KEY = "metric";
+const TOTAL_COLUMN_KEY = "total";
 
-interface HeaderGroup {
-  label: string;
-  className: string;
-  columns: HeaderColumn[];
-}
-
-const getValueClassName = (value: number | null) => {
-  if (value === null || value === 0) {
-    return "value-neutral";
-  }
-  if (value > 0) {
-    return "value-positive";
-  }
-  return "value-negative";
-};
-
-const buildHeaderGroups = (rows: PsiRow[], orientation: Required<CrossTableViewProps>["orientation"]): HeaderGroup[] => {
+const buildGroupMeta = (
+  rows: PsiRow[],
+  orientation: Required<CrossTableViewProps>["orientation"],
+): MatrixGroupMeta[] => {
   if (orientation === "channel-first") {
-    const map = new Map<string, Set<string>>();
-    rows.forEach((row) => {
-      const channel = row.channel || "-";
-      const warehouse = row.warehouse || "-";
-      const set = map.get(channel) ?? new Set<string>();
-      set.add(warehouse);
-      map.set(channel, set);
-    });
-    return Array.from(map.entries())
-      .map(([channel, warehouses]) => ({
-        label: channel,
-        className: "channel-header",
-        columns: Array.from(warehouses)
-          .sort((a, b) => a.localeCompare(b))
-          .map<HeaderColumn>((warehouse) => ({
-            key: makeColumnKey(warehouse, channel),
-            warehouse,
-            channel,
-            label: warehouse,
-            className: "warehouse-header",
-          })),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label));
+    return buildChannelFirstGroups(rows);
   }
-
-  return buildColumnGroups(rows).map<HeaderGroup>((group) => ({
-    label: group.warehouse,
-    className: "warehouse-header",
-    columns: group.channels.map<HeaderColumn>((channel) => ({
-      key: makeColumnKey(group.warehouse, channel),
-      warehouse: group.warehouse,
-      channel,
-      label: channel,
-      className: "channel-header",
-    })),
-  }));
+  return buildWarehouseFirstGroups(rows);
 };
 
-export default function CrossTableView({ rows, metrics, orientation = "warehouse-first" }: CrossTableViewProps) {
-  const headerGroups = useMemo(() => buildHeaderGroups(rows, orientation), [rows, orientation]);
-  const headerColumns = useMemo(
-    () => headerGroups.flatMap((group) => group.columns),
-    [headerGroups],
-  );
-  const rowMap = useMemo(() => {
-    const map = new Map<string, PsiRow>();
-    rows.forEach((row) => {
-      map.set(makeColumnKey(row.warehouse, row.channel), row);
-    });
-    return map;
-  }, [rows]);
+const buildMetricColumn = (compactMode: boolean): Column<MetricRowData> => ({
+  key: METRIC_COLUMN_KEY,
+  name: "Metric",
+  width: PSI_GRID_CONFIG.widths.metric,
+  frozen: true,
+  headerCellClass: "psi-matrix-header psi-matrix-header--metric",
+  className: compactMode
+    ? "psi-matrix-cell psi-matrix-cell--metric psi-matrix-cell--compact"
+    : "psi-matrix-cell psi-matrix-cell--metric",
+  renderCell: ({ row }) => {
+    const label = compactMode && row.metricShortLabel ? row.metricShortLabel : row.metricLabel;
+    const tooltip = row.metricTooltip ?? row.metricLabel;
+    return (
+      <span className="psi-matrix-metric-label" title={tooltip}>
+        {label}
+      </span>
+    );
+  },
+});
 
-  if (headerColumns.length === 0) {
+const buildTotalColumn = (): Column<MetricRowData> => ({
+  key: TOTAL_COLUMN_KEY,
+  name: "Total",
+  width: PSI_GRID_CONFIG.widths.total,
+  frozen: true,
+  headerCellClass: "psi-matrix-header psi-matrix-header--total",
+  className: "psi-matrix-cell psi-matrix-cell--total",
+  renderCell: ({ row }) => {
+    const value = row.totalValue;
+    const formatted = formatMetricValue(value);
+    const trendClass = value === 0 ? "value-neutral" : value > 0 ? "value-positive" : "value-negative";
+    return <span className={`psi-matrix-value ${trendClass}`}>{formatted}</span>;
+  },
+});
+
+export default function CrossTableView({
+  rows,
+  metrics,
+  orientation = "warehouse-first",
+  compactMode,
+  rowDensity,
+}: CrossTableViewProps) {
+  const columnGroups = useMemo(() => buildGroupMeta(rows, orientation), [rows, orientation]);
+  const columnIds = useMemo(() => buildColumnIdList(columnGroups), [columnGroups]);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [visibleColumns, setVisibleColumns] = useState<Set<string>>(() => new Set(columnIds));
+
+  useEffect(() => {
+    setVisibleColumns((previous) => {
+      const next = new Set(previous);
+      columnIds.forEach((id) => {
+        next.add(id);
+      });
+      Array.from(next).forEach((id) => {
+        if (!columnIds.includes(id)) {
+          next.delete(id);
+        }
+      });
+      return next;
+    });
+  }, [columnIds]);
+
+  useEffect(() => {
+    setCollapsedGroups((previous) => {
+      const next = new Set<string>();
+      columnGroups.forEach((group) => {
+        if (previous.has(group.id)) {
+          next.add(group.id);
+        }
+      });
+      return next;
+    });
+  }, [columnGroups]);
+
+  const metricRows = useMemo(
+    () => buildMetricRows(rows, metrics, columnIds, columnGroups),
+    [rows, metrics, columnIds, columnGroups],
+  );
+
+  const metricColumn = useMemo(() => buildMetricColumn(compactMode), [compactMode]);
+  const totalColumn = useMemo(() => buildTotalColumn(), []);
+
+  const valueColumns = useMemo(() => {
+    const columns: Column<MetricRowData>[] = [];
+    const groupDescriptors: ColumnGroupDescriptor[] = [];
+
+    columnGroups.forEach((group) => {
+      const groupColumnKeys: string[] = [];
+      if (collapsedGroups.has(group.id)) {
+        const collapsedColumn = makeCollapsedGroupColumn(group, { compactMode });
+        columns.push({ ...collapsedColumn, className: "psi-matrix-value-cell psi-matrix-value-cell--collapsed" });
+        groupColumnKeys.push(collapsedColumn.key);
+      } else {
+        group.columns.forEach((meta) => {
+          if (!visibleColumns.has(meta.id)) {
+            return;
+          }
+          const column = makeValueColumn(meta, {
+            compactMode,
+            className: compactMode
+              ? "psi-matrix-value-cell psi-matrix-value-cell--compact"
+              : "psi-matrix-value-cell",
+          });
+          columns.push(column);
+          groupColumnKeys.push(column.key);
+        });
+        if (groupColumnKeys.length === 0) {
+          const placeholder = makeCollapsedGroupColumn(group, { compactMode });
+          const placeholderKey = `${placeholder.key}::placeholder`;
+          columns.push({
+            ...placeholder,
+            key: placeholderKey,
+            renderCell: () => <span className="psi-matrix-value value-neutral">—</span>,
+          });
+          groupColumnKeys.push(placeholderKey);
+        }
+      }
+
+      if (groupColumnKeys.length > 0) {
+        groupDescriptors.push({
+          id: group.id,
+          label: compactMode ? group.shortLabel : group.fullLabel,
+          columnKeys: groupColumnKeys,
+          collapsed: collapsedGroups.has(group.id),
+          tooltip: group.tooltip,
+        });
+      }
+    });
+
+    return { columns, groupDescriptors } as const;
+  }, [columnGroups, collapsedGroups, visibleColumns, compactMode]);
+
+  const columns = useMemo(
+    () => [metricColumn, totalColumn, ...valueColumns.columns],
+    [metricColumn, totalColumn, valueColumns.columns],
+  );
+
+  const columnGroupDescriptors = valueColumns.groupDescriptors;
+
+  const handleToggleGroup = useCallback((groupId: string) => {
+    setCollapsedGroups((previous) => {
+      const next = new Set(previous);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleToggleGroupVisibility = useCallback((groupId: string, visible: boolean) => {
+    const group = columnGroups.find((item) => item.id === groupId);
+    if (!group) {
+      return;
+    }
+    setVisibleColumns((previous) => {
+      const next = new Set(previous);
+      group.columns.forEach((column) => {
+        if (visible) {
+          next.add(column.id);
+        } else {
+          next.delete(column.id);
+        }
+      });
+      return next;
+    });
+  }, [columnGroups]);
+
+  const handleToggleColumnVisibility = useCallback((columnId: string, visible: boolean) => {
+    setVisibleColumns((previous) => {
+      const next = new Set(previous);
+      if (visible) {
+        next.add(columnId);
+      } else {
+        next.delete(columnId);
+      }
+      return next;
+    });
+  }, []);
+
+  if (columns.length <= 2) {
     return <p className="psi-matrix-empty">No rows match the current filters.</p>;
   }
 
-  const totalsByMetric = useMemo(() => {
-    const totals = new Map<string, number>();
-    metrics.forEach((metric) => {
-      const total = headerColumns.reduce((sum, column) => {
-        const value = getMetricValue(rowMap.get(column.key), metric.key);
-        return sum + safeNumber(value);
-      }, 0);
-      totals.set(metric.key, total);
-    });
-    return totals;
-  }, [headerColumns, metrics, rowMap]);
+  const gridClassName = [
+    "psi-matrix-grid",
+    compactMode ? "psi-matrix-grid--compact" : null,
+    rowDensity === "fixed" ? "psi-matrix-grid--fixed" : "psi-matrix-grid--auto",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
-  const getMetricLabelContent = (metricKey: MetricDefinition["key"], label: string) => {
-    if (metricKey === "gap") {
-      return (
-        <span className="metric-label-text" title="Gap = Stock @ Start − Std Stock">
-          {label}
-          <span className="metric-info" aria-hidden="true">
-            i
-          </span>
-        </span>
-      );
-    }
-    if (metricKey === "gapAfter") {
-      return (
-        <span className="metric-label-text" title="Gap After = Gap + Move">
-          {label}
-          <span className="metric-info" aria-hidden="true">
-            i
-          </span>
-        </span>
-      );
-    }
-    return label;
-  };
+  const fixedRowHeight = rowDensity === "fixed"
+    ? compactMode
+      ? PSI_GRID_CONFIG.compact.rowHeight
+      : PSI_GRID_CONFIG.defaultRowHeight
+    : undefined;
 
-  const renderNumberCell = (value: number | null) => {
-    if (value === null) {
-      return <span className="psi-matrix-value value-neutral">-</span>;
-    }
-    const className = `psi-matrix-value ${getValueClassName(value)}`;
-    const isNegative = value < 0;
-    const formatted = formatMetricValue(Math.abs(value));
-    return (
-      <span className={className}>
-        {isNegative ? (
-          <>
-            <span className="visually-hidden">マイナス</span>
-            <span aria-hidden="true" className="value-prefix">
-              🔺
-            </span>
-          </>
-        ) : null}
-        <span className="value-number">{formatted}</span>
-      </span>
-    );
-  };
-
-  const renderValue = (metricKey: MetricDefinition["key"], columnKey: string) => {
-    const value = getMetricValue(rowMap.get(columnKey), metricKey);
-    return renderNumberCell(value);
-  };
-
-  const renderTotalValue = (value: number) => renderNumberCell(value);
+  const gridStyle: CSSProperties | undefined = fixedRowHeight
+    ? ({ "--psi-matrix-row-height": `${fixedRowHeight}px` } as CSSProperties)
+    : undefined;
 
   return (
-    <div className="psi-matrix-scroll">
-      <table className="psi-matrix-table">
-        <thead>
-          <tr>
-            <th rowSpan={2} className="metric-column">
-              Metric
-            </th>
-            <th rowSpan={2} className="total-column">
-              Total
-            </th>
-            {headerGroups.map((group) => (
-              <th key={group.label} colSpan={group.columns.length} className={group.className}>
-                {group.label}
-              </th>
-            ))}
-          </tr>
-          <tr>
-            {headerGroups.flatMap((group) =>
-              group.columns.map((column) => (
-                <th key={column.key} className={column.className}>
-                  {column.label}
-                </th>
-              )),
-            )}
-          </tr>
-        </thead>
-        <tbody>
-          {metrics.map((metric) => {
-            const totalValue = totalsByMetric.get(metric.key) ?? 0;
-            return (
-              <tr key={metric.key}>
-                <th scope="row" className="metric-label">
-                  {getMetricLabelContent(metric.key, metric.label)}
-                </th>
-                <td className="total-cell">{renderTotalValue(totalValue)}</td>
-                {headerColumns.map((column) => (
-                  <td key={column.key}>{renderValue(metric.key, column.key)}</td>
-                ))}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+    <div className="psi-matrix-view">
+      <MatrixColumnVisibilityPanel
+        groups={columnGroups}
+        collapsedGroups={collapsedGroups}
+        visibleColumns={visibleColumns}
+        onToggleGroupCollapse={handleToggleGroup}
+        onToggleGroupVisibility={handleToggleGroupVisibility}
+        onToggleColumnVisibility={handleToggleColumnVisibility}
+      />
+      <div className={gridClassName} style={gridStyle}>
+        <DataGrid
+          columns={columns}
+          rows={metricRows}
+          rowKeyGetter={(row) => row.id}
+          className="psi-matrix-rdg"
+          columnGroups={columnGroupDescriptors}
+          onToggleColumnGroup={handleToggleGroup}
+          headerRowHeight={compactMode ? 36 : 44}
+          groupHeaderRowHeight={compactMode ? 32 : 40}
+          defaultColumnOptions={{ width: PSI_GRID_CONFIG.widths.value }}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
+++ b/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
@@ -1,19 +1,24 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+import DataGrid, { type Column, type ColumnGroupDescriptor } from "react-data-grid";
 
 import type { MetricDefinition, MetricKey, PsiRow } from "../types";
 import {
-  DEFAULT_HEATMAP_METRICS,
-  buildColumnGroups,
-  columnKeysFromGroups,
-  formatMetricValue,
-  getMetricValue,
-  makeColumnKey,
-  safeNumber,
-} from "../utils";
+  buildColumnIdList,
+  buildMetricRows,
+  buildWarehouseFirstGroups,
+  makeCollapsedGroupColumn,
+  type MatrixGroupMeta,
+  type MetricRowData,
+} from "../gridUtils";
+import { PSI_GRID_CONFIG, type RowDensityMode } from "../gridLayoutConfig";
+import { DEFAULT_HEATMAP_METRICS, formatMetricValue } from "../utils";
+import MatrixColumnVisibilityPanel from "../components/MatrixColumnVisibilityPanel";
 
 interface HeatmapViewProps {
   rows: PsiRow[];
   metrics: MetricDefinition[];
+  compactMode: boolean;
+  rowDensity: RowDensityMode;
 }
 
 const buildInitialSelection = (metrics: MetricDefinition[]) => {
@@ -31,34 +36,188 @@ const createHeatmapStyle = (value: number | null, maxAbs: number) => {
   const intensity = Math.min(Math.abs(value) / maxAbs, 1);
   const alpha = 0.2 + intensity * 0.5;
   const backgroundColor = value >= 0 ? `rgba(34, 197, 94, ${alpha})` : `rgba(239, 68, 68, ${alpha})`;
-  const textColor = intensity > 0.6 ? "var(--surface-body)" : undefined;
-  return { backgroundColor, color: textColor };
+  const color = intensity > 0.6 ? "var(--surface-body)" : undefined;
+  return { backgroundColor, color };
 };
 
-export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
-  const [selectedMetrics, setSelectedMetrics] = useState(() => buildInitialSelection(metrics));
-  const columnGroups = useMemo(() => buildColumnGroups(rows), [rows]);
-  const columnKeys = useMemo(() => columnKeysFromGroups(columnGroups), [columnGroups]);
-  const rowMap = useMemo(() => {
-    const map = new Map<string, PsiRow>();
-    rows.forEach((row) => {
-      map.set(makeColumnKey(row.warehouse, row.channel), row);
+const buildHeatmapColumn = (
+  meta: MatrixGroupMeta["columns"][number],
+  options: { compactMode: boolean; maxAbs: number },
+): Column<MetricRowData> => ({
+  key: meta.id,
+  name: options.compactMode ? meta.shortLabel : meta.fullLabel,
+  width: PSI_GRID_CONFIG.widths.value,
+  className: options.compactMode
+    ? "psi-matrix-value-cell psi-matrix-value-cell--compact psi-matrix-value-cell--heatmap"
+    : "psi-matrix-value-cell psi-matrix-value-cell--heatmap",
+  headerCellClass: "psi-matrix-header--heatmap",
+  renderCell: ({ row }) => {
+    const value = row.values[meta.id];
+    const formatted = formatMetricValue(value);
+    const style = createHeatmapStyle(value, options.maxAbs);
+    return (
+      <span className="psi-matrix-heatmap-value" style={style} title={`${meta.tooltip} : ${formatted}`}>
+        {formatted}
+      </span>
+    );
+  },
+});
+
+export default function HeatmapView({ rows, metrics, compactMode, rowDensity }: HeatmapViewProps) {
+  const [selectedMetrics, setSelectedMetrics] = useState<MetricKey[]>(() => buildInitialSelection(metrics));
+  const columnGroups = useMemo(() => buildWarehouseFirstGroups(rows), [rows]);
+  const columnIds = useMemo(() => buildColumnIdList(columnGroups), [columnGroups]);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [visibleColumns, setVisibleColumns] = useState<Set<string>>(() => new Set(columnIds));
+
+  useEffect(() => {
+    setVisibleColumns((previous) => {
+      const next = new Set(previous);
+      columnIds.forEach((id) => next.add(id));
+      Array.from(next).forEach((id) => {
+        if (!columnIds.includes(id)) {
+          next.delete(id);
+        }
+      });
+      return next;
     });
-    return map;
-  }, [rows]);
+  }, [columnIds]);
+
+  useEffect(() => {
+    setCollapsedGroups((previous) => {
+      const next = new Set<string>();
+      columnGroups.forEach((group) => {
+        if (previous.has(group.id)) {
+          next.add(group.id);
+        }
+      });
+      return next;
+    });
+  }, [columnGroups]);
+
+  const metricRows = useMemo(
+    () => buildMetricRows(rows, metrics, columnIds, columnGroups),
+    [rows, metrics, columnIds, columnGroups],
+  );
+
+  const activeRows = useMemo(
+    () => metricRows.filter((row) => selectedMetrics.includes(row.metricKey)),
+    [metricRows, selectedMetrics],
+  );
 
   const heatmapMax = useMemo(() => {
     let max = 0;
-    selectedMetrics.forEach((metric) => {
-      columnKeys.forEach((column) => {
-        const value = getMetricValue(rowMap.get(column.key), metric);
-        if (value !== null) {
-          max = Math.max(max, Math.abs(value));
+    activeRows.forEach((row) => {
+      columnIds.forEach((columnId) => {
+        const value = row.values[columnId];
+        if (typeof value === "number" && Number.isFinite(value)) {
+          const abs = Math.abs(value);
+          if (abs > max) {
+            max = abs;
+          }
         }
       });
     });
     return max;
-  }, [selectedMetrics, columnKeys, rowMap]);
+  }, [activeRows, columnIds]);
+
+  const metricColumn: Column<MetricRowData> = useMemo(
+    () => ({
+      key: "metric",
+      name: "Metric",
+      width: PSI_GRID_CONFIG.widths.metric,
+      frozen: true,
+      headerCellClass: "psi-matrix-header psi-matrix-header--metric",
+      className: compactMode
+        ? "psi-matrix-cell psi-matrix-cell--metric psi-matrix-cell--compact"
+        : "psi-matrix-cell psi-matrix-cell--metric",
+      renderCell: ({ row }) => {
+        const label = compactMode && row.metricShortLabel ? row.metricShortLabel : row.metricLabel;
+        return (
+          <span className="psi-matrix-metric-label" title={row.metricTooltip ?? row.metricLabel}>
+            {label}
+          </span>
+        );
+      },
+    }),
+    [compactMode],
+  );
+
+  const totalColumn: Column<MetricRowData> = useMemo(
+    () => ({
+      key: "total",
+      name: "Total",
+      width: PSI_GRID_CONFIG.widths.total,
+      frozen: true,
+      headerCellClass: "psi-matrix-header psi-matrix-header--total",
+      className: "psi-matrix-cell psi-matrix-cell--total",
+      renderCell: ({ row }) => {
+        const formatted = formatMetricValue(row.totalValue);
+        return <span className="psi-matrix-value psi-matrix-value--heatmap-total">{formatted}</span>;
+      },
+    }),
+    [],
+  );
+
+  const heatmapColumns = useMemo(() => {
+    const columns: Column<MetricRowData>[] = [];
+    const groupDescriptors: ColumnGroupDescriptor[] = [];
+
+    columnGroups.forEach((group) => {
+      const groupColumnKeys: string[] = [];
+      if (collapsedGroups.has(group.id)) {
+        const collapsed = makeCollapsedGroupColumn(group, {
+          compactMode,
+          renderValue: ({ row, formatted }) => {
+            const value = row.groupTotals[group.id] ?? 0;
+            const style = createHeatmapStyle(value, heatmapMax);
+            return (
+              <span className="psi-matrix-heatmap-value" style={style}>
+                {formatted}
+              </span>
+            );
+          },
+        });
+        columns.push({ ...collapsed, className: "psi-matrix-value-cell psi-matrix-value-cell--heatmap" });
+        groupColumnKeys.push(collapsed.key);
+      } else {
+        group.columns.forEach((meta) => {
+          if (!visibleColumns.has(meta.id)) {
+            return;
+          }
+          const column = buildHeatmapColumn(meta, { compactMode, maxAbs: heatmapMax });
+          columns.push(column);
+          groupColumnKeys.push(column.key);
+        });
+        if (groupColumnKeys.length === 0) {
+          const placeholder = makeCollapsedGroupColumn(group, {
+            compactMode,
+            renderValue: () => <span className="psi-matrix-heatmap-value">—</span>,
+          });
+          const placeholderKey = `${placeholder.key}::placeholder`;
+          columns.push({ ...placeholder, key: placeholderKey });
+          groupColumnKeys.push(placeholderKey);
+        }
+      }
+
+      if (groupColumnKeys.length > 0) {
+        groupDescriptors.push({
+          id: group.id,
+          label: compactMode ? group.shortLabel : group.fullLabel,
+          columnKeys: groupColumnKeys,
+          collapsed: collapsedGroups.has(group.id),
+          tooltip: group.tooltip,
+        });
+      }
+    });
+
+    return { columns, groupDescriptors } as const;
+  }, [columnGroups, collapsedGroups, visibleColumns, compactMode, heatmapMax]);
+
+  const allColumns = useMemo(
+    () => [metricColumn, totalColumn, ...heatmapColumns.columns],
+    [metricColumn, totalColumn, heatmapColumns.columns],
+  );
 
   const handleToggleMetric = (metricKey: MetricKey) => {
     setSelectedMetrics((prev) => {
@@ -77,9 +236,70 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
     setSelectedMetrics(buildInitialSelection(metrics));
   };
 
-  if (columnKeys.length === 0) {
+  const handleToggleGroup = useCallback((groupId: string) => {
+    setCollapsedGroups((previous) => {
+      const next = new Set(previous);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleToggleGroupVisibility = useCallback((groupId: string, visible: boolean) => {
+    const group = columnGroups.find((item) => item.id === groupId);
+    if (!group) {
+      return;
+    }
+    setVisibleColumns((previous) => {
+      const next = new Set(previous);
+      group.columns.forEach((column) => {
+        if (visible) {
+          next.add(column.id);
+        } else {
+          next.delete(column.id);
+        }
+      });
+      return next;
+    });
+  }, [columnGroups]);
+
+  const handleToggleColumnVisibility = useCallback((columnId: string, visible: boolean) => {
+    setVisibleColumns((previous) => {
+      const next = new Set(previous);
+      if (visible) {
+        next.add(columnId);
+      } else {
+        next.delete(columnId);
+      }
+      return next;
+    });
+  }, []);
+
+  if (allColumns.length <= 2) {
     return <p className="psi-matrix-empty">No rows match the current filters.</p>;
   }
+
+  const gridClassName = [
+    "psi-matrix-grid",
+    "psi-matrix-grid--heatmap",
+    compactMode ? "psi-matrix-grid--compact" : null,
+    rowDensity === "fixed" ? "psi-matrix-grid--fixed" : "psi-matrix-grid--auto",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const fixedRowHeight = rowDensity === "fixed"
+    ? compactMode
+      ? PSI_GRID_CONFIG.compact.rowHeight
+      : PSI_GRID_CONFIG.defaultRowHeight
+    : undefined;
+
+  const gridStyle: CSSProperties | undefined = fixedRowHeight
+    ? ({ "--psi-matrix-row-height": `${fixedRowHeight}px` } as CSSProperties)
+    : undefined;
 
   return (
     <div className="psi-heatmap">
@@ -108,65 +328,29 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
       {selectedMetrics.length === 0 ? (
         <p className="psi-matrix-empty">Select at least one metric to display the heatmap.</p>
       ) : (
-        <div className="psi-matrix-scroll">
-          <table className="psi-matrix-table psi-heatmap-table">
-            <thead>
-              <tr>
-                <th rowSpan={2} className="metric-column">
-                  Metric
-                </th>
-                {columnGroups.map((group) => (
-                  <th key={group.warehouse} colSpan={group.channels.length} className="warehouse-header">
-                    {group.warehouse}
-                  </th>
-                ))}
-                <th rowSpan={2} className="total-column">
-                  Total
-                </th>
-              </tr>
-              <tr>
-                {columnGroups.flatMap((group) =>
-                  group.channels.map((channel) => (
-                    <th key={`${group.warehouse}|${channel}`} className="channel-header">
-                      {channel}
-                    </th>
-                  )),
-                )}
-              </tr>
-            </thead>
-            <tbody>
-              {selectedMetrics.map((metricKey) => {
-                const metric = metrics.find((item) => item.key === metricKey);
-                if (!metric) {
-                  return null;
-                }
-                return (
-                  <tr key={metric.key}>
-                    <th scope="row" className="metric-label">
-                      {metric.label}
-                    </th>
-                    {columnKeys.map((column) => {
-                      const value = getMetricValue(rowMap.get(column.key), metric.key);
-                      return (
-                        <td key={column.key} style={createHeatmapStyle(value, heatmapMax)}>
-                          {formatMetricValue(value)}
-                        </td>
-                      );
-                    })}
-                    <td className="total-cell">
-                      {formatMetricValue(
-                        columnKeys.reduce((sum, column) => {
-                          const value = getMetricValue(rowMap.get(column.key), metric.key);
-                          return sum + safeNumber(value);
-                        }, 0),
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <>
+          <MatrixColumnVisibilityPanel
+            groups={columnGroups}
+            collapsedGroups={collapsedGroups}
+            visibleColumns={visibleColumns}
+            onToggleGroupCollapse={handleToggleGroup}
+            onToggleGroupVisibility={handleToggleGroupVisibility}
+            onToggleColumnVisibility={handleToggleColumnVisibility}
+          />
+          <div className={gridClassName} style={gridStyle}>
+            <DataGrid
+              columns={allColumns}
+              rows={activeRows}
+              rowKeyGetter={(row) => row.id}
+              className="psi-matrix-rdg"
+              columnGroups={heatmapColumns.groupDescriptors}
+              onToggleColumnGroup={handleToggleGroup}
+              headerRowHeight={compactMode ? 36 : 44}
+              groupHeaderRowHeight={compactMode ? 32 : 40}
+              defaultColumnOptions={{ width: PSI_GRID_CONFIG.widths.value }}
+            />
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/react-data-grid.d.ts
+++ b/frontend/src/react-data-grid.d.ts
@@ -6,6 +6,7 @@ declare module "react-data-grid" {
     RowsChangeData,
     CellClickArgs,
     DataGridProps,
+    ColumnGroupDescriptor,
   } from "../vendor/react-data-grid/index.d.ts";
 
   const DataGrid: typeof import("../vendor/react-data-grid/index.d.ts")['default'];

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -14,6 +14,33 @@
   gap: 0.75rem;
 }
 
+.psi-matrix-grid-controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.6rem;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.psi-matrix-grid-toggle,
+.psi-matrix-grid-density {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.psi-matrix-grid-density select {
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-input);
+  background: var(--surface-input);
+  padding: 0.35rem 0.6rem;
+  color: var(--text-primary);
+}
+
 .psi-matrix-tabs .sku-navigation {
   display: block;
 }
@@ -272,6 +299,224 @@
   overflow-x: auto;
 }
 
+.psi-matrix-grid {
+  --psi-matrix-row-height: 38px;
+  border: 1px solid var(--border-default);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.psi-matrix-grid .rdg {
+  border: none;
+  border-radius: 0;
+  background: var(--surface-table);
+  color: var(--text-primary);
+}
+
+.psi-matrix-grid .rdg-header {
+  background: var(--surface-table-header);
+  border-bottom-color: var(--border-default);
+}
+
+.psi-matrix-grid .rdg-header-cell,
+.psi-matrix-grid .rdg-header-group {
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  line-height: 1.2;
+}
+
+.psi-matrix-grid .rdg-header-group {
+  justify-content: space-between;
+}
+
+.psi-matrix-grid .rdg-row {
+  min-height: var(--psi-matrix-row-height);
+}
+
+.psi-matrix-grid--auto .rdg-row {
+  min-height: unset;
+}
+
+.psi-matrix-grid .rdg-cell {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.psi-matrix-grid--compact .rdg-header-cell,
+.psi-matrix-grid--compact .rdg-cell {
+  padding: 4px 8px;
+  line-height: var(--line-height-tight, 1.2);
+}
+
+.psi-matrix-grid--compact {
+  --line-height-tight: 1.2;
+  --psi-matrix-row-height: 28px;
+}
+
+.psi-matrix-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: normal;
+}
+
+.psi-matrix-cell--metric {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.psi-matrix-cell--total {
+  justify-content: flex-end;
+  font-weight: 600;
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.psi-matrix-value-cell {
+  justify-content: flex-end;
+  font-variant-numeric: tabular-nums;
+}
+
+.psi-matrix-value-cell--collapsed {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.psi-matrix-value-cell--compact {
+  font-size: 0.85rem;
+}
+
+.psi-matrix-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.psi-matrix-value.value-positive {
+  color: var(--accent-green, #16a34a);
+}
+
+.psi-matrix-value.value-negative {
+  color: var(--accent-red, #dc2626);
+}
+
+.psi-matrix-value.value-neutral {
+  color: var(--text-secondary);
+}
+
+.psi-matrix-metric-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.psi-matrix-column-panel {
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.6rem;
+  background: var(--surface-panel-soft, rgba(241, 245, 249, 0.6));
+}
+
+.psi-matrix-column-panel summary {
+  cursor: pointer;
+  padding: 0.6rem 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.psi-matrix-column-panel__content {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem 0.9rem;
+}
+
+.psi-matrix-column-panel__group {
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.72);
+  overflow: hidden;
+}
+
+.psi-matrix-column-panel__group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.45rem 0.6rem;
+  background: rgba(148, 163, 184, 0.12);
+  gap: 0.5rem;
+}
+
+.psi-matrix-column-panel__group-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.psi-matrix-column-panel__toggle {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--border-default);
+  background: var(--surface-panel);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.psi-matrix-column-panel__count {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.psi-matrix-column-panel__channels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.55rem 0.6rem 0.75rem;
+}
+
+.psi-matrix-column-panel__channel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 0.25rem 0.45rem;
+  border-radius: 0.4rem;
+  background: rgba(226, 232, 240, 0.5);
+}
+
+.psi-matrix-heatmap-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  padding: 0.2rem 0.35rem;
+  border-radius: 0.35rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.psi-matrix-value-cell--heatmap {
+  justify-content: stretch;
+}
+
+.psi-matrix-heatmap-value span {
+  width: 100%;
+}
+
+.psi-matrix-value--heatmap-total {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.psi-matrix-grid--heatmap .rdg-header {
+  background: rgba(148, 163, 184, 0.16);
+}
 .psi-matrix-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/vendor/react-data-grid/index.d.ts
+++ b/frontend/vendor/react-data-grid/index.d.ts
@@ -53,7 +53,19 @@ export interface DataGridProps<RowType> {
   };
   viewportRef?: React.Ref<HTMLDivElement>;
   rowClassName?: (row: RowType, rowIdx: number) => string | undefined;
+  columnGroups?: readonly ColumnGroupDescriptor[];
+  onToggleColumnGroup?: (groupId: string) => void;
+  headerRowHeight?: number;
+  groupHeaderRowHeight?: number;
 }
 
 export default function DataGrid<RowType>(props: DataGridProps<RowType>): JSX.Element;
 export { DataGrid };
+
+export interface ColumnGroupDescriptor {
+  id: string;
+  label: string;
+  columnKeys: string[];
+  collapsed?: boolean;
+  tooltip?: string;
+}

--- a/frontend/vendor/react-data-grid/index.jsx
+++ b/frontend/vendor/react-data-grid/index.jsx
@@ -31,6 +31,10 @@ function DataGrid({
   defaultColumnOptions,
   viewportRef,
   rowClassName,
+  columnGroups,
+  onToggleColumnGroup,
+  headerRowHeight,
+  groupHeaderRowHeight,
 }) {
   const columnWidth = defaultColumnOptions?.width ?? 140;
   const columnsWithWidth = useMemo(
@@ -47,6 +51,38 @@ function DataGrid({
     [columnsWithWidth]
   );
 
+  const columnIndexMap = useMemo(() => {
+    const map = new Map();
+    columnsWithWidth.forEach((column, index) => {
+      map.set(column.key, index);
+    });
+    return map;
+  }, [columnsWithWidth]);
+
+  const computedColumnGroups = useMemo(() => {
+    if (!columnGroups || columnGroups.length === 0) {
+      return [];
+    }
+    return columnGroups
+      .map((group) => {
+        const indices = group.columnKeys
+          .map((key) => columnIndexMap.get(key))
+          .filter((value) => typeof value === "number")
+          .sort((a, b) => a - b);
+        if (indices.length === 0) {
+          return null;
+        }
+        const startIndex = indices[0];
+        const span = indices.length;
+        return {
+          ...group,
+          startIndex,
+          span,
+        };
+      })
+      .filter(Boolean);
+  }, [columnGroups, columnIndexMap]);
+
   const frozenOffsets = useMemo(() => {
     let offset = 0;
     return columnsWithWidth.map((column) => {
@@ -62,6 +98,7 @@ function DataGrid({
   const [internalRows, setInternalRows] = useState(rows);
   const [editing, setEditing] = useState(null);
   const headerInnerRef = useRef(null);
+  const headerGroupRef = useRef(null);
   const bodyRef = useRef(null);
 
   useEffect(() => {
@@ -79,12 +116,18 @@ function DataGrid({
   useEffect(() => {
     const body = bodyRef.current;
     const headerInner = headerInnerRef.current;
-    if (!body || !headerInner) {
+    const headerGroupsEl = headerGroupRef.current;
+    if (!body || (!headerInner && !headerGroupsEl)) {
       return undefined;
     }
 
     const handleScroll = () => {
-      headerInner.style.transform = `translateX(${-body.scrollLeft}px)`;
+      if (headerInner) {
+        headerInner.style.transform = `translateX(${-body.scrollLeft}px)`;
+      }
+      if (headerGroupsEl) {
+        headerGroupsEl.style.transform = `translateX(${-body.scrollLeft}px)`;
+      }
     };
 
     body.addEventListener("scroll", handleScroll, { passive: true });
@@ -93,7 +136,7 @@ function DataGrid({
     return () => {
       body.removeEventListener("scroll", handleScroll);
     };
-  }, [templateColumns]);
+  }, [templateColumns, computedColumnGroups.length]);
 
   const startEditing = (rowIdx, column, columnIdx) => {
     if (!column.renderEditCell) {
@@ -174,7 +217,46 @@ function DataGrid({
   return (
     <div className={clsx("rdg", className)} style={style}>
       <div className="rdg-header">
-        <div className="rdg-header-row" ref={headerInnerRef} style={{ gridTemplateColumns: templateColumns }}>
+        {computedColumnGroups.length > 0 ? (
+          <div
+            className="rdg-header-row rdg-header-row--groups"
+            ref={headerGroupRef}
+            style={{
+              gridTemplateColumns: templateColumns,
+              height: groupHeaderRowHeight ?? "auto",
+            }}
+          >
+            {computedColumnGroups.map((group) => {
+              const gridColumn = `${group.startIndex + 1} / span ${group.span}`;
+              const handleToggle = () => {
+                if (onToggleColumnGroup) {
+                  onToggleColumnGroup(group.id);
+                }
+              };
+              return (
+                <button
+                  key={group.id}
+                  type="button"
+                  className="rdg-header-group"
+                  style={{ gridColumn }}
+                  onClick={handleToggle}
+                  title={group.tooltip ?? group.label}
+                  aria-expanded={group.collapsed ? "false" : "true"}
+                >
+                  <span className="rdg-header-group__label">{group.label}</span>
+                  <span className="rdg-header-group__indicator" aria-hidden="true">
+                    {group.collapsed ? "▸" : "▾"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+        <div
+          className="rdg-header-row"
+          ref={headerInnerRef}
+          style={{ gridTemplateColumns: templateColumns, height: headerRowHeight ?? "auto" }}
+        >
           {columnsWithWidth.map((column, columnIdx) => {
             const frozenOffset = frozenOffsets[columnIdx];
             return (

--- a/frontend/vendor/react-data-grid/lib/styles.css
+++ b/frontend/vendor/react-data-grid/lib/styles.css
@@ -22,6 +22,30 @@
   display: grid;
 }
 
+.rdg-header-row--groups {
+  border-bottom: 1px solid #d0d7de;
+}
+
+.rdg-header-group {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 6px 10px;
+  border-right: 1px solid #d0d7de;
+  box-sizing: border-box;
+  color: inherit;
+}
+
+.rdg-header-group__indicator {
+  font-size: 0.85em;
+}
+
 .rdg-header-cell {
   padding: 8px 12px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- replace PSI Matrix cross/heatmap tables with a fixed-width React DataGrid implementation that keeps Metric/Total pinned and supports warehouse/channel group collapsing
- add compact mode, row height density toggle, and column visibility panel shared across PSI Matrix tabs
- extend the in-repo DataGrid to render grouped headers and document the new controls in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e26feea054832eb49f0a28f3f87244