### PR TITLE
Fix PSI matrix column widths

### DIFF
--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -199,7 +199,9 @@ export default function CrossTableView({ rows, metrics, orientation = "warehouse
                 </th>
                 <td className="total-cell">{renderTotalValue(totalValue)}</td>
                 {headerColumns.map((column) => (
-                  <td key={column.key}>{renderValue(metric.key, column.key)}</td>
+                  <td key={column.key} className="matrix-value-cell">
+                    {renderValue(metric.key, column.key)}
+                  </td>
                 ))}
               </tr>
             );

--- a/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
+++ b/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
@@ -148,7 +148,11 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
                     {columnKeys.map((column) => {
                       const value = getMetricValue(rowMap.get(column.key), metric.key);
                       return (
-                        <td key={column.key} style={createHeatmapStyle(value, heatmapMax)}>
+                        <td
+                          key={column.key}
+                          className="matrix-value-cell"
+                          style={createHeatmapStyle(value, heatmapMax)}
+                        >
                           {formatMetricValue(value)}
                         </td>
                       );

--- a/frontend/src/styles/psi-matrix.css
+++ b/frontend/src/styles/psi-matrix.css
@@ -268,15 +268,18 @@
   margin-top: 0.5rem;
 }
 
+
 .psi-matrix-scroll {
   overflow-x: auto;
 }
 
 .psi-matrix-table {
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   border-collapse: collapse;
   background: var(--surface-table);
   font-size: 0.9rem;
+  table-layout: fixed;
 }
 
 .psi-matrix-table th,
@@ -288,6 +291,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+.psi-matrix-table .metric-column,
+.psi-matrix-table .metric-label {
+  width: 180px;
+  min-width: 180px;
+  max-width: 180px;
+}
+
 .psi-matrix-table thead th {
   position: sticky;
   top: 0;
@@ -297,18 +307,12 @@
   font-weight: 600;
 }
 
-.psi-matrix-table .metric-column,
-.psi-matrix-table .metric-label {
-  text-align: left;
-}
-
 .psi-matrix-table .metric-column {
   position: sticky;
   left: 0;
   z-index: 3;
   background: var(--surface-table-header);
-  min-width: 200px;
-  width: 200px;
+  text-align: left;
 }
 
 .psi-matrix-table .metric-label {
@@ -316,29 +320,43 @@
   left: 0;
   z-index: 1;
   background: var(--surface-table);
+  text-align: left;
 }
 
 .psi-matrix-table .total-column {
   position: sticky;
-  left: 200px;
+  left: 180px;
   z-index: 3;
   background: var(--surface-table-header-highlight, var(--surface-table-header));
   font-weight: 700;
   text-align: right;
-  width: calc(6ch + 1.2rem);
-  min-width: calc(6ch + 1.2rem);
-  max-width: calc(6ch + 1.2rem);
+  width: 100px;
+  min-width: 100px;
+  max-width: 100px;
 }
 
 .psi-matrix-table .total-cell {
   position: sticky;
-  left: 200px;
+  left: 180px;
   z-index: 1;
   font-weight: 600;
   background: var(--surface-table-total, rgba(59, 130, 246, 0.08));
-  width: calc(6ch + 1.2rem);
-  min-width: calc(6ch + 1.2rem);
-  max-width: calc(6ch + 1.2rem);
+  width: 100px;
+  min-width: 100px;
+  max-width: 100px;
+}
+
+.psi-matrix-table .warehouse-header,
+.psi-matrix-table .channel-header,
+.psi-matrix-table .matrix-value-cell {
+  width: 120px;
+  min-width: 120px;
+  max-width: 120px;
+}
+
+.psi-matrix-table .warehouse-header,
+.psi-matrix-table .channel-header {
+  text-align: center;
 }
 
 .psi-matrix-table tbody th {


### PR DESCRIPTION
## Summary
- set explicit widths for metric, total, and value columns in the PSI matrix tables to avoid automatic expansion
- mark PSI matrix value cells so cross table and heatmap views share the fixed width styling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e275038d38832e920eb2b91dd6ca9a