### PR TITLE
Adjust PSI matrix metrics to new definitions

### DIFF
--- a/docs/reallocation.md
+++ b/docs/reallocation.md
@@ -5,10 +5,10 @@
 ### 1. Gap・Gap After と PSI 指標の算出
 
 - **バックエンド入力**：`fetch_matrix_rows` は `stock_at_anchor`（期首在庫）、`inbound_qty`、`outbound_qty`、`stdstock`、`move` を返却するが、`stock_closing` はそのままでは不足分を表せない値（0 あるいは未設定）で送られてくるケースがある。【F:backend/app/services/transfer_plans.py†L175-L199】
-- **フロント合成**：再配置画面ではサーバー返却行とローカルドラフトの差分を `move = baseMove - savedMove + draftMove`（サマリー表示時は `baseMove + draftMove`）で再構成し、`stock_closing = stock_at_anchor + inbound_qty - outbound_qty + move`、`stock_fin = stock_closing` を導出する。【F:frontend/src/pages/ReallocationPage.tsx†L802-L858】
-- **Gap 値の利用**：`gap` は常に `stdstock - stock_at_anchor` を再計算し、`gap_after = gap + move` を保持することで不足が正値で表現される。【F:frontend/src/pages/ReallocationPage.tsx†L820-L846】
+- **フロント合成**：再配置画面では Transfer Plan Lines の集計から `move` を算出し、`stock_closing = stock_at_anchor + inbound_qty - outbound_qty`、`stock_fin = stock_closing + move` を導出する。【F:frontend/src/pages/ReallocationPage.tsx†L802-L858】
+- **Gap 値の利用**：`gap` は `stock_fin - stdstock`、`gap_after = gap + move` を保持し、在庫差を最終値基準で把握する。【F:frontend/src/pages/ReallocationPage.tsx†L820-L846】
 - **PSI 行へのマッピング**：UI に渡す段階でも同じ式で `stockClosing`、`stockFinal`、`gap`、`gapAfter` を再計算してから `PSIMatrixTabs` に供給する。【F:frontend/src/pages/ReallocationPage.tsx†L1042-L1072】
-- **KPI/ビューの参照**：`getMetricValue` も `Gap = Std − Stock @ Start`、`Gap After = Gap + Move` を返すため、カード・表・ヒートマップで基準が統一された。【F:frontend/src/features/reallocation/psi/utils.ts†L56-L85】
+- **KPI/ビューの参照**：`getMetricValue` も `Gap = Stock Final − Std Stock`、`Gap After = Gap + Move` を返すため、カード・表・ヒートマップで基準が統一される。【F:frontend/src/features/reallocation/psi/utils.ts†L56-L85】
 
 ### 2. ドラフト合成・クエリキー・再フェッチ
 
@@ -23,7 +23,7 @@
 - **バリデーション**：保存 API は `from == to`、`line_id` 重複、`plan_id` 不一致を拒否し、`stock_at_anchor` を超える出庫をエラーとする（安全在庫相当）。【F:backend/app/routers/transfer_plans.py†L214-L253】
 - **タイブレーク**：現行 inter 選定は「余剰量の多い順」単一基準のみで、チャネル種別・倉庫規模・安定ソートは未実装。【F:backend/app/services/transfer_logic.py†L148-L179】
 
-## B. 決定木ロジック仕様（Gap = Std − Stock @ Start 前提）
+## B. 決定木ロジック仕様（Gap = Stock Final − Std 前提）
 
 ### 1. フローチャート（簡易）
 
@@ -62,16 +62,16 @@ for each sku:
 ### 3. 出力と算定式
 
 - **Move 行形式**：`{ sku, from_warehouse, from_channel, to_warehouse, to_channel, qty, reason }`（現行 API と互換）。【F:backend/app/services/transfer_logic.py†L131-L177】
-- **Gap After**：各セルで `GapAfter = (Std − Stock@Start) + MoveNet`。Move は入庫なら正、出庫なら負として Gap に加算する（UI 再計算も同式を明記）。【F:frontend/src/pages/ReallocationPage.tsx†L1044-L1069】
+- **Gap After**：各セルで `GapAfter = (StockFinal − Std) + MoveNet`。Move は入庫なら正、出庫なら負として Gap に加算する（UI 再計算も同式を明記）。【F:frontend/src/pages/ReallocationPage.tsx†L1044-L1069】
 - **在庫下限**：`available_surplus` 判定で `stock_at_anchor - allocated_out` を超過しないことを保証。必要に応じて別安全在庫しきい値を掛けられる旨を注記。【F:backend/app/services/transfer_logic.py†L61-L73】
 
 ## C. 不整合と改善提案
 
 1. **Gap 基準の混在是正（対応済み）**
-   - `Gap = Std − Stock @ Start` へ統一し、`simulatedMatrixRows`・`PSIMatrixTabs`・`getMetricValue` が同じ基準で再計算するよう修正済み。【F:frontend/src/pages/ReallocationPage.tsx†L802-L858】【F:frontend/src/pages/ReallocationPage.tsx†L1042-L1072】【F:frontend/src/features/reallocation/psi/utils.ts†L56-L85】
+   - `Gap = Stock Final − Std` へ統一し、`simulatedMatrixRows`・`PSIMatrixTabs`・`getMetricValue` が同じ基準で再計算するよう修正済み。【F:frontend/src/pages/ReallocationPage.tsx†L802-L858】【F:frontend/src/pages/ReallocationPage.tsx†L1042-L1072】【F:frontend/src/features/reallocation/psi/utils.ts†L56-L85】
 
 2. **UI 明示**
-   - KPI カード・ツールチップに「Gap は Std vs Stock @ Start（期首基準）」と記載することで利用者に基準点を提示。
+   - KPI カード・ツールチップに「Gap は Stock Final vs Std（期末基準）」と記載することで利用者に基準点を提示。
 
 3. **インタードナーのソート強化**
    - 決定木ストーリーに沿い、`donors_inter.sort` にチャネル優先度・倉庫合計在庫・安定キーを組み合わせる（`tuple` ソートで実装可能）。
@@ -82,17 +82,17 @@ for each sku:
 ## D. データ受け渡しと UI 変換フロー
 
 1. **API 応答（MatrixRow）**：`/api/psi/matrix` は SKU × 倉庫 × チャネル行を返し、`stock_at_anchor`（期首在庫）、`inbound_qty`、`outbound_qty`、`stdstock`、`move` などの基礎数値を含む。`stock_closing` は未設定でもよく、フロントで派生させる。【F:frontend/src/types.ts†L116-L132】
-2. **移動量の合成**：保存済みプラン行とドラフト行を SKU × 倉庫 × チャネル軸でマージし、既存 move とドラフト move を統合した `move` を得て `simulatedMatrixRows` を構築する。【F:frontend/src/pages/ReallocationPage.tsx†L802-L858】
-3. **派生指標の算出**：各行で `stock_closing = stock_start + inbound - outbound + move`、`stock_fin = stock_closing`、`gap = stdstock - stock_start`、`gap_after = gap + move` を再計算し、欠損を補完する。【F:frontend/src/pages/ReallocationPage.tsx†L820-L846】
-4. **UI へのマッピング**：テーブル描画前に同じ式で `stockClosing` や `gapAfter` を埋め込み、`PSIMatrixTabs` と `getMetricValue` でも `Gap = Std − Start` と `Gap After = Gap + Move` を共有する。【F:frontend/src/pages/ReallocationPage.tsx†L1042-L1072】【F:frontend/src/features/reallocation/psi/utils.ts†L56-L85】
+2. **移動量の合成**：保存済みプラン行とドラフト行を SKU × 倉庫 × チャネル軸でマージし、Transfer Plan Lines の合計として `move` を算出して `simulatedMatrixRows` を構築する。【F:frontend/src/pages/ReallocationPage.tsx†L802-L858】
+3. **派生指標の算出**：各行で `stock_closing = stock_start + inbound - outbound`、`stock_fin = stock_closing + move`、`gap = stock_fin - stdstock`、`gap_after = gap + move` を再計算し、欠損を補完する。【F:frontend/src/pages/ReallocationPage.tsx†L820-L846】
+4. **UI へのマッピング**：テーブル描画前に同じ式で `stockClosing` や `gapAfter` を埋め込み、`PSIMatrixTabs` と `getMetricValue` でも `Gap = Stock Final − Std` と `Gap After = Gap + Move` を共有する。【F:frontend/src/pages/ReallocationPage.tsx†L1042-L1072】【F:frontend/src/features/reallocation/psi/utils.ts†L56-L85】
 
 ---
 
 ### 参考：ダミーデータのトレース
 
-| SKU/倉庫/チャネル | Std | Stock@Start | Move | Gap (=Std−Start) | GapAfter (=Gap+Move) |
+| SKU/倉庫/チャネル | Std | Stock@Start | Move | Gap (=StockFinal−Std) | GapAfter (=Gap+Move) |
 | --- | --- | --- | --- | --- | --- |
-| 住商GL online retail | 4.55 | 4 | +1 | +0.55 | +1.55 |
-| 名鉄運輸 online wholesale | 24.57 | 27 | −1 | −2.43 | −3.43 |
+| 住商GL online retail | 4.55 | 4 | +1 | +0.45 | +1.45 |
+| 名鉄運輸 online wholesale | 24.57 | 27 | −1 | −3.43 | −4.43 |
 
-Gap の符号が意図通り（不足で正）になること、GapAfter が Move を加味した差分であることを確認できる。
+Gap の符号が意図通り（余剰で正、不足で負）になること、GapAfter が Move を加味した差分であることを確認できる。

--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -65,9 +65,9 @@ export const getMetricValue = (row: PsiRow | undefined, metric: MetricKey): numb
   }
   switch (metric) {
     case "gap": {
+      const stockFinal = safeNumber(row.stockFinal);
       const stdStock = safeNumber(row.stdStock);
-      const stockStart = safeNumber(row.stockStart);
-      return stockStart - stdStock;
+      return stockFinal - stdStock;
     }
     case "gapAfter": {
       const gap = getMetricValue(row, "gap");

--- a/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
+++ b/frontend/src/features/reallocation/psi/views/CrossTableView.tsx
@@ -112,7 +112,7 @@ export default function CrossTableView({ rows, metrics, orientation = "warehouse
   const getMetricLabelContent = (metricKey: MetricDefinition["key"], label: string) => {
     if (metricKey === "gap") {
       return (
-        <span className="metric-label-text" title="Gap = Stock @ Start − Std Stock">
+        <span className="metric-label-text" title="Gap = Stock Final − Std Stock">
           {label}
           <span className="metric-info" aria-hidden="true">
             i

--- a/frontend/src/features/reallocation/psi/views/KpiView.tsx
+++ b/frontend/src/features/reallocation/psi/views/KpiView.tsx
@@ -66,13 +66,22 @@ export default function KpiView({ rows }: { rows: PsiRow[] }) {
             {columnKeys.map((column) => {
               const row = rowMap.get(column.key);
               const stockStartValue = safeNumber(row?.stockStart);
+              const inboundValue = safeNumber(row?.inbound);
+              const outboundValue = safeNumber(row?.outbound);
               const stdStockValue = safeNumber(row?.stdStock);
               const moveValue = safeNumber(row?.move);
-              const gapValue = row?.gap ?? stockStartValue - stdStockValue;
-              const gapAfterValue =
-                row?.gapAfter ?? stockStartValue + moveValue - stdStockValue;
+              const stockClosingValue =
+                typeof row?.stockClosing === "number" && Number.isFinite(row.stockClosing)
+                  ? row.stockClosing
+                  : stockStartValue + inboundValue - outboundValue;
+              const stockFinalValue =
+                typeof row?.stockFinal === "number" && Number.isFinite(row.stockFinal)
+                  ? row.stockFinal
+                  : stockClosingValue + moveValue;
+              const gapValue = row?.gap ?? stockFinalValue - stdStockValue;
+              const gapAfterValue = row?.gapAfter ?? gapValue + moveValue;
               const values: Record<MiniTableMetric, number> = {
-                stockFinal: safeNumber(row?.stockFinal),
+                stockFinal: stockFinalValue,
                 gap: gapValue,
                 gapAfter: gapAfterValue,
               };

--- a/frontend/src/features/reallocation/psi/views/OriginView.tsx
+++ b/frontend/src/features/reallocation/psi/views/OriginView.tsx
@@ -29,9 +29,20 @@ export default function OriginView({ rows }: OriginViewProps) {
         <tbody>
           {rows.map((row) => {
             const stockStartValue = safeNumber(row.stockStart);
+            const inboundValue = safeNumber(row.inbound);
+            const outboundValue = safeNumber(row.outbound);
             const moveValue = safeNumber(row.move);
             const stdStockValue = safeNumber(row.stdStock);
-            const gapAfter = row.gapAfter ?? stockStartValue + moveValue - stdStockValue;
+            const stockClosingValue =
+              typeof row.stockClosing === "number" && Number.isFinite(row.stockClosing)
+                ? row.stockClosing
+                : stockStartValue + inboundValue - outboundValue;
+            const stockFinalValue =
+              typeof row.stockFinal === "number" && Number.isFinite(row.stockFinal)
+                ? row.stockFinal
+                : stockClosingValue + moveValue;
+            const gapValue = row.gap ?? stockFinalValue - stdStockValue;
+            const gapAfter = row.gapAfter ?? gapValue + moveValue;
             return (
               <tr key={`${row.sku}|${row.warehouse}|${row.channel}`}>
                 <td>{row.sku}</td>
@@ -43,9 +54,9 @@ export default function OriginView({ rows }: OriginViewProps) {
                 <td>{formatMetricValue(row.outbound)}</td>
                 <td>{formatMetricValue(row.stockClosing)}</td>
                 <td>{formatMetricValue(row.stdStock)}</td>
-                <td>{formatMetricValue(row.gap)}</td>
+                <td>{formatMetricValue(gapValue)}</td>
                 <td>{formatMetricValue(row.move)}</td>
-                <td>{formatMetricValue(row.stockFinal)}</td>
+                <td>{formatMetricValue(stockFinalValue)}</td>
                 <td style={{ color: gapAfter < 0 ? "#c0392b" : undefined }}>
                   {formatMetricValue(gapAfter)}
                 </td>

--- a/frontend/src/pages/ReallocationPage.tsx
+++ b/frontend/src/pages/ReallocationPage.tsx
@@ -811,17 +811,15 @@ export default function ReallocationPage() {
     keys.forEach((key) => {
       const baseRow = baseMap.get(key);
       const [sku_code, warehouse_name, channel] = key.split(MATRIX_KEY_DELIMITER);
-      const baseMove = baseRow?.move ?? 0;
-      const savedMove = baselineMoveMap.get(key) ?? 0;
       const draftMove = draftMoveMap.get(key) ?? 0;
-      const move = usingSummaryMatrix ? baseMove + draftMove : baseMove - savedMove + draftMove;
       const stock_at_anchor = baseRow?.stock_at_anchor ?? 0;
       const inbound_qty = baseRow?.inbound_qty ?? 0;
       const outbound_qty = baseRow?.outbound_qty ?? 0;
       const stdstock = baseRow?.stdstock ?? 0;
-      const gap = stdstock - stock_at_anchor;
-      const stock_closing = stock_at_anchor + inbound_qty - outbound_qty + move;
-      const stock_fin = stock_closing;
+      const stock_closing = stock_at_anchor + inbound_qty - outbound_qty;
+      const move = draftMove;
+      const stock_fin = stock_closing + move;
+      const gap = stock_fin - stdstock;
       const sku_name = baseRow?.sku_name ?? skuNameMap.get(sku_code) ?? null;
       const category_1 = baseRow?.category_1 ?? null;
       const category_2 = baseRow?.category_2 ?? null;
@@ -853,7 +851,7 @@ export default function ReallocationPage() {
       }
       return a.channel.localeCompare(b.channel);
     });
-  }, [baseMatrixRows, baselineMoveMap, draftMoveMap, skuNameMap, usingSummaryMatrix]);
+  }, [baseMatrixRows, baselineMoveMap, draftMoveMap, skuNameMap]);
 
   const skuOptions = useMemo(() => {
     const optionMap = new Map<string, string | null>();
@@ -1045,8 +1043,9 @@ export default function ReallocationPage() {
         const outbound = row.outbound_qty ?? 0;
         const stdStock = row.stdstock ?? 0;
         const move = row.move ?? 0;
-        const stockClosing = stockStart + inbound - outbound + move;
-        const gap = stdStock - stockStart;
+        const stockClosing = stockStart + inbound - outbound;
+        const stockFinal = stockClosing + move;
+        const gap = stockFinal - stdStock;
         const gapAfter = gap + move;
         return {
           sku: row.sku_code,
@@ -1062,8 +1061,8 @@ export default function ReallocationPage() {
           stockClosing,
           stdStock: row.stdstock,
           gap,
-          move: row.move,
-          stockFinal: stockClosing,
+          move,
+          stockFinal,
           gapAfter,
         };
       }),


### PR DESCRIPTION
## Summary
- derive PSI matrix move values from transfer plan lines and recompute stock closing/final/gap metrics to match the new specification
- update PSI utilities and views so displayed Gap, Gap After, and Stock Final reflect the revised formulas
- refresh the reallocation documentation to describe the updated PSI metric calculations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e518696708832e86d46748c3cc1ba3