### PR TITLE
Align PSI matrix metric order with master configuration

### DIFF
--- a/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
+++ b/frontend/src/features/reallocation/psi/PSIMatrixTabs.tsx
@@ -6,7 +6,13 @@ import HeatmapView from "./views/HeatmapView";
 import BarsView from "./views/BarsView";
 import KpiView from "./views/KpiView";
 import type { PsiRow } from "./types";
-import { METRIC_DEFINITIONS, formatMetricValue, safeNumber } from "./utils";
+import { usePSIMetricsQuery } from "../../../hooks/usePSIMetrics";
+import {
+  METRIC_DEFINITIONS,
+  formatMetricValue,
+  orderMetricsByDisplayOrder,
+  safeNumber,
+} from "./utils";
 import "../../../styles/psi-matrix.css";
 
 const TAB_CONFIG = [
@@ -70,6 +76,12 @@ export function PSIMatrixTabs({
   skuSearch,
   onSkuSearchChange,
 }: PSIMatrixTabsProps) {
+  const { data: masterMetrics } = usePSIMetricsQuery();
+  const metricDefinitions = useMemo(
+    () => orderMetricsByDisplayOrder(METRIC_DEFINITIONS, masterMetrics),
+    [masterMetrics],
+  );
+
   const normalizedSkuList = useMemo(() => {
     if (skuList.length > 0) {
       return skuList;
@@ -358,16 +370,16 @@ export function PSIMatrixTabs({
         break;
       case "cross":
         tabContent = (
-          <CrossTableView rows={rowsForSku} metrics={METRIC_DEFINITIONS} orientation="warehouse-first" />
+          <CrossTableView rows={rowsForSku} metrics={metricDefinitions} orientation="warehouse-first" />
         );
         break;
       case "cross2":
         tabContent = (
-          <CrossTableView rows={rowsForSku} metrics={METRIC_DEFINITIONS} orientation="channel-first" />
+          <CrossTableView rows={rowsForSku} metrics={metricDefinitions} orientation="channel-first" />
         );
         break;
       case "heatmap":
-        tabContent = <HeatmapView rows={rowsForSku} metrics={METRIC_DEFINITIONS} />;
+        tabContent = <HeatmapView rows={rowsForSku} metrics={metricDefinitions} />;
         break;
       case "bars":
         tabContent = <BarsView rows={rowsForSku} />;

--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -1,4 +1,11 @@
-import type { ColumnGroup, ColumnKey, MetricDefinition, MetricKey, PsiRow } from "./types";
+import type {
+  ColumnGroup,
+  ColumnKey,
+  MetricDefinition,
+  MetricKey,
+  PsiRow,
+} from "./types";
+import type { PSIMetricDefinition } from "../../../types";
 
 export const METRIC_DEFINITIONS: MetricDefinition[] = [
   { key: "stockStart", label: "Stock @ Start", shortLabel: "Start" },
@@ -24,6 +31,70 @@ export const KPI_CARD_METRICS: Array<{ key: MetricKey; label: string; emphasize?
 ];
 
 export const DEFAULT_HEATMAP_METRICS: MetricKey[] = ["gap", "gapAfter"];
+
+const MASTER_METRIC_NAME_MAP: Partial<Record<string, MetricKey>> = {
+  "stock_at_anchor": "stockStart",
+  "stock start": "stockStart",
+  "stock_start": "stockStart",
+  inbound: "inbound",
+  "inbound_qty": "inbound",
+  "inbound qty": "inbound",
+  outbound: "outbound",
+  "outbound_qty": "outbound",
+  "outbound qty": "outbound",
+  "stock_closing": "stockClosing",
+  "stock closing": "stockClosing",
+  "stock_close": "stockClosing",
+  move: "move",
+  "stock_fin": "stockFinal",
+  "stock final": "stockFinal",
+  "stock_final": "stockFinal",
+  stdstock: "stdStock",
+  "std stock": "stdStock",
+  "std_stock": "stdStock",
+  gap: "gap",
+  "gap_after": "gapAfter",
+  "gap after": "gapAfter",
+};
+
+export const orderMetricsByDisplayOrder = (
+  baseMetrics: MetricDefinition[],
+  masterMetrics?: PSIMetricDefinition[],
+): MetricDefinition[] => {
+  if (!masterMetrics?.length) {
+    return baseMetrics;
+  }
+
+  const definitionsByKey = new Map<MetricKey, MetricDefinition>();
+  baseMetrics.forEach((definition) => {
+    definitionsByKey.set(definition.key, definition);
+  });
+
+  const seen = new Set<MetricKey>();
+  const ordered: MetricDefinition[] = [];
+
+  for (const master of masterMetrics) {
+    const normalizedName = master.name.trim().toLowerCase();
+    const metricKey = MASTER_METRIC_NAME_MAP[normalizedName];
+    if (!metricKey || seen.has(metricKey)) {
+      continue;
+    }
+    const definition = definitionsByKey.get(metricKey);
+    if (!definition) {
+      continue;
+    }
+    ordered.push(definition);
+    seen.add(metricKey);
+  }
+
+  baseMetrics.forEach((definition) => {
+    if (!seen.has(definition.key)) {
+      ordered.push(definition);
+    }
+  });
+
+  return ordered;
+};
 
 export const makeColumnKey = (warehouse: string, channel: string) => `${warehouse}｜${channel}`;
 

--- a/frontend/src/hooks/usePSIMetrics.ts
+++ b/frontend/src/hooks/usePSIMetrics.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import api from "../lib/api";
+import type { PSIMetricDefinition } from "../types";
+
+export const PSI_METRICS_QUERY_KEY = ["psi-metrics"] as const;
+
+const fetchPSIMetrics = async (): Promise<PSIMetricDefinition[]> => {
+  const { data } = await api.get<PSIMetricDefinition[]>("/api/psi-metrics");
+  if (!Array.isArray(data)) {
+    throw new Error("Unexpected PSI metrics response format.");
+  }
+  return data;
+};
+
+export const usePSIMetricsQuery = () =>
+  useQuery({
+    queryKey: PSI_METRICS_QUERY_KEY,
+    queryFn: fetchPSIMetrics,
+  });


### PR DESCRIPTION
## Summary
- add a shared React Query hook to load PSI metric definitions from the backend
- derive the PSI matrix metric order from the master display order before rendering tables

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68f1004d9504832eb6350e49ae0f7604