### PR TITLE
Align PSI Matrix metrics with master order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 dist/
 frontend/node_modules/
 frontend/dist/
+frontend/dist-tests/
 .auth_test.db
 backend/tests/auth_test.db
 .DS_Store

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:test": "node scripts/build-tests.mjs",
+    "test": "npm run build:test && node --test dist-tests"
   },
   "dependencies": {
     "@tanstack/react-query": "5.62.9",
@@ -20,8 +22,8 @@
     "@types/react": "18.3.7",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "4.3.4",
+    "rollup": "^4.24.0",
     "typescript": "5.6.3",
-    "vite": "^5.4.20",
-    "rollup": "^4.24.0"
+    "vite": "^5.4.20"
   }
 }

--- a/frontend/scripts/build-tests.mjs
+++ b/frontend/scripts/build-tests.mjs
@@ -1,0 +1,32 @@
+import { rm, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+const outdir = resolve(projectRoot, "dist-tests");
+
+const entryPoints = [
+  resolve(projectRoot, "tests/unit/orderMetrics.test.ts"),
+  resolve(projectRoot, "tests/e2e/psiMatrix.test.tsx"),
+];
+
+await rm(outdir, { recursive: true, force: true });
+await mkdir(outdir, { recursive: true });
+
+await build({
+  entryPoints,
+  outdir,
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  target: "node20",
+  sourcemap: false,
+  loader: {
+    ".ts": "ts",
+    ".tsx": "tsx",
+  },
+  logLevel: "info",
+  external: ["react", "react-dom", "react-dom/server"],
+});

--- a/frontend/src/features/reallocation/psi/utils.ts
+++ b/frontend/src/features/reallocation/psi/utils.ts
@@ -6,6 +6,7 @@ import type {
   PsiRow,
 } from "./types";
 import type { PSIMetricDefinition } from "../../../types";
+import { orderMetrics } from "../../../utils/metrics";
 
 export const METRIC_DEFINITIONS: MetricDefinition[] = [
   { key: "stockStart", label: "Stock @ Start", shortLabel: "Start" },
@@ -73,7 +74,9 @@ export const orderMetricsByDisplayOrder = (
   const seen = new Set<MetricKey>();
   const ordered: MetricDefinition[] = [];
 
-  for (const master of masterMetrics) {
+  const sortedMasters = orderMetrics(masterMetrics);
+
+  for (const master of sortedMasters) {
     const normalizedName = master.name.trim().toLowerCase();
     const metricKey = MASTER_METRIC_NAME_MAP[normalizedName];
     if (!metricKey || seen.has(metricKey)) {

--- a/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
+++ b/frontend/src/features/reallocation/psi/views/HeatmapView.tsx
@@ -14,9 +14,20 @@ import {
 interface HeatmapViewProps {
   rows: PsiRow[];
   metrics: MetricDefinition[];
+  initialSelection?: MetricKey[];
 }
 
-const buildInitialSelection = (metrics: MetricDefinition[]) => {
+const buildInitialSelection = (metrics: MetricDefinition[], initialSelection?: MetricKey[]) => {
+  if (initialSelection?.length) {
+    const allowed = new Set(initialSelection);
+    const normalized = metrics
+      .map((metric) => metric.key)
+      .filter((metricKey) => allowed.has(metricKey));
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
   const defaults = metrics.filter((metric) => DEFAULT_HEATMAP_METRICS.includes(metric.key));
   if (defaults.length > 0) {
     return defaults.map((metric) => metric.key);
@@ -35,8 +46,14 @@ const createHeatmapStyle = (value: number | null, maxAbs: number) => {
   return { backgroundColor, color: textColor };
 };
 
-export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
-  const [selectedMetrics, setSelectedMetrics] = useState(() => buildInitialSelection(metrics));
+export default function HeatmapView({ rows, metrics, initialSelection }: HeatmapViewProps) {
+  const [selectedMetricSet, setSelectedMetricSet] = useState(
+    () => new Set<MetricKey>(buildInitialSelection(metrics, initialSelection)),
+  );
+  const selectedMetrics = useMemo(
+    () => metrics.filter((metric) => selectedMetricSet.has(metric.key)).map((metric) => metric.key),
+    [metrics, selectedMetricSet],
+  );
   const columnGroups = useMemo(() => buildColumnGroups(rows), [rows]);
   const columnKeys = useMemo(() => columnKeysFromGroups(columnGroups), [columnGroups]);
   const rowMap = useMemo(() => {
@@ -61,20 +78,23 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
   }, [selectedMetrics, columnKeys, rowMap]);
 
   const handleToggleMetric = (metricKey: MetricKey) => {
-    setSelectedMetrics((prev) => {
-      if (prev.includes(metricKey)) {
-        return prev.filter((item) => item !== metricKey);
+    setSelectedMetricSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(metricKey)) {
+        next.delete(metricKey);
+      } else {
+        next.add(metricKey);
       }
-      return [...prev, metricKey];
+      return next;
     });
   };
 
   const handleSelectAll = () => {
-    setSelectedMetrics(metrics.map((metric) => metric.key));
+    setSelectedMetricSet(new Set(metrics.map((metric) => metric.key)));
   };
 
   const handleReset = () => {
-    setSelectedMetrics(buildInitialSelection(metrics));
+    setSelectedMetricSet(new Set(buildInitialSelection(metrics, initialSelection)));
   };
 
   if (columnKeys.length === 0) {
@@ -97,7 +117,7 @@ export default function HeatmapView({ rows, metrics }: HeatmapViewProps) {
             <label key={metric.key} className="psi-heatmap-checkbox">
               <input
                 type="checkbox"
-                checked={selectedMetrics.includes(metric.key)}
+                checked={selectedMetricSet.has(metric.key)}
                 onChange={() => handleToggleMetric(metric.key)}
               />
               <span>{metric.label}</span>

--- a/frontend/src/hooks/usePSIMetrics.ts
+++ b/frontend/src/hooks/usePSIMetrics.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import api from "../lib/api";
 import type { PSIMetricDefinition } from "../types";
+import { orderMetrics } from "../utils/metrics";
 
 export const PSI_METRICS_QUERY_KEY = ["psi-metrics"] as const;
 
@@ -17,4 +18,5 @@ export const usePSIMetricsQuery = () =>
   useQuery({
     queryKey: PSI_METRICS_QUERY_KEY,
     queryFn: fetchPSIMetrics,
+    select: orderMetrics,
   });

--- a/frontend/src/utils/metrics.ts
+++ b/frontend/src/utils/metrics.ts
@@ -1,0 +1,42 @@
+export const normalizeDisplayOrder = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+};
+
+export const orderMetrics = <T extends { display_order?: unknown }>(
+  metrics: readonly T[],
+): Array<T & { display_order: number }> => {
+  const normalized = metrics.map((metric, index) => {
+    const normalizedOrder = normalizeDisplayOrder(metric.display_order);
+    const displayOrder = normalizedOrder ?? Number.MAX_SAFE_INTEGER;
+    return {
+      metric,
+      displayOrder,
+      index,
+    };
+  });
+
+  normalized.sort((a, b) => {
+    if (a.displayOrder !== b.displayOrder) {
+      return a.displayOrder - b.displayOrder;
+    }
+    return a.index - b.index;
+  });
+
+  return normalized.map(({ metric, displayOrder }) => ({
+    ...metric,
+    display_order: displayOrder,
+  }));
+};

--- a/frontend/tests/e2e/psiMatrix.test.tsx
+++ b/frontend/tests/e2e/psiMatrix.test.tsx
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import CrossTableView from "../../src/features/reallocation/psi/views/CrossTableView";
+import HeatmapView from "../../src/features/reallocation/psi/views/HeatmapView";
+import { METRIC_DEFINITIONS, orderMetricsByDisplayOrder } from "../../src/features/reallocation/psi/utils";
+import type { MetricDefinition, PsiRow } from "../../src/features/reallocation/psi/types";
+import type { PSIMetricDefinition } from "../../src/types";
+
+const buildMasterMetrics = (): PSIMetricDefinition[] => [
+  { name: "inbound", is_editable: false, display_order: 1 },
+  { name: "stock_start", is_editable: false, display_order: 2 },
+  { name: "outbound", is_editable: false, display_order: 3 },
+  { name: "gap", is_editable: false, display_order: 4 },
+  { name: "gap_after", is_editable: false, display_order: 5 },
+];
+
+const buildRows = (): PsiRow[] => [
+  {
+    sku: "SKU-1",
+    warehouse: "W1",
+    channel: "Online",
+    stockStart: 100,
+    inbound: 10,
+    outbound: 20,
+    stockClosing: 90,
+    move: 5,
+    stockFinal: 95,
+    stdStock: 80,
+  },
+  {
+    sku: "SKU-1",
+    warehouse: "W1",
+    channel: "Store",
+    stockStart: 50,
+    inbound: 5,
+    outbound: 10,
+    stockClosing: 45,
+    move: -5,
+    stockFinal: 40,
+    stdStock: 60,
+  },
+  {
+    sku: "SKU-1",
+    warehouse: "W2",
+    channel: "Online",
+    stockStart: 30,
+    inbound: 2,
+    outbound: 1,
+    stockClosing: 31,
+    move: 0,
+    stockFinal: 31,
+    stdStock: 25,
+  },
+];
+
+const stripHtml = (value: string) => value.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+
+const extractMetricLabelsFromTable = (html: string): string[] => {
+  const labels: string[] = [];
+  const metricCellPattern = /<th\s+scope="row"\s+class="metric-label">([\s\S]*?)<\/th>/g;
+  let match: RegExpExecArray | null;
+  while ((match = metricCellPattern.exec(html))) {
+    const text = stripHtml(match[1]).replace(/\s*i\s*$/, "").trim();
+    if (text) {
+      labels.push(text);
+    }
+  }
+  return labels;
+};
+
+const extractCheckboxLabels = (html: string): string[] => {
+  const labels: string[] = [];
+  const checkboxPattern = /<label[^>]*class="psi-heatmap-checkbox"[^>]*>[\s\S]*?<span>(.*?)<\/span>[\s\S]*?<\/label>/g;
+  let match: RegExpExecArray | null;
+  while ((match = checkboxPattern.exec(html))) {
+    labels.push(stripHtml(match[1]));
+  }
+  return labels;
+};
+
+const masterMetrics = buildMasterMetrics();
+const orderedMetrics: MetricDefinition[] = orderMetricsByDisplayOrder(METRIC_DEFINITIONS, masterMetrics);
+const expectedMetricLabels = orderedMetrics.map((metric) => metric.label);
+const rows = buildRows();
+
+test("cross table keeps metric order for warehouse-first orientation", () => {
+  const markup = renderToStaticMarkup(
+    <CrossTableView rows={rows} metrics={orderedMetrics} orientation="warehouse-first" />,
+  );
+  const labels = extractMetricLabelsFromTable(markup);
+  assert.deepEqual(labels, expectedMetricLabels);
+});
+
+test("cross table keeps metric order for channel-first orientation", () => {
+  const markup = renderToStaticMarkup(
+    <CrossTableView rows={rows} metrics={orderedMetrics} orientation="channel-first" />,
+  );
+  const labels = extractMetricLabelsFromTable(markup);
+  assert.deepEqual(labels, expectedMetricLabels);
+});
+
+test("heatmap uses metric order for checkboxes and table rows", () => {
+  const markup = renderToStaticMarkup(<HeatmapView rows={rows} metrics={orderedMetrics} />);
+  const checkboxLabels = extractCheckboxLabels(markup);
+  assert.deepEqual(checkboxLabels, expectedMetricLabels);
+
+  const rowLabels = extractMetricLabelsFromTable(markup);
+  assert.deepEqual(rowLabels, expectedMetricLabels.filter((label) => label === "Gap" || label === "Gap After"));
+});
+
+test("heatmap preserves metric order when restoring selections", () => {
+  const customSelection = [orderedMetrics[4].key, orderedMetrics[0].key];
+  const markup = renderToStaticMarkup(
+    <HeatmapView rows={rows} metrics={orderedMetrics} initialSelection={customSelection} />,
+  );
+  const rowLabels = extractMetricLabelsFromTable(markup);
+  const expectedSelectedLabels = expectedMetricLabels.filter((label) =>
+    [orderedMetrics[0].label, orderedMetrics[4].label].includes(label),
+  );
+  assert.deepEqual(rowLabels, expectedSelectedLabels);
+});

--- a/frontend/tests/types/node-shim.d.ts
+++ b/frontend/tests/types/node-shim.d.ts
@@ -1,0 +1,16 @@
+declare module "node:test" {
+  type TestFn = (name: string, fn: () => void | Promise<void>) => void;
+  const test: TestFn;
+  export default test;
+  export { test };
+}
+
+declare module "node:assert/strict" {
+  const assert: {
+    (value: unknown, message?: string): void;
+    equal: (actual: unknown, expected: unknown, message?: string) => void;
+    deepEqual: (actual: unknown, expected: unknown, message?: string) => void;
+    ok: (value: unknown, message?: string) => void;
+  };
+  export default assert;
+}

--- a/frontend/tests/unit/orderMetrics.test.ts
+++ b/frontend/tests/unit/orderMetrics.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeDisplayOrder, orderMetrics } from "../../src/utils/metrics";
+
+test("normalizeDisplayOrder returns numbers as-is", () => {
+  assert.equal(normalizeDisplayOrder(5), 5);
+  assert.equal(normalizeDisplayOrder(0), 0);
+});
+
+test("normalizeDisplayOrder parses numeric strings", () => {
+  assert.equal(normalizeDisplayOrder("10"), 10);
+  assert.equal(normalizeDisplayOrder("  2.5 "), 2.5);
+});
+
+test("normalizeDisplayOrder returns null for invalid values", () => {
+  assert.equal(normalizeDisplayOrder(undefined), null);
+  assert.equal(normalizeDisplayOrder(null), null);
+  assert.equal(normalizeDisplayOrder(""), null);
+  assert.equal(normalizeDisplayOrder("abc"), null);
+});
+
+test("orderMetrics sorts metrics by numeric display order", () => {
+  const metrics = [
+    { name: "B", display_order: 20 },
+    { name: "A", display_order: 10 },
+    { name: "C", display_order: 30 },
+  ];
+
+  const result = orderMetrics(metrics);
+  assert.deepEqual(
+    result.map((metric) => metric.name),
+    ["A", "B", "C"],
+  );
+  result.forEach((metric) => assert.equal(typeof metric.display_order, "number"));
+});
+
+test("orderMetrics places undefined display orders at the end", () => {
+  const metrics = [
+    { name: "B", display_order: null },
+    { name: "A" },
+    { name: "C", display_order: "5" },
+  ];
+
+  const result = orderMetrics(metrics);
+  assert.deepEqual(
+    result.map((metric) => metric.name),
+    ["C", "B", "A"],
+  );
+  assert.equal(result[0].display_order, 5);
+  assert.ok(result[1].display_order >= Number.MAX_SAFE_INTEGER);
+  assert.ok(result[2].display_order >= Number.MAX_SAFE_INTEGER);
+});
+
+test("orderMetrics preserves original order for identical display orders", () => {
+  const metrics = [
+    { name: "A", display_order: 1 },
+    { name: "B", display_order: 1 },
+    { name: "C", display_order: 1 },
+  ];
+
+  const result = orderMetrics(metrics);
+  assert.deepEqual(
+    result.map((metric) => metric.name),
+    ["A", "B", "C"],
+  );
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,8 +16,4 @@ export default defineConfig({
       },
     },
   },
-  test: {
-    environment: "jsdom",
-    setupFiles: "./src/setupTests.ts",
-  },
 });


### PR DESCRIPTION
## Summary
- add a reusable `orderMetrics` helper that normalizes `display_order`, wire it into the PSI metrics query, and reuse it when ordering metric definitions
- update the PSI heatmap to maintain master-defined ordering when toggling metrics and accept an optional initial selection
- add lightweight Node-based unit and end-to-end tests with an esbuild-powered test build script and ignore the generated artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68f1061e7394832ebfdca86f56d5bfdb